### PR TITLE
docs: bring the docs back in line with the toolchain

### DIFF
--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -30,7 +30,8 @@ One Angular codebase, two modes
 ===============================
 
 The application is the Angular SPA under :file:`v2/` (Angular 22; the build requires
-Node ``22.22.3+``, per :file:`v2/Dockerfile`). Routing is **hash-based**
+Node ``^22.22.3 || ^24.15.0 || >=26.0.0`` and uses ``node:26-alpine``, per
+:file:`v2/Dockerfile`). Routing is **hash-based**
 (``useHash`` routing), so no server rewrite rules are required for the SPA to work
 under any base path.
 
@@ -218,7 +219,7 @@ The shared image
 
 :file:`v2/Dockerfile` is a two-stage build:
 
-* **Build stage** — ``node:22-alpine``; ``npm ci`` from the lockfile, then
+* **Build stage** — ``node:26-alpine``; ``npm ci`` from the lockfile, then
   ``npm run build -- --base-href / --configuration production``. The image serves from
   the domain root; a reverse proxy maps host/path to the container.
 * **Runtime stage** — ``nginx:alpine`` serving ``dist/tradeoff-v2/`` from

--- a/docs/guides/builder.rst
+++ b/docs/guides/builder.rst
@@ -62,7 +62,7 @@ The scripts in :file:`v2/package.json`:
      - Incremental rebuild for local development.
    * - ``test``
      - ``ng test``
-     - Karma unit tests (``@angular/build:karma``).
+     - Vitest unit tests (``@angular/build:unit-test``, jsdom).
    * - ``e2e``
      - ``ng build && playwright test``
      - Build, then run the Playwright end-to-end suite.
@@ -189,7 +189,7 @@ Build stage
 
 .. code-block:: dockerfile
 
-   FROM node:22-alpine AS build
+   FROM node:26-alpine AS build
    WORKDIR /app
    COPY package.json package-lock.json ./
    RUN npm ci
@@ -198,8 +198,9 @@ Build stage
 
 Key points:
 
-* **Base image** ``node:22-alpine``. Node ``22.22.3+`` is required by Angular 22;
-  the package ``engines`` constraint is ``^22.22.3 || ^24.15.0 || >=26``.
+* **Base image** ``node:26-alpine`` — the newest major Angular 22 accepts
+  (``^22.22.3 || ^24.15.0 || >=26.0.0``), matching the ``26.5.0`` pin in CI and
+  the Pages deploy.
 * **Layer caching.** ``package.json`` and ``package-lock.json`` are copied *before*
   the rest of the source and ``npm ci`` runs against just the lockfile, so the
   dependency-install layer is only invalidated when the lockfile changes — editing
@@ -308,7 +309,7 @@ Example calculator (FastAPI)
 
 .. code-block:: dockerfile
 
-   FROM python:3.12-slim
+   FROM python:3.14-slim
    WORKDIR /app
    COPY requirements.txt .
    RUN pip install --no-cache-dir -r requirements.txt
@@ -329,9 +330,9 @@ simple allocation-based score. Pinned dependencies in
    * - Package
      - Version
    * - ``fastapi``
-     - ``0.115.6``
+     - ``0.140.13``
    * - ``uvicorn[standard]``
-     - ``0.34.0``
+     - ``0.52.0``
 
 The browser-facing GeoServer base URL is supplied at run time via the
 ``GEOSERVER_PUBLIC_URL`` environment variable (default
@@ -351,7 +352,7 @@ What *is* built is the one-shot **seeder**,
 
 .. code-block:: dockerfile
 
-   FROM python:3.12-slim
+   FROM python:3.14-slim
    COPY seed.py /seed.py
    ENTRYPOINT ["python3", "/seed.py"]
 
@@ -403,7 +404,7 @@ The job runs from the ``v2`` working directory and proceeds in order:
    * - Checkout
      - ``actions/checkout@v4``
    * - Node
-     - ``actions/setup-node@v4`` with ``node-version: 20``, ``cache: npm``,
+     - ``actions/setup-node@v7`` with ``node-version: 26.5.0``, ``cache: npm``,
        ``cache-dependency-path: v2/package-lock.json``
    * - Install
      - ``npm ci``
@@ -413,20 +414,23 @@ The job runs from the ``v2`` working directory and proceeds in order:
      - ``npm test -- --watch=false --browsers=ChromeHeadlessNoSandbox``
    * - E2E (Playwright)
      - ``npm run e2e``
+   * - Lighthouse CI
+     - ``npm run lhci``
    * - On failure
-     - upload ``v2/playwright-report`` (``actions/upload-artifact@v4``,
-       ``retention-days: 7``)
+     - upload ``v2/playwright-report`` and ``v2/.lighthouseci/reports``
+       (``actions/upload-artifact@v7``, ``retention-days: 7``)
 
-Karma and Playwright (``channel: chrome``) use the preinstalled Chrome via
-``CHROME_BIN: /usr/bin/google-chrome``. A pull request must pass build + unit + e2e
-to be mergeable.
+Playwright (``channel: chrome``) and Lighthouse use the preinstalled Chrome via
+``CHROME_BIN`` / ``CHROME_PATH``. The unit suite needs no browser — it runs under
+jsdom. A pull request must pass build + unit + e2e + Lighthouse to be mergeable.
 
 .. note::
 
-   CI pins ``node-version: 20`` for the build/test gate, whereas the image and
-   Pages builds use Node 22 (the version Angular 22 *requires* to run). The gate
-   confirms the app compiles and its tests pass; the published artifacts are built
-   on the required Node 22.
+   CI and the Pages deploy both pin ``node-version: 26.5.0`` — the newest release
+   Angular 22 accepts — so the gate runs the same runtime that ships. This has not
+   always been true: the gate previously pinned Node 20, which Angular 22 rejects
+   outright, and the Build step failed on every run for roughly seven weeks before
+   it was noticed. Keep the two workflows in step.
 
 
 Publishing the container image (ghcr)
@@ -456,8 +460,8 @@ Publishing to GitHub Pages
 A third workflow, :file:`.github/workflows/deploy.yml`, deploys the app to GitHub
 Pages at ``https://<owner>.github.io/esgame/``. It installs with ``npm ci`` and
 builds with ``--base-href /esgame/ --configuration production`` on Node
-``22.22.3``, archives the legacy v1 game under ``dist/tradeoff-v2/v1/``, and uploads
-``v2/dist/tradeoff-v2`` via ``actions/upload-pages-artifact@v3``. The ``404.html``
+``26.5.0``, archives the legacy v1 game under ``dist/tradeoff-v2/v1/``, and uploads
+``v2/dist/tradeoff-v2`` via ``actions/upload-pages-artifact@v5``. The ``404.html``
 SPA-redirect page is emitted automatically from ``src/404.html`` (it is in the
 ``angular.json`` assets list), so no extra fallback-copy step is needed.
 
@@ -479,17 +483,19 @@ same constraints are applied everywhere:
        failing if ``package.json`` and the lockfile disagree. Used identically in
        the Dockerfile, ``ci.yml``, and ``deploy.yml``.
    * - Pinned Angular packages
-     - All ``@angular/*`` packages and ``@angular/build`` / ``@angular/cli`` are
-       pinned to ``22.0.0`` (exact, no caret) in :file:`v2/package.json`;
+     - All ``@angular/*`` packages are pinned exactly (no caret) in
+       :file:`v2/package.json` — ``22.0.8`` for the framework, ``22.0.6`` for
+       ``material`` / ``cdk``, ``22.0.9`` for ``@angular/build`` / ``@angular/cli``;
        ``typescript`` is pinned to ``6.0.3`` and ``zone.js`` to ``0.16.2``.
+       ``typescript`` cannot advance past ``6.0.x``: ``@angular/compiler-cli@22``
+       declares ``typescript: ">=6.0 <6.1"``.
    * - Node version
-     - Angular 22 requires ``^22.22.3 || ^24.15.0 || >=26``. The image uses
-       ``node:22-alpine`` and Pages pins ``22.22.3``; CI's build/test gate runs on
-       Node 20.
+     - Angular 22 requires ``^22.22.3 || ^24.15.0 || >=26.0.0``. The image uses
+       ``node:26-alpine``; CI and Pages both pin ``26.5.0``.
    * - Pinned image bases
-     - ``node:22-alpine``, ``nginx:alpine``, ``python:3.12-slim``, and
+     - ``node:26-alpine``, ``nginx:alpine``, ``python:3.14-slim``, and
        ``docker.osgeo.org/geoserver:2.28.4``; the example calculator pins
-       ``fastapi==0.115.6`` and ``uvicorn[standard]==0.34.0``.
+       ``fastapi==0.140.13`` and ``uvicorn[standard]==0.52.0``.
    * - Configuration-free build
      - No backend address is compiled in. ``CALC_URL`` (and ``config.json`` more
        broadly) is applied at *run time*, so a given image hash is reproducible and

--- a/docs/guides/deployer.rst
+++ b/docs/guides/deployer.rst
@@ -117,8 +117,8 @@ What the build does
 
 The ``build`` job runs on ``ubuntu-latest`` and:
 
-#. checks out the repo and sets up Node **22.22.3** (Angular 22 requires
-   ``^22.22.3 || ^24.15.0 || >=26``), with ``npm`` caching keyed on
+#. checks out the repo and sets up Node **26.5.0**, the newest release Angular 22
+   accepts (``^22.22.3 || ^24.15.0 || >=26.0.0``), with ``npm`` caching keyed on
    :file:`v2/package-lock.json`;
 #. installs with ``npm ci`` (working directory :file:`v2`);
 #. builds **with the project base href**:
@@ -134,7 +134,7 @@ The ``build`` job runs on ``ubuntu-latest`` and:
    ``calc.html``, ``wc.htm``, ``calc_files`` and ``images`` into
    :file:`v2/dist/tradeoff-v2/v1/`;
 #. uploads :file:`v2/dist/tradeoff-v2` as the Pages artifact
-   (``actions/upload-pages-artifact@v3``).
+   (``actions/upload-pages-artifact@v5``).
 
 The ``deploy`` job then publishes that artifact with
 ``actions/deploy-pages@v4`` into the ``github-pages`` environment. The required

--- a/docs/guides/developer.rst
+++ b/docs/guides/developer.rst
@@ -85,14 +85,16 @@ All versions below are pinned in :file:`esgame/v2/package.json`.
      - Version
      - Notes
    * - Angular
-     - ``22.0.0``
-     - ``@angular/core``, ``common``, ``forms``, ``router``, ``material``,
-       ``cdk``, ``animations``, ``platform-browser`` — all pinned to ``22.0.0``.
+     - ``22.0.8``
+     - ``@angular/core``, ``common``, ``forms``, ``router``, ``animations``,
+       ``platform-browser`` at ``22.0.8``; ``material`` and ``cdk`` at
+       ``22.0.6``. ``platform-browser-dynamic`` was dropped — ``src/main.ts``
+       bootstraps with ``platformBrowser()`` from ``@angular/platform-browser``.
    * - Build / serve / test builder
-     - ``@angular/build 22.0.0``
+     - ``@angular/build 22.0.9``
      - The esbuild-based **application** builder. ``angular.json`` uses
        ``@angular/build:application`` (build), ``:dev-server`` (serve), and
-       ``:karma`` (test). No webpack.
+       ``:unit-test`` (test). No webpack.
    * - TypeScript
      - ``6.0.3``
      - ``tsConfig`` targets ``ES2022`` with ``strict: true``,
@@ -108,30 +110,36 @@ All versions below are pinned in :file:`esgame/v2/package.json`.
      - ``~7.8.2``
      - Reactive state in ``GameService`` (``BehaviorSubject`` streams).
    * - uuid
-     - ``^14.0.0``
+     - ``^14.0.1``
      - Generates the per-session ``game_id`` sent to the calculator.
    * - zone.js
      - ``0.16.2``
      - Polyfill (configured in ``angular.json`` ``polyfills``).
-   * - Karma + Jasmine
-     - ``karma ~6.4.4``, ``jasmine-core ^6.3.0``
-     - Unit tests via ``@angular/build:karma``.
+   * - Vitest + jsdom
+     - ``vitest ^4.1.10``, ``jsdom ^30.0.1``
+     - Unit tests via ``@angular/build:unit-test`` (``npm test``). Replaced
+       Karma + Jasmine, whose ``socket.io``/``ws`` chain carried every
+       outstanding audit finding. The specs are unchanged — they use only
+       ``describe``/``it``/``expect``, which Vitest provides.
    * - Playwright
-     - ``^1.60.0``
-     - End-to-end tests (``npm run e2e``).
-   * - angular-cli-ghpages
-     - ``^3.1.0``
-     - The ``deploy`` architect target for the static GitHub Pages build.
+     - ``^1.62.0``
+     - End-to-end tests (``npm run e2e``), driving the system Chrome.
+   * - Lighthouse CI
+     - ``@lhci/cli ^0.15.1``
+     - Bundle-size and Core Web Vitals gate (``npm run lhci``), configured in
+       :file:`v2/lighthouserc.json`. See :file:`perf/README.md`.
 
 .. note::
 
-   **Node.js >= 22.22.3 is required.** Angular 22 and the
-   ``@angular/build`` esbuild toolchain do not run on older Node releases.
-   Verify your version before installing:
+   **Node.js ^22.22.3 || ^24.15.0 || >=26.0.0 is required.** That is the range
+   Angular 22's CLI accepts; the ``@angular/build`` esbuild toolchain does not
+   run outside it. CI and the Pages deploy both pin **26.5.0**, the newest
+   accepted release, so the gate runs the same runtime that ships. Verify your
+   version before installing:
 
    .. code-block:: sh
 
-      node --version    # must be >= 22.22.3
+      node --version    # ^22.22.3 || ^24.15.0 || >=26.0.0
 
 The build is configured in :file:`esgame/v2/angular.json`. Highlights:
 
@@ -177,19 +185,24 @@ Other scripts (from :file:`package.json`):
    * - ``npm run watch``
      - ``ng build --watch --configuration development`` — rebuild on change.
    * - ``npm test``
-     - ``ng test`` — Karma + Jasmine unit tests.
+     - ``ng test`` — Vitest unit tests.
    * - ``npm run e2e``
      - ``ng build && playwright test`` — end-to-end tests against the built app.
+   * - ``npm run lhci``
+     - Lighthouse CI bundle-size / Core Web Vitals gate.
 
-Running unit tests headless
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Running unit tests once
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-``npm test`` opens an interactive Chrome via ``karma-chrome-launcher`` by
-default. For CI or a headless terminal, run a single headless pass:
+``npm test`` runs Vitest in watch mode. For CI or a one-shot pass:
 
 .. code-block:: sh
 
-   npm test -- --watch=false --browsers=ChromeHeadless
+   npm test -- --watch=false
+
+No browser is involved: the unit suite runs under **jsdom**, so there is
+nothing to install and no ``CHROME_BIN`` to set. Real-browser behavior is
+covered by the Playwright e2e suite instead.
 
 Existing specs cover the configuration and scoring logic — for example
 :file:`services/config.service.spec.ts`, :file:`services/score.service.spec.ts`,

--- a/docs/reference/containers.rst
+++ b/docs/reference/containers.rst
@@ -26,7 +26,7 @@ Build stage
 
 .. code-block:: dockerfile
 
-   FROM node:22-alpine AS build
+   FROM node:26-alpine AS build
    WORKDIR /app
    COPY package.json package-lock.json ./
    RUN npm ci
@@ -35,8 +35,9 @@ Build stage
 
 Notable points:
 
-* **Base image** ``node:22-alpine``. Node 22.22.3+ is required by Angular 22
-  (the package ``engines`` constraint is ``^22.22.3 || ^24.15.0 || >=26``).
+* **Base image** ``node:26-alpine`` — the newest major Angular 22 accepts
+  (``^22.22.3 || ^24.15.0 || >=26.0.0``), matching the ``26.5.0`` pin in CI and
+  the Pages deploy.
 * **Layer caching.** ``package.json`` and ``package-lock.json`` are copied first and
   ``npm ci`` is run before the rest of the source, so dependency installation is only
   re-run when the lockfile changes.
@@ -315,7 +316,7 @@ calculator
 ~~~~~~~~~~
 
 A stateless FastAPI stand-in built from :file:`calculator/Dockerfile`
-(``python:3.12-slim``; ``fastapi==0.115.6`` and ``uvicorn[standard]==0.34.0``), launched as
+(``python:3.14-slim``; ``fastapi==0.140.13`` and ``uvicorn[standard]==0.52.0``), launched as
 ``uvicorn app:app --host 0.0.0.0 --port 8000``. It exposes:
 
 * ``GET /`` — health, returns ``{"status": "ok"}``.
@@ -339,7 +340,7 @@ referenced *in place* by the external coverages the seeder registers.
 geoserver-seed (one-shot)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Built from :file:`geoserver/Dockerfile` (``python:3.12-slim``, stdlib only,
+Built from :file:`geoserver/Dockerfile` (``python:3.14-slim``, stdlib only,
 ``ENTRYPOINT ["python3", "/seed.py"]``) with ``restart: "no"`` — it runs once and exits.
 It ``depends_on: [geoserver]`` and reaches it via the **in-network** URL
 ``GEOSERVER_URL: http://geoserver:8080/geoserver`` (contrast the calculator's

--- a/docs/reference/geoserver.rst
+++ b/docs/reference/geoserver.rst
@@ -25,7 +25,7 @@ This page is grounded in the example stack under
    * - :file:`geoserver/palettes.json`
      - Palette definitions and the coverage-to-style mapping the seeder consumes.
    * - :file:`geoserver/Dockerfile`
-     - Builds the seeder image (``python:3.12-slim`` + :file:`seed.py`).
+     - Builds the seeder image (``python:3.14-slim`` + :file:`seed.py`).
    * - :file:`geoserver/rasters/`
      - The eight ``*.tif`` consequence rasters, bind-mounted read-only into both GeoServer and the seeder.
    * - :file:`docker-compose.yml`
@@ -85,8 +85,23 @@ attaches the ``Authorization: Basic`` header, and (when ``ctype`` is given) a
 ``Content-Type`` header. The request is sent with a 30-second timeout.
 
 It returns **only the HTTP status code** — ``r.status`` on success, or
-``e.code`` when the response is an ``HTTPError``. No body is parsed; callers
-branch on the status code alone. This means a 4xx/5xx never raises out of ``gs``.
+``e.code`` when the response is an ``HTTPError``. No body is parsed, and a
+4xx/5xx never raises out of ``gs``, so that probing callers such as ``exists``
+can branch on the status.
+
+``gs_ok(method, path, data=None, ctype=None)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Wraps ``gs`` and raises ``SeedError`` on any non-2xx status. **Every mutating
+call goes through it.** Calls used to go through ``gs`` directly with the status
+discarded, which meant a rejected request looked exactly like a successful one —
+the seeder logged ``[seed] done`` having registered nothing.
+
+``gs_json(path)``
+~~~~~~~~~~~~~~~~~
+
+GETs ``path`` and returns the parsed JSON body, or ``None`` if the call failed.
+Used by the final verification step.
 
 ``exists(path)``
 ~~~~~~~~~~~~~~~~
@@ -151,12 +166,19 @@ steps, in order:
 
       PUT /rest/workspaces/esgame/coveragestores/{name}/external.geotiff?coverageName={name}
       Content-Type: text/plain
-      file:///rasters/{name}.tif
+      /rasters/{name}.tif
 
-   The ``external.geotiff`` endpoint with a ``file://`` body tells GeoServer to
-   reference the GeoTIFF **in place** rather than copy/upload it — only the catalog
-   entry lands in the data dir. ``?coverageName={name}`` names the published
-   coverage to match the store.
+   The ``external.geotiff`` endpoint tells GeoServer to reference the GeoTIFF
+   **in place** rather than copy/upload it — only the catalog entry lands in the
+   data dir. ``?coverageName={name}`` names the published coverage to match the
+   store.
+
+   .. warning::
+
+      The body must be a **plain absolute path**, not a URL. GeoServer 2.28
+      rejects every ``file:`` form with ``400 Failed to locate the input file``.
+      The seeder used to send ``file:///rasters/{name}.tif`` and, because it
+      ignored the response status, reported success while registering nothing.
 
 #. **Create or update styles.** For each *distinct* style name actually used
    (``sorted(set(coverage_styles.values()))``), build the SLD with
@@ -214,7 +236,7 @@ REST endpoints used
      - Does the coverage store exist?
    * - ``PUT``
      - ``/rest/workspaces/esgame/coveragestores/{name}/external.geotiff?coverageName={name}``
-     - Register an *external* GeoTIFF (``file://`` body).
+     - Register an *external* GeoTIFF (plain absolute path as the body).
    * - ``GET``
      - ``/rest/workspaces/esgame/styles/{pname}.json``
      - Does the style exist?
@@ -343,7 +365,7 @@ never coupled to the registration logic, and registration runs exactly once.
 
 .. code-block:: dockerfile
 
-   FROM python:3.12-slim
+   FROM python:3.14-slim
    COPY seed.py /seed.py
    ENTRYPOINT ["python3", "/seed.py"]
 
@@ -392,8 +414,13 @@ Why this survives a reboot:
   read-only into the seeder so it has the same files GeoServer references.
 
 The rasters bind mount is the same source path (``./geoserver/rasters``) on both
-services, so the ``file:///rasters/{name}.tif`` URLs the seeder writes resolve
+services, so the ``/rasters/{name}.tif`` paths the seeder writes resolve
 identically inside the GeoServer container.
+
+After the styles are applied the seeder reads the catalog back and compares the
+registered coverage stores against the ``*.tif`` files on disk, raising
+``SeedError`` if they disagree. A silently empty workspace therefore fails the
+container instead of exiting 0.
 
 
 WCS GetCoverage access pattern


### PR DESCRIPTION
Today's changes (#35–#46) left the Sphinx docs describing a stack that no longer exists. Six files were wrong.

| File | Corrections |
|---|---|
| `developer.rst` | Angular 22.0.0 → 22.0.8/.6/.9; **Karma + Jasmine → Vitest + jsdom**; uuid ^14.0.0 → ^14.0.1; Playwright ^1.60 → ^1.62; added Lighthouse CI; dropped the `angular-cli-ghpages` row (the `ng deploy` target it documented is gone); *"Node >= 22.22.3"* → the real range, noting CI/deploy pin 26.5.0; replaced the `karma-chrome-launcher` headless instructions, which no longer apply now that units run under jsdom |
| `builder.rst` | `:karma` → `:unit-test`; `node:22-alpine` → `node:26-alpine`; `python:3.12` → `3.14`; fastapi/uvicorn versions; `upload-artifact@v4` → v7; `upload-pages-artifact@v3` → v5; `setup-node@v4`/Node 20 → `@v7`/26.5.0; the reproducibility table's pins; added the TypeScript `<6.1` cap |
| `deployer.rst` | Node 22.22.3 → 26.5.0; `upload-pages-artifact` v3 → v5 |
| `architecture.rst` | Node requirement + `node:26-alpine` |
| `containers.rst` | `node:22-alpine` → `node:26-alpine`; example deps |
| `geoserver.rst` | the seeder's PUT body is a **plain path**, not `file://`; documented `gs_ok` / `gs_json` and the new verification step |

## Two notes kept as history rather than deleted

Both described bugs that were live for weeks and are worth not repeating:

- `builder.rst`'s Node note now explains that the gate once pinned Node 20 — which Angular 22 rejects outright — and failed on every run for ~7 weeks before anyone noticed.
- `geoserver.rst` warns that a `file:` body is rejected with `400 Failed to locate the input file`, and that the old seeder hid it by discarding the status.

## Verification

`sphinx-build` completes with **no warnings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE