### PR TITLE
chore(ci): move all Actions to current majors, Python 3.12 → 3.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
       # Google Chrome is preinstalled on ubuntu-latest; Karma + Playwright (channel: chrome) use it.
       CHROME_BIN: /usr/bin/google-chrome
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           # Newest Node that Angular 22's CLI accepts (^22.22.3 || ^24.15.0 || >=26.0.0).
           # Keep in sync with deploy.yml so the gate matches what ships.
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: v2/playwright-report

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,9 +32,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           # Newest Node that Angular 22's CLI accepts (^22.22.3 || ^24.15.0 || >=26.0.0).
           # Keep in sync with ci.yml so the gate matches what ships.
@@ -59,9 +59,11 @@ jobs:
       # Note: 404.html (the spa-github-pages redirect for clean URLs) is built from src/404.html
       # via the angular.json assets list, so no SPA-fallback copy step is needed here.
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
-          python-version: '3.12'
+          # docs/requirements.txt is unpinned, so Sphinx floats to its newest
+          # release; nothing in it caps the interpreter.
+          python-version: '3.15'
 
       - name: Build Sphinx docs (served from /esgame/docs/)
         run: |
@@ -73,7 +75,7 @@ jobs:
           # _static / _sources directories are never skipped.
           touch v2/dist/tradeoff-v2/.nojekyll
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: v2/dist/tradeoff-v2
 
@@ -85,4 +87,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -21,18 +21,18 @@ jobs:
   build-push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -40,7 +40,7 @@ jobs:
             type=semver,pattern={{version}}
             type=sha
 
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v7
         with:
           context: v2
           push: true


### PR DESCRIPTION
Every action across the three workflows sat on a major GitHub has since superseded. The v4 generation also runs on the **Node 20 action runtime**, which GitHub force-migrated to Node 24 on 2026-06-16 and removes from runners on **2026-09-16** — so these were on a clock, and every run was already emitting the deprecation warning.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | **v7** |
| `actions/setup-node` | v4 | **v7** |
| `actions/upload-artifact` | v4 | **v7** |
| `actions/setup-python` | v5 | **v7** |
| `actions/upload-pages-artifact` | v3 | **v5** |
| `actions/deploy-pages` | v4 | **v5** |
| `docker/setup-buildx-action` | v3 | **v4** |
| `docker/login-action` | v3 | **v4** |
| `docker/metadata-action` | v5 | **v6** |
| `docker/build-push-action` | v5 | **v7** |

Also bumps the docs interpreter **3.12 → 3.15**. `docs/requirements.txt` is unpinned (`sphinx>=7`, `furo`, `myst-parser`), so it already floats to the newest Sphinx and nothing in it caps the interpreter.

## Verification

- `ci.yml` — exercised directly by this PR's CI run.
- `deploy.yml` / `image.yml` — dispatched on this branch via `workflow_dispatch`. The Pages **deploy** job is expected to be refused on a non-default branch (environment protection); what that dispatch validates is the whole build path: checkout → setup-node → npm ci → Angular build → setup-python 3.15 → Sphinx → upload-pages-artifact.

A failed Pages deploy does not disturb the live site — Pages only swaps the published version on a successful run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE