### PR TITLE
fix(e2e): serve byte ranges so the board actually renders under test

### DIFF
--- a/v2/e2e/app.spec.ts
+++ b/v2/e2e/app.spec.ts
@@ -27,6 +27,25 @@ test('the dynamic route renders the SVG game', async ({ page }) => {
 	await expect(page.locator('tro-svg-game-board').first()).toBeVisible();
 });
 
+// Every assertion above passes against an empty board — they only prove the component
+// mounted. This one fails unless the GeoTIFFs actually decoded into fields, which is
+// what the byte-range support in e2e/serve.mjs exists for.
+test('the grid board decodes its GeoTIFFs into fields', async ({ page }) => {
+	const errors: string[] = [];
+	page.on('pageerror', e => errors.push(e.message));
+	page.on('console', m => { if (m.type() === 'error') errors.push(m.text()); });
+
+	await page.goto('/');
+	await expect(page.locator('tro-grid-game-board').first()).toBeVisible();
+	// 812 fields per 28x29 board; the page shows the main board plus side maps.
+	await expect.poll(() => page.locator('tro-field').count(), { timeout: 30_000 })
+		.toBeGreaterThanOrEqual(812);
+
+	// geotiff.js reports "Server responded with full file" when a Range request is
+	// answered with the whole body, and then silently renders nothing.
+	expect(errors).toEqual([]);
+});
+
 test('runtime config.json is served and selects the static default', async ({ request }) => {
 	const res = await request.get('/assets/config.json');
 	expect(res.ok()).toBeTruthy();

--- a/v2/e2e/serve.mjs
+++ b/v2/e2e/serve.mjs
@@ -1,5 +1,12 @@
 // Minimal static server with SPA fallback (mirrors the container's nginx `try_files ... /index.html`).
 // Serves the production build for the Playwright e2e suite.
+//
+// Range requests are supported because geotiff.js fetches the consequence/suitability
+// GeoTIFFs by byte range. A server that answers a Range request with the whole file
+// makes it abort with "Server responded with full file", and the board never populates
+// — which is what happened here before, so the e2e suite could only ever assert that
+// the board element mounted, never that it rendered any fields. nginx and GitHub Pages
+// both honour Range, so this only ever affected local/CI runs.
 import http from 'node:http';
 import { readFile, stat } from 'node:fs/promises';
 import { join, extname } from 'node:path';
@@ -12,6 +19,29 @@ const TYPES = {
 	'.tif': 'image/tiff', '.png': 'image/png', '.ico': 'image/x-icon', '.svg': 'image/svg+xml', '.woff2': 'font/woff2',
 };
 
+// Parses a single-range "bytes=start-end" header against a known size.
+// Returns null when absent/unsatisfiable-as-written, so the caller falls back to 200.
+function parseRange(header, size) {
+	if (!header) return null;
+	const m = /^bytes=(\d*)-(\d*)$/.exec(header.trim());
+	if (!m) return null;
+	const [, rawStart, rawEnd] = m;
+	if (rawStart === '' && rawEnd === '') return null;
+	let start, end;
+	if (rawStart === '') {
+		// suffix range: last N bytes
+		const n = Number(rawEnd);
+		if (!n) return null;
+		start = Math.max(0, size - n);
+		end = size - 1;
+	} else {
+		start = Number(rawStart);
+		end = rawEnd === '' ? size - 1 : Math.min(Number(rawEnd), size - 1);
+	}
+	if (!Number.isFinite(start) || !Number.isFinite(end) || start > end || start >= size) return null;
+	return { start, end };
+}
+
 http.createServer(async (req, res) => {
 	const { pathname } = new URL(req.url, 'http://localhost');
 	let file = join(ROOT, decodeURIComponent(pathname));
@@ -22,7 +52,24 @@ http.createServer(async (req, res) => {
 	}
 	try {
 		const body = await readFile(file);
-		res.writeHead(200, { 'Content-Type': TYPES[extname(file)] || 'application/octet-stream' });
+		const type = TYPES[extname(file)] || 'application/octet-stream';
+		const range = parseRange(req.headers.range, body.length);
+		if (range) {
+			const { start, end } = range;
+			res.writeHead(206, {
+				'Content-Type': type,
+				'Content-Range': `bytes ${start}-${end}/${body.length}`,
+				'Content-Length': end - start + 1,
+				'Accept-Ranges': 'bytes',
+			});
+			res.end(body.subarray(start, end + 1));
+			return;
+		}
+		res.writeHead(200, {
+			'Content-Type': type,
+			'Content-Length': body.length,
+			'Accept-Ranges': 'bytes',
+		});
 		res.end(body);
 	} catch {
 		res.writeHead(404); res.end('not found');


### PR DESCRIPTION
The e2e suite has never rendered a game board.

`e2e/serve.mjs` answered every request with the whole file, ignoring `Range`. geotiff.js fetches the suitability/consequence GeoTIFFs by byte range, gives up with **`Server responded with full file`**, and the board silently stays empty. Under the old server:

```
tro-field count: 0
errors: [ 'Server responded with full file' ]
```

Every existing assertion still passed, because they only check that `tro-grid-game-board` is *visible* — an empty board satisfies that. So the suite was green while the thing it exists to test never happened.

nginx and GitHub Pages both honour `Range`, so this only ever affected local and CI runs — the deployed app is fine.

## Changes

- **`serve.mjs` handles `Range`** — single ranges including open-ended (`bytes=N-`) and suffix (`bytes=-N`) forms, replying `206` with `Content-Range`, and advertising `Accept-Ranges: bytes`. Unparseable or unsatisfiable ranges fall back to a normal `200` rather than erroring.
- **A test that can actually fail**: asserts ≥ 812 `tro-field` elements (the 28×29 board) and that the console stayed clean.

After the fix:

```
tro-field count: 2436
errors: none
```

## Verified in both directions

- With the fix: **6/6** e2e pass, including the new test.
- Without it (reverting `serve.mjs` only): the new test **fails** — the field count never reaches 812 and it times out. So it is a real gate, not a decoration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE