### PR TITLE
fix(ci): pin docs Python to 3.14.6 (3.15 has no ubuntu-24.04 build)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,8 +62,10 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           # docs/requirements.txt is unpinned, so Sphinx floats to its newest
-          # release; nothing in it caps the interpreter.
-          python-version: '3.15'
+          # release; nothing in it caps the interpreter. The cap is the runner:
+          # 3.14.6 is the newest stable build actions/python-versions ships for
+          # ubuntu-24.04 x64 (3.15 is released, but has no image for it yet).
+          python-version: '3.14.6'
 
       - name: Build Sphinx docs (served from /esgame/docs/)
         run: |


### PR DESCRIPTION
#36 set `python-version: '3.15'`, which broke the Pages deploy:

```
##[error]The version '3.15' with architecture 'x64' was not found for Ubuntu 24.04.
```

3.15.0 is a released CPython version, but `actions/python-versions` has not published an **ubuntu-24.04 x64** build for it. I picked it off the release-tag list rather than the per-platform manifest — my mistake.

The real cap is the runner image. Newest stable with a 24.04 x64 build is **3.14.6**.

## Impact

None to the live site — the `deploy` job was skipped because `build` failed, and Pages only swaps the published version on a successful run. The site is still serving the last good deploy.

The rest of #36 is confirmed good: **CI** and **Build & publish container image** both passed on master with the new action majors (checkout v7, setup-node v7, upload-artifact v7, docker v4/v6/v7).

## Verification

Built the docs locally on Python 3.14.4 with the newest unpinned resolution — Sphinx **9.1.0**, furo 2025.12.19, myst-parser 5.1.0 — `build succeeded`, all 16 pages written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE