### PR TITLE
examples: pygeoapi as a lightweight, read-only GeoServer alternative

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,12 @@
 COMPOSE_STATIC  := docker compose -p esgame -f v2/docker-compose.yml
 COMPOSE_DYNAMIC := docker compose -p esgame-dynamic -f v2/docker-compose.yml -f v2/docker-compose.dynamic.yml
 COMPOSE_EXAMPLE := docker compose -p esgame-dynamic-example -f examples/esgame-dynamic/docker-compose.yml
+COMPOSE_PYGEOAPI := docker compose -p esgame-dynamic-pygeoapi -f examples/esgame-dynamic/docker-compose.pygeoapi.yml
 
 .PHONY: esgame-build esgame-up esgame-down \
         esgame-dynamic-build esgame-dynamic-up esgame-dynamic-down \
-        esgame-dynamic-example-build esgame-dynamic-example-up esgame-dynamic-example-down
+        esgame-dynamic-example-build esgame-dynamic-example-up esgame-dynamic-example-down \
+        esgame-dynamic-pygeoapi-build esgame-dynamic-pygeoapi-up esgame-dynamic-pygeoapi-down
 
 # ---- static 'esgame' stack (frontend only) ----
 
@@ -79,3 +81,25 @@ esgame-dynamic-example-up: esgame-dynamic-example-build
 ## Stop and remove the example (keeps the geoserver-data volume; add 'down -v' to wipe it).
 esgame-dynamic-example-down:
 	$(COMPOSE_EXAMPLE) down
+
+# ---- the same example, but with pygeoapi (READ-ONLY) instead of GeoServer ----
+# A lighter-weight drop-in: pygeoapi serves the consequence rasters as OGC API - Coverages from a
+# static config — no catalog, no persistent volume, no seeder. READ-ONLY: there is no runtime
+# publish/REST API. Shares the 81/8000 ports with the GeoServer example, so run only one at a time.
+
+## Build the esgame base + the pygeoapi-variant images.
+esgame-dynamic-pygeoapi-build:
+	docker build -t $(ESGAME_BASE) v2
+	ESGAME_IMAGE=$(ESGAME_BASE) $(COMPOSE_PYGEOAPI) build
+
+## Build + start the pygeoapi variant of the example in the background.
+esgame-dynamic-pygeoapi-up: esgame-dynamic-pygeoapi-build
+	$(COMPOSE_PYGEOAPI) up -d
+	@echo ""
+	@echo "esgame-dynamic (pygeoapi) up:  http://localhost:81/  (place fields, press Next Level)"
+	@echo "  calculator http://localhost:8000/   pygeoapi http://localhost:5005/"
+	@echo "  (pygeoapi starts in a few seconds; rasters are read-only, from its static config)"
+
+## Stop and remove the pygeoapi variant.
+esgame-dynamic-pygeoapi-down:
+	$(COMPOSE_PYGEOAPI) down

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -11,4 +11,5 @@ container in the system. Each page is grounded in the actual source.
    frontend-components
    calculator
    geoserver
+   pygeoapi
    containers

--- a/docs/reference/pygeoapi.rst
+++ b/docs/reference/pygeoapi.rst
@@ -1,0 +1,148 @@
+pygeoapi: a lightweight, read-only GeoServer alternative
+========================================================
+
+The ``esgame-dynamic`` example ships an **alternative raster backend** that replaces GeoServer (and
+its one-shot seeder and persistent data volume) with a single small `pygeoapi
+<https://github.com/geopython/pygeoapi>`_ container. It is a **drop-in** replacement for the
+read-only path the game uses, with one important constraint — it serves **read-only data only**.
+
+Files: :file:`examples/esgame-dynamic/pygeoapi/Dockerfile`,
+:file:`examples/esgame-dynamic/pygeoapi/pygeoapi-config.yml`, and
+:file:`examples/esgame-dynamic/docker-compose.pygeoapi.yml`.
+
+.. warning::
+
+   **Read-only data only.** pygeoapi publishes its collections from a **static config file**; there
+   is no run-time publish/REST API as GeoServer has. The example's consequence rasters never change,
+   so this is fine here — but a deployment that must **add, replace, or mutate rasters at run time**
+   (as GeoServer's REST API and the :doc:`seeder <geoserver>` allow) cannot use this variant. To add
+   or change a raster with pygeoapi you edit :file:`pygeoapi-config.yml` and restart the container.
+
+
+Why it is a drop-in
+-------------------
+
+The frontend only ever fetches *a raster URL the calculator hands it* (see :doc:`/data-flow`) and
+decodes the returned GeoTIFF client-side — it does not care which server produced it. So swapping
+GeoServer for pygeoapi requires no frontend change at all. Two things differ between the stacks:
+
+#. the **calculator** emits a pygeoapi coverage URL instead of a WCS URL (one env var), and
+#. the **backend container** is pygeoapi instead of GeoServer.
+
+The frontend bundle and the calculator *image* are byte-for-byte identical across the two stacks.
+
+.. list-table:: The same raster, two URL forms
+   :header-rows: 1
+   :widths: 18 41 41
+
+   * -
+     - GeoServer (WCS)
+     - pygeoapi (OGC API - Coverages)
+   * - URL
+       (``{coverage}`` = e.g. ``ag_carbon``)
+     - ``/geoserver/wcs?service=WCS&version=2.0.1&request=GetCoverage&coverageId=esgame__{coverage}&format=image/tiff``
+     - ``/collections/{coverage}/coverage?f=GTiff``
+   * - Returns
+     - the consequence GeoTIFF (``image/tiff``)
+     - the **same** consequence GeoTIFF (``application/x-geotiff``)
+   * - Publishing
+     - REST API + one-shot seeder, persistent catalog
+     - static config, regenerated at start (read-only)
+
+
+The ``RASTER_URL_TEMPLATE`` mechanism
+-------------------------------------
+
+The example calculator (:doc:`calculator`) builds each raster URL from a single template env var, so
+it is backend-agnostic:
+
+.. code-block:: python
+
+   # examples/esgame-dynamic/calculator/app.py
+   RASTER_URL_TEMPLATE = os.environ.get(
+       "RASTER_URL_TEMPLATE",
+       f"{GEOSERVER_PUBLIC_URL}/wcs?service=WCS&version=2.0.1&request=GetCoverage"
+       f"&coverageId={WORKSPACE}__{{coverage}}&format=image/tiff",
+   )
+   ...
+   url = RASTER_URL_TEMPLATE.format(coverage=coverage)
+
+* **Default** (unset): a GeoServer WCS ``GetCoverage`` URL — the GeoServer stack is unchanged.
+* **pygeoapi stack** sets, in ``docker-compose.pygeoapi.yml``::
+
+    RASTER_URL_TEMPLATE: "http://localhost:5005/collections/{coverage}/coverage?f=GTiff"
+
+Any other read-only backend that can return a GeoTIFF works too — just point the template at it.
+
+
+The pygeoapi config
+-------------------
+
+:file:`pygeoapi/pygeoapi-config.yml` defines a ``server`` block (CORS enabled — the browser fetches
+the rasters cross-origin) and one **coverage collection per consequence raster**, served by the
+``rasterio`` provider:
+
+.. code-block:: yaml
+
+   resources:
+     ag_carbon:
+       type: collection
+       title: ag_carbon
+       extents:
+         spatial:
+           bbox: [0, 0, 28, 29]
+           crs: http://www.opengis.net/def/crs/EPSG/0/3857
+       providers:
+         - type: coverage
+           name: rasterio
+           data: /rasters/ag_carbon.tif
+           format:
+             name: GTiff
+             mimetype: application/x-geotiff
+
+The eight collections (``ag_carbon``, ``ag_habitat``, ``ag_water``, ``ag_hunt``, and the four
+``ranch_*``) correspond exactly to the calculator's ``CONSEQUENCES`` map, so
+``/collections/<name>/coverage?f=GTiff`` resolves for every consequence id.
+
+
+The image and compose
+----------------------
+
+The Dockerfile is intentionally tiny — the base image's entrypoint regenerates the OpenAPI document
+from the config on every start, so the collections always reflect ``pygeoapi-config.yml``:
+
+.. code-block:: dockerfile
+
+   FROM geopython/pygeoapi:latest
+   COPY pygeoapi-config.yml /pygeoapi/local.config.yml
+
+``docker-compose.pygeoapi.yml`` wires three services — ``frontend`` (unchanged), ``calculator``
+(with ``RASTER_URL_TEMPLATE``), and ``pygeoapi`` — and mounts the **same** ``./geoserver/rasters``
+folder read-only at ``/rasters``. There is **no seeder and no persistent volume**: pygeoapi reads its
+collections from the baked-in config at startup. It is exposed on host port **5005** (port 5000 is a
+common collision — local registries, Flask, macOS AirPlay).
+
+
+Running it
+----------
+
+.. code-block:: sh
+
+   make esgame-dynamic-pygeoapi-up      # http://localhost:81/  (calculator :8000, pygeoapi :5005)
+   make esgame-dynamic-pygeoapi-down
+
+The GeoServer and pygeoapi variants share the ``81``/``8000`` ports, so run only one at a time.
+
+
+Verification
+------------
+
+The drop-in was checked at every layer:
+
+* pygeoapi returns a GeoTIFF **byte-identical** to the source raster (same size, CRS ``EPSG:3857``,
+  and value statistics — min 0, max 125, mean 29.618) at ``/collections/<name>/coverage?f=GTiff``;
+* the calculator's ``POST`` response carries those pygeoapi URLs and per-consequence scores;
+* from the frontend's own origin (``http://localhost:81``) the browser fetches a coverage
+  **cross-origin** successfully (HTTP 200, valid CORS response, a complete ``II*`` TIFF) — exactly
+  what :doc:`TiffService </reference/frontend-services>` does when the consequence maps load;
+* the full stack builds and the SVG game renders against it.

--- a/examples/esgame-dynamic/README.md
+++ b/examples/esgame-dynamic/README.md
@@ -64,3 +64,35 @@ So after the first `up`:
 - The durable source of truth is the committed `geoserver/rasters/` folder + the persisted catalog.
 - To wipe and re-seed from scratch: `docker compose -p esgame-dynamic-example down -v` (removes the
   volume), then `up`.
+
+## Alternative backend: pygeoapi (lighter-weight, **read-only**)
+
+`docker-compose.pygeoapi.yml` is a drop-in alternative that replaces GeoServer (plus its one-shot
+seeder and persistent data volume) with a single small [pygeoapi](https://github.com/geopython/pygeoapi)
+container. pygeoapi serves the same consequence rasters as **OGC API - Coverages**; each is fetchable
+as a GeoTIFF at `…/collections/<name>/coverage?f=GTiff` — the drop-in equivalent of GeoServer's WCS
+`GetCoverage`.
+
+```sh
+make esgame-dynamic-pygeoapi-up      # http://localhost:81/  (calculator :8000, pygeoapi :5005)
+make esgame-dynamic-pygeoapi-down
+# or directly:
+ESGAME_IMAGE=local/esgame-core:latest \
+  docker compose -p esgame-dynamic-pygeoapi -f docker-compose.pygeoapi.yml up -d --build
+```
+
+**It is a true drop-in:** the frontend bundle and the calculator *image* are identical to the
+GeoServer stack. The only differences are (1) the calculator's `RASTER_URL_TEMPLATE` env var, which
+points it at pygeoapi's coverage URL instead of WCS, and (2) the backend container. The frontend
+never changes — it just fetches whatever raster URL the calculator returns. (Shares the `81`/`8000`
+ports with the GeoServer example, so run only one at a time.)
+
+> ⚠️ **Read-only data only.** pygeoapi publishes collections from a **static config file**
+> (`pygeoapi/pygeoapi-config.yml`); there is **no run-time publish/REST API** as GeoServer has. That
+> is fine here because the example's rasters never change — but a deployment that must **add, replace,
+> or mutate rasters at run time** (as GeoServer's REST API and the seeder allow) cannot use this
+> variant. To add or change a raster with pygeoapi you edit the config and restart the container.
+
+Why it's lighter: no catalog, no persistent data volume, no separate seeder job, and a much smaller
+image — pygeoapi reads its collections from the baked-in config on every start. The rasters are the
+same `geoserver/rasters/*.tif`, mounted read-only.

--- a/examples/esgame-dynamic/calculator/app.py
+++ b/examples/esgame-dynamic/calculator/app.py
@@ -1,10 +1,11 @@
 """Simple example calculator for the esgame dynamic stack.
 
 On each level submit (the POST the frontend makes to calcUrl) it returns, per consequence-map id,
-a GeoServer WCS GetCoverage URL for the matching coverage plus a simple allocation-based score.
+a browser-facing raster URL for the matching coverage plus a simple allocation-based score. The
+URL is built from RASTER_URL_TEMPLATE, which defaults to a GeoServer WCS GetCoverage URL but can be
+pointed at any read-only raster backend that returns a GeoTIFF (e.g. pygeoapi).
 
-It does NOT seed GeoServer — that's a separate one-shot job (../geoserver/seed.sh), and GeoServer
-reloads the coverages from its persistent data dir on boot. This calculator is stateless.
+It does NOT seed/publish the rasters — that is the backend's job. This calculator is stateless.
 """
 import os
 
@@ -14,6 +15,17 @@ from fastapi.middleware.cors import CORSMiddleware
 # Browser-facing GeoServer base URL (the WCS URLs the frontend fetches).
 GEOSERVER_PUBLIC_URL = os.environ.get("GEOSERVER_PUBLIC_URL", "http://localhost:8080/geoserver")
 WORKSPACE = "esgame"
+
+# Per-coverage raster URL, browser-facing. ``{coverage}`` is replaced with the coverage name.
+# Defaults to a GeoServer WCS GetCoverage URL (image/tiff). Override RASTER_URL_TEMPLATE to point
+# at any other read-only raster backend that can return a GeoTIFF — e.g. pygeoapi
+# (OGC API - Coverages), a drop-in lighter-weight alternative to GeoServer:
+#   RASTER_URL_TEMPLATE=http://localhost:5005/collections/{coverage}/coverage?f=GTiff
+RASTER_URL_TEMPLATE = os.environ.get(
+    "RASTER_URL_TEMPLATE",
+    f"{GEOSERVER_PUBLIC_URL}/wcs?service=WCS&version=2.0.1&request=GetCoverage"
+    f"&coverageId={WORKSPACE}__{{coverage}}&format=image/tiff",
+)
 
 # consequence-map id (from data.json) -> (coverage name, per-service score factor)
 CONSEQUENCES = {
@@ -42,7 +54,6 @@ async def calculate(req: Request):
     for cid, (coverage, factor) in CONSEQUENCES.items():
         count = n_ag if cid in AG_IDS else n_ranch
         score = round(count / total * factor, 3)
-        url = (f"{GEOSERVER_PUBLIC_URL}/wcs?service=WCS&version=2.0.1&request=GetCoverage"
-               f"&coverageId={WORKSPACE}__{coverage}&format=image/tiff")
+        url = RASTER_URL_TEMPLATE.format(coverage=coverage)
         results.append({"id": cid, "name": coverage, "score": score, "url": url})
     return {"results": results}

--- a/examples/esgame-dynamic/docker-compose.pygeoapi.yml
+++ b/examples/esgame-dynamic/docker-compose.pygeoapi.yml
@@ -1,0 +1,55 @@
+# Alternative to docker-compose.yml that replaces the heavyweight GeoServer (+ its one-shot seeder
+# and persistent data volume) with a single lightweight pygeoapi container.
+#
+#   frontend    - the esgame image + this example's SVG config (UNCHANGED vs the GeoServer stack)
+#   calculator  - the SAME image, but RASTER_URL_TEMPLATE points it at pygeoapi instead of WCS
+#   pygeoapi    - serves the consequence rasters as OGC API - Coverages (read-only)
+#
+# Drop-in: the frontend bundle and the calculator image are identical to the GeoServer stack; only
+# the calculator's RASTER_URL_TEMPLATE and the raster backend differ. Run EITHER this or the GeoServer
+# compose (they share the 81/8000 ports) — not both at once.
+#
+#   ESGAME_IMAGE=local/esgame-core:latest \
+#     docker compose -p esgame-dynamic-pygeoapi -f docker-compose.pygeoapi.yml up -d --build
+#
+# READ-ONLY caveat: pygeoapi publishes the rasters from a static config; there is no run-time
+# publish/REST API. Fine here because the example rasters never change. A deployment that must add or
+# mutate rasters at run time (as GeoServer's REST API allows) cannot use this variant.
+name: esgame-dynamic-pygeoapi
+
+services:
+  frontend:
+    build:
+      context: ./frontend
+      args:
+        ESGAME_IMAGE: ${ESGAME_IMAGE:-ghcr.io/mlacayoemery/esgame:master}
+    image: esgame-dynamic-example-frontend
+    container_name: esgame-dynamic-pygeoapi-frontend
+    volumes:
+      - ./frontend/config.json:/usr/share/nginx/html/assets/config.json:ro
+    ports:
+      - "81:80"
+    depends_on: [calculator]
+
+  calculator:
+    build: ./calculator
+    image: esgame-dynamic-example-calculator
+    container_name: esgame-dynamic-pygeoapi-calculator
+    environment:
+      # Point the calculator at pygeoapi's OGC API - Coverages instead of GeoServer's WCS. The
+      # browser fetches this URL directly, so it is the host-facing pygeoapi address. {coverage} is
+      # substituted with the coverage name (e.g. ag_carbon).
+      RASTER_URL_TEMPLATE: "http://localhost:5005/collections/{coverage}/coverage?f=GTiff"
+    ports:
+      - "8000:8000"
+
+  pygeoapi:
+    build: ./pygeoapi
+    image: esgame-dynamic-example-pygeoapi
+    container_name: esgame-dynamic-pygeoapi
+    # The same raster folder GeoServer uses, mounted read-only. No catalog, no persistent volume,
+    # no seeder — pygeoapi reads the collections from its baked-in config on every start.
+    volumes:
+      - ./geoserver/rasters:/rasters:ro
+    ports:
+      - "5005:80"

--- a/examples/esgame-dynamic/pygeoapi/Dockerfile
+++ b/examples/esgame-dynamic/pygeoapi/Dockerfile
@@ -1,0 +1,17 @@
+# Lightweight, READ-ONLY alternative to the GeoServer container for the esgame dynamic example.
+#
+# pygeoapi serves the consequence rasters as OGC API - Coverages; each is returnable as a GeoTIFF at
+#   /collections/<name>/coverage?f=GTiff
+# which is the drop-in equivalent of the GeoServer WCS GetCoverage URL the calculator otherwise emits
+# (point the calculator at it with RASTER_URL_TEMPLATE — see docker-compose.pygeoapi.yml).
+#
+# READ-ONLY: collections are defined statically in pygeoapi-config.yml. Unlike GeoServer there is no
+# REST API to publish or modify data at run time. To add/change a raster, edit the config and restart.
+# The rasters themselves are mounted read-only at /rasters by the compose file (shared with GeoServer's
+# ./geoserver/rasters), so this image stays tiny — no catalog, no persistent data dir, no seeder.
+#
+# The base image's entrypoint regenerates the OpenAPI document from this config on every start, so the
+# collections always reflect pygeoapi-config.yml.
+FROM geopython/pygeoapi:latest
+
+COPY pygeoapi-config.yml /pygeoapi/local.config.yml

--- a/examples/esgame-dynamic/pygeoapi/pygeoapi-config.yml
+++ b/examples/esgame-dynamic/pygeoapi/pygeoapi-config.yml
@@ -1,0 +1,183 @@
+# pygeoapi configuration — esgame dynamic example (lightweight GeoServer alternative).
+#
+# Serves the 8 consequence rasters as OGC API - Coverages, each returnable as GeoTIFF at
+#   /collections/<name>/coverage?f=GTiff
+# which is the drop-in equivalent of the GeoServer WCS GetCoverage the calculator otherwise emits.
+#
+# READ-ONLY: collections are defined statically here. Unlike GeoServer there is no REST API to
+# publish/modify data at run time — to add or change a raster you edit this file and restart.
+server:
+  bind:
+    host: 0.0.0.0
+    port: 80
+  url: http://localhost:5005
+  mimetype: application/json; charset=UTF-8
+  encoding: utf-8
+  languages: [en-US]
+  cors: true
+  pretty_print: true
+  limits:
+    default_items: 20
+    max_items: 50
+  map:
+    url: https://tile.openstreetmap.org/{z}/{x}/{y}.png
+    attribution: '&copy; OpenStreetMap contributors'
+
+logging:
+  level: ERROR
+
+metadata:
+  identification:
+    title: esgame example raster server (pygeoapi)
+    description: Consequence rasters for the esgame dynamic example, served via OGC API - Coverages.
+    keywords: [esgame, ecosystem services, coverages]
+    keywords_type: theme
+    terms_of_service: https://creativecommons.org/licenses/by/4.0/
+    url: https://github.com/mlacayoemery/esgame
+  license:
+    name: CC-BY 4.0
+    url: https://creativecommons.org/licenses/by/4.0/
+  provider:
+    name: esgame
+    url: https://github.com/mlacayoemery/esgame
+  contact:
+    name: esgame
+    url: https://github.com/mlacayoemery/esgame
+
+resources:
+
+  ag_carbon:
+    type: collection
+    title: ag_carbon
+    description: Consequence raster (carbon storage) for the esgame dynamic example.
+    keywords: [carbon]
+    extents:
+      spatial:
+        bbox: [0, 0, 28, 29]
+        crs: http://www.opengis.net/def/crs/EPSG/0/3857
+    providers:
+      - type: coverage
+        name: rasterio
+        data: /rasters/ag_carbon.tif
+        format:
+          name: GTiff
+          mimetype: application/x-geotiff
+
+  ag_habitat:
+    type: collection
+    title: ag_habitat
+    description: Consequence raster (habitat quality) for the esgame dynamic example.
+    keywords: [habitat]
+    extents:
+      spatial:
+        bbox: [0, 0, 28, 29]
+        crs: http://www.opengis.net/def/crs/EPSG/0/3857
+    providers:
+      - type: coverage
+        name: rasterio
+        data: /rasters/ag_habitat.tif
+        format:
+          name: GTiff
+          mimetype: application/x-geotiff
+
+  ag_water:
+    type: collection
+    title: ag_water
+    description: Consequence raster (water yield) for the esgame dynamic example.
+    keywords: [water]
+    extents:
+      spatial:
+        bbox: [0, 0, 28, 29]
+        crs: http://www.opengis.net/def/crs/EPSG/0/3857
+    providers:
+      - type: coverage
+        name: rasterio
+        data: /rasters/ag_water.tif
+        format:
+          name: GTiff
+          mimetype: application/x-geotiff
+
+  ag_hunt:
+    type: collection
+    title: ag_hunt
+    description: Consequence raster (hunting / recreation) for the esgame dynamic example.
+    keywords: [hunt]
+    extents:
+      spatial:
+        bbox: [0, 0, 28, 29]
+        crs: http://www.opengis.net/def/crs/EPSG/0/3857
+    providers:
+      - type: coverage
+        name: rasterio
+        data: /rasters/ag_hunt.tif
+        format:
+          name: GTiff
+          mimetype: application/x-geotiff
+
+  ranch_carbon:
+    type: collection
+    title: ranch_carbon
+    description: Consequence raster (carbon storage) for the esgame dynamic example.
+    keywords: [carbon]
+    extents:
+      spatial:
+        bbox: [0, 0, 28, 29]
+        crs: http://www.opengis.net/def/crs/EPSG/0/3857
+    providers:
+      - type: coverage
+        name: rasterio
+        data: /rasters/ranch_carbon.tif
+        format:
+          name: GTiff
+          mimetype: application/x-geotiff
+
+  ranch_habitat:
+    type: collection
+    title: ranch_habitat
+    description: Consequence raster (habitat quality) for the esgame dynamic example.
+    keywords: [habitat]
+    extents:
+      spatial:
+        bbox: [0, 0, 28, 29]
+        crs: http://www.opengis.net/def/crs/EPSG/0/3857
+    providers:
+      - type: coverage
+        name: rasterio
+        data: /rasters/ranch_habitat.tif
+        format:
+          name: GTiff
+          mimetype: application/x-geotiff
+
+  ranch_water:
+    type: collection
+    title: ranch_water
+    description: Consequence raster (water yield) for the esgame dynamic example.
+    keywords: [water]
+    extents:
+      spatial:
+        bbox: [0, 0, 28, 29]
+        crs: http://www.opengis.net/def/crs/EPSG/0/3857
+    providers:
+      - type: coverage
+        name: rasterio
+        data: /rasters/ranch_water.tif
+        format:
+          name: GTiff
+          mimetype: application/x-geotiff
+
+  ranch_hunt:
+    type: collection
+    title: ranch_hunt
+    description: Consequence raster (hunting / recreation) for the esgame dynamic example.
+    keywords: [hunt]
+    extents:
+      spatial:
+        bbox: [0, 0, 28, 29]
+        crs: http://www.opengis.net/def/crs/EPSG/0/3857
+    providers:
+      - type: coverage
+        name: rasterio
+        data: /rasters/ranch_hunt.tif
+        format:
+          name: GTiff
+          mimetype: application/x-geotiff


### PR DESCRIPTION
Adds a **drop-in alternative raster backend** for the `esgame-dynamic` example: a single small [pygeoapi](https://github.com/geopython/pygeoapi) container in place of GeoServer (plus its one-shot seeder and persistent data volume).

pygeoapi serves the consequence rasters as **OGC API - Coverages**; each is fetchable as a GeoTIFF at `/collections/<name>/coverage?f=GTiff` — the equivalent of GeoServer's WCS `GetCoverage`.

## Drop-in design
The frontend bundle and the calculator *image* are **identical** to the GeoServer stack. Only two things change:
1. the calculator builds the raster URL from a new **`RASTER_URL_TEMPLATE`** env var (default = the GeoServer WCS form, so the existing stack is untouched); the pygeoapi compose points it at pygeoapi.
2. the backend container.

The frontend never changes — it just fetches whatever URL the calculator returns.

## ⚠️ Read-only data only
pygeoapi publishes collections from a **static config file** — there is no run-time publish/REST API as GeoServer has. Fine for the example's fixed rasters; a deployment that must **add/replace/mutate rasters at run time** still needs GeoServer. (Prominently noted in the README, the docs page, and the compose/Dockerfile.)

## What's included
- `calculator/app.py` — `RASTER_URL_TEMPLATE` (backward-compatible default)
- `pygeoapi/Dockerfile` + `pygeoapi/pygeoapi-config.yml` (8 rasterio coverage collections, CORS on)
- `docker-compose.pygeoapi.yml` (frontend + calculator + pygeoapi on :5005; no seeder/volume)
- `Makefile`: `esgame-dynamic-pygeoapi-{build,up,down}`
- `docs/reference/pygeoapi.rst` + README section

## Verified end-to-end
- pygeoapi returns a **byte-identical** GeoTIFF (same size, `EPSG:3857`, min 0 / max 125 / mean 29.618);
- the calculator's POST response carries the pygeoapi URLs + scores;
- from the frontend's own origin the browser fetches a coverage **cross-origin** (HTTP 200, valid CORS, complete TIFF) — exactly what `TiffService` does;
- the full stack builds and the SVG game renders against it.

`make esgame-dynamic-pygeoapi-up`  →  http://localhost:81/  (calculator :8000, pygeoapi :5005)

🤖 Generated with [Claude Code](https://claude.com/claude-code)