### PR TITLE
refactor(styles): migrate Sass @import to the module system (@use)

### DIFF
--- a/v2/src/app/help/help.component.scss
+++ b/v2/src/app/help/help.component.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@use 'variables' as *;
 
 .icon-help-circle {
 	cursor: pointer;

--- a/v2/src/app/legend-board/legend-board.component.scss
+++ b/v2/src/app/legend-board/legend-board.component.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@use 'variables' as *;
 
 :host {
     &:not(.is-gradient) {

--- a/v2/src/app/level-indicator/level-indicator.component.scss
+++ b/v2/src/app/level-indicator/level-indicator.component.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@use 'variables' as *;
 
 :host {
 	border-radius: 15px;

--- a/v2/src/app/level/svg-level/svg-level.component.scss
+++ b/v2/src/app/level/svg-level/svg-level.component.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@use 'variables' as *;
 
 
 :host {

--- a/v2/src/app/loading-indicator/loading-indicator.component.scss
+++ b/v2/src/app/loading-indicator/loading-indicator.component.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@use 'variables' as *;
 
 :host {
 	display: none;

--- a/v2/src/app/product-type-button/production-type-button.component.scss
+++ b/v2/src/app/product-type-button/production-type-button.component.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@use 'variables' as *;
 
 :host {
 	display: flex;

--- a/v2/src/app/score-indicator/score-indicator.component.scss
+++ b/v2/src/app/score-indicator/score-indicator.component.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@use 'variables' as *;
 
 .score-indicator {
 	border: 1px solid black;

--- a/v2/src/styles.scss
+++ b/v2/src/styles.scss
@@ -1,5 +1,18 @@
 /* You can add global styles to this file, and also import other style files */
 
+/* @use must precede all other rules, so the partials load up front. Each partial
+   now @use-s what it needs instead of relying on @import order.
+   The emitted CSS holds the same 243 rules as the @import version — only their
+   order changes. Safe here because no partial targets html/body, so nothing that
+   moved competes with the element rules below. */
+@use 'styles/material';
+@use 'styles/fonts';
+@use 'styles/variables';
+@use 'styles/utils';
+@use 'styles/headings';
+@use 'styles/button';
+@use 'styles/layout';
+
 @font-face {
 	font-family: 'Roboto';
 	src: url('./assets/fonts/Roboto/Roboto-Regular.ttf');
@@ -15,12 +28,5 @@ body {
 	padding: 0;
 }
 
-@import 'styles/material';
-@import 'styles/fonts';
-@import 'styles/variables';
-@import 'styles/utils';
-@import 'styles/headings';
-@import 'styles/button';
-@import 'styles/layout';
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }

--- a/v2/src/styles/button.scss
+++ b/v2/src/styles/button.scss
@@ -1,3 +1,5 @@
+@use 'variables' as *;
+
 .button {
 	padding: 5px 20px;
 	background-color: $color-primary;

--- a/v2/src/styles/utils.scss
+++ b/v2/src/styles/utils.scss
@@ -1,3 +1,5 @@
+@use 'variables' as *;
+
 .--positive {
 	color: $color-positive;
 }


### PR DESCRIPTION
`@import` is deprecated and **Dart Sass 3.0 removes it** — every production build was emitting the warning. sass is currently 1.99.0 via `@angular/build`.

## sass-migrator couldn't do this automatically

`utils.scss` and `button.scss` consume variables they never import, relying on `styles.scss` `@import`-ing `variables.scss` *first*. The module system has no equivalent of that ambient scope, so the migrator bails:

```
Error: This variable was loaded from a nested import of src/styles/variables.scss.
The module system only supports loading nested CSS using the load-css() mixin,
which doesn't load variables.
```

So each partial now declares what it uses:

| File | Change |
|---|---|
| `styles/utils.scss` | `+ @use 'variables' as *` |
| `styles/button.scss` | `+ @use 'variables' as *` |
| `styles.scss` | `@import` → `@use`, hoisted above the element rules (`@use` must precede other rules) |
| 7 component `.scss` | `@import 'variables'` → `@use 'variables' as *` |

## Hoisting reorders the output — so I checked it

`@use` must come first, which moves the partials' CSS ahead of `@font-face` / `html` / `body`. Verified rather than assumed:

- The built stylesheet contains the **same 243 rules** before and after — identical multiset, same 104,990 bytes. Only order differs.
- **No partial targets `html`/`body`**, so nothing that moved competes with the element rules in `styles.scss`.
- `/config` renders **pixel-identical**. `/dynamic-game` differs only in the Material spinner's animation frame (visually identical otherwise).
- `/` is not pixel-comparable — it is non-deterministic across two runs of the *same* build, so I ruled it out as a signal rather than reading into it.
- **Sass deprecation warnings: 3+ → 0.**

## Verification

Build clean, **12/12** unit, **5/5** e2e, Lighthouse assertions pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE