### PR TITLE
Bump zone.js 0.15.1 → 0.16.2

### DIFF
--- a/v2/package-lock.json
+++ b/v2/package-lock.json
@@ -25,7 +25,7 @@
         "subsink": "^1.0.2",
         "tslib": "^2.8.1",
         "uuid": "^14.0.0",
-        "zone.js": "0.15.1"
+        "zone.js": "0.16.2"
       },
       "devDependencies": {
         "@angular/build": "22.0.0",
@@ -10191,9 +10191,9 @@
       }
     },
     "node_modules/zone.js": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
-      "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.2.tgz",
+      "integrity": "sha512-Eky7p2Z1Ig3NnbfodSPoARCjKBSTFMnE/ACsP1L/XJEfY4SdOFce19BsUCWVwL6K5ABZFy5J3bjcMWffX+YM3Q==",
       "license": "MIT"
     },
     "node_modules/zstddec": {

--- a/v2/package.json
+++ b/v2/package.json
@@ -28,7 +28,7 @@
     "subsink": "^1.0.2",
     "tslib": "^2.8.1",
     "uuid": "^14.0.0",
-    "zone.js": "0.15.1"
+    "zone.js": "0.16.2"
   },
   "devDependencies": {
     "@angular/build": "22.0.0",


### PR DESCRIPTION
The one remaining outdated package after #28. zone.js 0.15.1 → 0.16.2 (latest). Angular 22 supports `~0.15.0 || ~0.16.0`, so 0.16.2 is in range. No security impact (`npm audit` was already 0).

Verified: production build green, **12/12** unit tests pass, app boots and renders. `npm ci` lockfile consistent, audit still 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)