### PR TITLE
docs: proper root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,65 @@
 # esgame
 
+**esgame** is the *Tradeoff / Ecosystem-Services* land-use allocation game — an Angular
+single-page application in which players allocate a fixed budget of production types
+(e.g. arable land, livestock) across a landscape and immediately see the
+ecosystem-service trade-offs that result.
 
+- ▶️ **Play it:** https://mlacayoemery.github.io/esgame/ (the legacy v1 game is archived at [`/v1/`](https://mlacayoemery.github.io/esgame/v1/))
+- 📖 **Documentation:** https://mlacayoemery.github.io/esgame/docs/ — architecture, data flow, game mechanics, and guides for users, developers, builders, and deployers
+
+## One codebase, two game modes, three deployment shapes
+
+- **GRID / "static"** mode scores entirely client-side — no backend. This is what GitHub
+  Pages serves, and the canonical way to play.
+- **SVG / "dynamic"** mode delegates scoring to a calculation backend, which returns a
+  score plus consequence-raster URLs served by GeoServer (or pygeoapi).
+
+Deployment shapes: the static GitHub Pages build, self-contained **Docker Compose**
+stacks (below), and a **Kubernetes** base under [deploy/k8s/](deploy/k8s/).
+A single container image serves any of them — runtime configuration and game data are
+loaded from a mounted `assets/config.json` at startup, so nothing is baked in.
+See [static vs. dynamic](https://mlacayoemery.github.io/esgame/docs/static-vs-dynamic.html)
+in the docs for a full comparison.
+
+## Quick start
+
+Local development (see [v2/README.md](v2/README.md) for details):
+
+```sh
+cd v2 && npm install && ng serve   # http://localhost:4200/
+```
+
+Docker Compose stacks, from the repo root (all serve the frontend on **:81** — run one
+at a time):
+
+| `make` target | Stack |
+|---|---|
+| `esgame-up` | Static frontend only — exactly what GitHub Pages hosts |
+| `esgame-dynamic-up` | Frontend + R/Plumber calculator + GeoServer (what [places](deploy/k8s/) deploys) |
+| `esgame-dynamic-example-up` | Self-contained playable dynamic example: FastAPI calculator + seeded GeoServer ([examples/esgame-dynamic/](examples/esgame-dynamic/)) |
+| `esgame-dynamic-pygeoapi-up` | The same example with read-only [pygeoapi](examples/esgame-dynamic/pygeoapi/) in place of GeoServer |
+
+Each target has a matching `-down`; see the [Makefile](Makefile) for ports and notes.
+
+## Repository layout
+
+| Path | Contents |
+|---|---|
+| [v2/](v2/) | The Angular app (the current game), its Dockerfile and compose files |
+| [docs/](docs/) | Sphinx documentation, published to [`/esgame/docs/`](https://mlacayoemery.github.io/esgame/docs/) |
+| [examples/esgame-dynamic/](examples/esgame-dynamic/) | Self-contained dynamic-mode example stack (FastAPI calculator + GeoServer or pygeoapi) |
+| [deploy/k8s/](deploy/k8s/) | Kustomize base for deploying the full dynamic stack to Kubernetes |
+| [tools/R/](tools/R/) | The R/Plumber calculation backend used by the dynamic stack |
+| [perf/](perf/) | k6 load test for the calculation backend ([perf/README.md](perf/README.md)) |
+| `index.html`, `calc.html`, `wc.htm`, [calc_files/](calc_files/), [images/](images/) | The legacy v1 game, archived on Pages under `/v1/` |
+
+## CI & publishing
+
+- [ci.yml](.github/workflows/ci.yml) — builds the v2 app, runs unit tests and Playwright e2e
+- [deploy.yml](.github/workflows/deploy.yml) — publishes to GitHub Pages: the v2 app at the root, v1 under `/v1/`, and the Sphinx docs under `/docs/`
+- [image.yml](.github/workflows/image.yml) — publishes the container image to `ghcr.io/mlacayoemery/esgame`
+
+## License
+
+[GPL-3.0](LICENSE)


### PR DESCRIPTION
The root README was a bare `# esgame`, while the repo has grown comprehensive Sphinx docs on GitHub Pages, a self-contained dynamic example with two raster backends, a Kubernetes base, and perf tooling. This gives the repo a real front door.

## What the README now covers
- **What the game is** (one paragraph, matching the docs landing page) with direct links to **play it** (Pages root, plus the archived v1 under `/v1/`) and **read the docs** (`/esgame/docs/`).
- **The mode/deployment matrix** — GRID/static (client-side, what Pages serves) vs SVG/dynamic (calculation backend + raster service), and the three deployment shapes (Pages, Docker Compose, k8s), including the mounted-`config.json` single-image design.
- **Quick start** — `ng serve` for development plus a table of the four `make` compose targets (static, dynamic with R+GeoServer, the FastAPI example, and its pygeoapi variant).
- **Repository layout** — what each top-level directory is, including identifying the loose root HTML files as the archived legacy v1 game.
- **CI & publishing** — what each of the three workflows builds and where it publishes.
- **License** — GPL-3.0.

All claims checked against the sources: the Makefile, `v2/docker-compose.dynamic.yml` (R calculator + GeoServer), `deploy.yml` (Pages layout: app at root, `/v1/`, `/docs/`), `ci.yml` (build + unit + Playwright), and `image.yml` (ghcr image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)