### PR TITLE
ci: run on Node 26.5.0 so the build stops failing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          # Newest Node that Angular 22's CLI accepts (^22.22.3 || ^24.15.0 || >=26.0.0).
+          # Keep in sync with deploy.yml so the gate matches what ships.
+          node-version: 26.5.0
           cache: npm
           cache-dependency-path: v2/package-lock.json
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,8 +36,9 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          # Angular 22 requires Node ^22.22.3 || ^24.15.0 || >=26.
-          node-version: 22.22.3
+          # Newest Node that Angular 22's CLI accepts (^22.22.3 || ^24.15.0 || >=26.0.0).
+          # Keep in sync with ci.yml so the gate matches what ships.
+          node-version: 26.5.0
           cache: npm
           cache-dependency-path: v2/package-lock.json
 


### PR DESCRIPTION
## Problem

The CI **Build** step has failed on every run since PR #29 (2026-06-10):

```
Node.js version v20.20.2 detected.
The Angular CLI requires a minimum Node.js version of v22.22.3 or v24.15.0 or v26.0.0.
```

Angular 22 declares `node: ^22.22.3 || ^24.15.0 || >=26.0.0`, but `ci.yml` still pinned `node-version: 20`.

It went unnoticed because CI is path-filtered to `v2/**`, and everything merged since (#30–#34) was docs and examples — so CI never ran on those PRs. **master has had no working build/test gate for ~7 weeks.**

## Fix

Pin both `ci.yml` and `deploy.yml` to **26.5.0**, the newest release Angular 22 accepts, and keep them in sync so the gate runs the same runtime that ships. `deploy.yml` was on 22.22.3, so CI and deploy were also diverging.

24.18.0 is the current LTS if a more conservative runtime is ever preferred — nothing in the dependency tree requires it.

## Verification

Run locally on Node 26 (the full CI gate):

- Production build succeeds
- **12/12** unit tests pass
- **5/5** Playwright e2e pass

## Follow-ups (not in this PR)

- `actions/checkout@v4`, `setup-node@v4`, `upload-artifact@v4` emit Node 20 deprecation warnings; GitHub forced Node 24 on 2026-06-16 and removes Node 20 on 2026-09-16.
- The build warns `bundle initial exceeded maximum budget. Budget 1.00 MB was not met by 103.95 kB with a total of 1.10 MB` — `perf/README.md` currently misstates this as "~995 KB vs the 500 KB initial budget".
- Dependabot reports 27 vulnerabilities on the default branch (14 high).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE