### PR TITLE
chore: modernize container base images and example Python deps

### DIFF
--- a/examples/esgame-dynamic/calculator/Dockerfile
+++ b/examples/esgame-dynamic/calculator/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.14-slim
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/examples/esgame-dynamic/calculator/requirements.txt
+++ b/examples/esgame-dynamic/calculator/requirements.txt
@@ -1,2 +1,2 @@
-fastapi==0.115.6
-uvicorn[standard]==0.34.0
+fastapi==0.140.13
+uvicorn[standard]==0.52.0

--- a/examples/esgame-dynamic/geoserver/Dockerfile
+++ b/examples/esgame-dynamic/geoserver/Dockerfile
@@ -1,4 +1,4 @@
 # One-shot GeoServer seeder image (Python stdlib only - registers coverages + palette styles).
-FROM python:3.12-slim
+FROM python:3.14-slim
 COPY seed.py /seed.py
 ENTRYPOINT ["python3", "/seed.py"]

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -1,6 +1,7 @@
 # ---- Build stage ----
-# Node 22.22.3+ required by Angular 22 (engines: ^22.22.3 || ^24.15.0 || >=26).
-FROM node:22-alpine AS build
+# Angular 22 requires Node ^22.22.3 || ^24.15.0 || >=26.0.0. Track the newest
+# accepted major, matching the 26.5.0 pin in ci.yml / deploy.yml.
+FROM node:26-alpine AS build
 WORKDIR /app
 
 # Install deps first for better layer caching (only re-runs when lockfile changes)

--- a/v2/docker-compose.dynamic.yml
+++ b/v2/docker-compose.dynamic.yml
@@ -20,8 +20,9 @@ services:
     # url: http://localhost:8000/openapi.json
 
   esgame-geoserver:
-    # Pin to a specific patch (e.g. 2.24.4) instead of the rolling 2.24.x tag for reproducibility.
-    image: docker.osgeo.org/geoserver:2.24.x
+    # Pinned to a specific patch (not a rolling 2.x tag) for reproducibility, and kept in
+    # step with examples/esgame-dynamic/docker-compose.yml so both stacks run the same server.
+    image: docker.osgeo.org/geoserver:2.28.4
     environment:
       CORS_ENABLED: "true"
     ports:


### PR DESCRIPTION
| File | Before | After |
|---|---|---|
| `v2/Dockerfile` | `node:22-alpine` | **`node:26-alpine`** |
| `examples/.../calculator/Dockerfile` | `python:3.12-slim` | **`python:3.14-slim`** |
| `examples/.../geoserver/Dockerfile` (seeder) | `python:3.12-slim` | **`python:3.14-slim`** |
| `examples/.../calculator/requirements.txt` | fastapi 0.115.6, uvicorn 0.34.0 | **fastapi 0.140.13, uvicorn 0.52.0** |

`node:26-alpine` matches the 26.5.0 pin now used by `ci.yml` and `deploy.yml`, so the shipped image builds on the same runtime the gate tests.

Also pins `v2/docker-compose.dynamic.yml` to **GeoServer 2.28.4**. It was on the rolling `2.24.x` tag — contradicting its own comment (*"Pin to a specific patch … for reproducibility"*) and disagreeing with `examples/esgame-dynamic/docker-compose.yml`, which already used 2.28.4. That's the newest 2.x on docker.osgeo.org.

## Verification

Built and ran the containers locally:

- **v2 image on node:26-alpine** — serves `/` (200) and `/assets/config.json` (200), page title `TradeoffV2`
- **calculator** — container reports `python 3.14.6 / fastapi 0.140.13 / uvicorn 0.52.0`; `GET /` returns `{"status":"ok"}`, `POST /` returns 8 correctly scored results
- **seeder** — image builds and runs on 3.14

## Separate bug found while testing (not addressed here)

Bringing up `examples/esgame-dynamic` revealed that **the seeder never actually registers any rasters**. `geoserver/seed.py` ignores the HTTP status from its `external.geotiff` PUT, so it logs `[seed] coverage <name>` and `[seed] done` while GeoServer returns **400 Failed to locate the input file `file:///rasters/<name>.tif`** for all 8 (`RESTUtils.handleEXTERNALUpload:196`). Result: the `esgame` workspace has zero `coverageStores` and WCS `GetCoverage` 404s.

**This is pre-existing, not from this PR.** I verified it by stashing these changes, rebuilding the seeder from pristine master on python:3.12, wiping the volume, and re-running — identical outcome (`{"coverageStores":""}`, WCS 404, 16 "Failed to locate" errors in the GeoServer log). Filed to fix next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE