### PR TITLE
refactor: replace subsink with Angular's takeUntilDestroyed

### DIFF
--- a/v2/package-lock.json
+++ b/v2/package-lock.json
@@ -21,7 +21,6 @@
         "@ngx-translate/http-loader": "^18.0.0",
         "geotiff": "^3.0.5",
         "rxjs": "~7.8.2",
-        "subsink": "^1.0.2",
         "tslib": "^2.8.1",
         "uuid": "^14.0.1",
         "zone.js": "0.16.2"
@@ -10467,12 +10466,6 @@
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
-    },
-    "node_modules/subsink": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/subsink/-/subsink-1.0.2.tgz",
-      "integrity": "sha512-QFL2oKaA6jVai82dcF0/SIKHNrKJO/wAiHBw9CG576+eBzeg+lZmpG63Tvajx3yg05Hf9ZIZ+zroJutj3hvLNQ==",
-      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "5.5.0",

--- a/v2/package.json
+++ b/v2/package.json
@@ -25,7 +25,6 @@
     "@ngx-translate/http-loader": "^18.0.0",
     "geotiff": "^3.0.5",
     "rxjs": "~7.8.2",
-    "subsink": "^1.0.2",
     "tslib": "^2.8.1",
     "uuid": "^14.0.1",
     "zone.js": "0.16.2"

--- a/v2/src/app/field/grid-field/grid-field.component.ts
+++ b/v2/src/app/field/grid-field/grid-field.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, HostBinding, Input, Renderer2 } from '@angular/core';
-import { SubSink } from 'subsink';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FieldBaseComponent } from '../field-base.component';
 import { HighlightSide } from 'src/app/shared/models/field';
 import { GameService } from 'src/app/services/game.service';
@@ -20,7 +20,6 @@ export class GridFieldComponent extends FieldBaseComponent {
 		return false;
 	}
 	private _imageMode = false;
-	private _sink = new SubSink();
 
 	@Input() set imageMode(mode: any) {
 		this._imageMode = mode !== false;
@@ -49,11 +48,11 @@ export class GridFieldComponent extends FieldBaseComponent {
 		cdRef: ChangeDetectorRef
 	) {
 		super(gameService, renderer, elementRef, cdRef);
-		this._sink.sink = this.gameService.settingsObs.subscribe(settings => {
+		this.gameService.settingsObs.pipe(takeUntilDestroyed()).subscribe(settings => {
 			this.elementSize = settings.elementSize;
 			this.imageMode = settings.imageMode;
 		});
-		gameService.settingsObs.subscribe(settings => {
+		gameService.settingsObs.pipe(takeUntilDestroyed()).subscribe(settings => {
 			this.highlightColor = settings.highlightColor;
 		});
 	}
@@ -106,8 +105,4 @@ export class GridFieldComponent extends FieldBaseComponent {
 		this.showProductionImage = true;
 	}
 
-	override ngOnDestroy(): void {
-		super.ngOnDestroy();
-		this._sink.unsubscribe();
-	}
 }

--- a/v2/src/app/game-board/game-board-base.component.ts
+++ b/v2/src/app/game-board/game-board-base.component.ts
@@ -1,10 +1,10 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, HostBinding, HostListener, Input, OnDestroy, Renderer2 } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, ElementRef, HostBinding, HostListener, Input, OnDestroy, Renderer2, inject } from '@angular/core';
 import { GameService } from '../services/game.service';
 import { Field, HighlightField, SelectedField } from '../shared/models/field';
 import { GameBoard, GameBoardClickMode } from '../shared/models/game-board';
 import { Settings } from '../shared/models/settings';
 import { Legend } from '../shared/models/legend';
-import { SubSink } from 'subsink';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ProductionType } from '../shared/models/production-type';
 
 @Component({
@@ -18,8 +18,10 @@ export abstract class GameBoardBaseComponent implements OnDestroy {
 	protected _clickMode = GameBoardClickMode.SelectBoard;
 	protected _selectedFields: SelectedField[] = [];
 	protected _highlightedFields: HighlightField[] = [];
-	protected _sink = new SubSink();
 	protected _listeners: (() => void)[] = [];
+	// Explicit ref so subclasses can use takeUntilDestroyed(this.destroyRef) from lifecycle hooks,
+	// which are not injection contexts.
+	protected readonly destroyRef = inject(DestroyRef);
 	protected _readOnly = false;
 
 	fields: Field[] = [];
@@ -70,10 +72,10 @@ export abstract class GameBoardBaseComponent implements OnDestroy {
 		protected elementRef: ElementRef,
 		protected cdRef: ChangeDetectorRef
 	) {
-		this._sink.sink = this.gameService.settingsObs.subscribe(settings => {
+		this.gameService.settingsObs.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(settings => {
 			this.settings = settings;
 		});
-		gameService.productionTypesObs.subscribe(prodTypes => {
+		gameService.productionTypesObs.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(prodTypes => {
 			this.productionTypes = prodTypes;
 		});
 	}
@@ -100,7 +102,6 @@ export abstract class GameBoardBaseComponent implements OnDestroy {
 	protected abstract drawSelectedFields(): void;
 
 	ngOnDestroy(): void {
-		this._sink.unsubscribe();
 		this._listeners.forEach(fn => fn());
 	}
 }

--- a/v2/src/app/game-board/grid-game-board/grid-game-board.component.ts
+++ b/v2/src/app/game-board/grid-game-board/grid-game-board.component.ts
@@ -3,6 +3,7 @@ import { GameBoardBaseComponent } from '../game-board-base.component';
 import { GameService } from 'src/app/services/game.service';
 import { GameBoard } from 'src/app/shared/models/game-board';
 import { GridFieldComponent } from 'src/app/field/grid-field/grid-field.component';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
     selector: 'tro-grid-game-board',
@@ -26,7 +27,7 @@ export class GridGameBoardComponent extends GameBoardBaseComponent implements Af
 		cdRef: ChangeDetectorRef
 		) {
 			super(gameService, renderer, elementRef, cdRef);
-			this._sink.sink = this.gameService.highlightFieldObs.subscribe(fieldNumbers => {
+			this.gameService.highlightFieldObs.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(fieldNumbers => {
 				this._highlightedFields.forEach(o => this.fieldComponents?.get(o.id)?.removeHighlight());
 				this._highlightedFields = fieldNumbers;
 
@@ -44,12 +45,12 @@ export class GridGameBoardComponent extends GameBoardBaseComponent implements Af
 		}
 
 		ngAfterViewInit() {
-			this._sink.sink = this.gameService.selectedFieldsObs.subscribe(fields => {
+			this.gameService.selectedFieldsObs.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(fields => {
 				this._selectedFields = fields;
 				setTimeout(() => this.drawSelectedFields());
 			});
 
-			this._sink.sink = this.fieldComponents.changes.subscribe(_ => {
+			this.fieldComponents.changes.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(_ => {
 				setTimeout(() => this.drawSelectedFields());
 			});
 		}

--- a/v2/src/app/game-board/svg-game-board/svg-game-board.component.ts
+++ b/v2/src/app/game-board/svg-game-board/svg-game-board.component.ts
@@ -4,6 +4,7 @@ import { SvgFieldComponent } from 'src/app/field/svg-field/svg-field.component';
 import { GameService } from 'src/app/services/game.service';
 import { GameBoardType } from 'src/app/shared/models/game-board-type';
 import { GameBoardClickMode } from 'src/app/shared/models/game-board';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
     selector: 'tro-svg-game-board',
@@ -24,11 +25,11 @@ export class SvgGameBoardComponent extends GameBoardBaseComponent implements Aft
 
 	constructor(gameService: GameService, renderer: Renderer2, elementRef: ElementRef, cdRef: ChangeDetectorRef) {
 		super(gameService, renderer, elementRef, cdRef);
-		this._sink.sink = this.gameService.settingsObs.subscribe(s => {
+		this.gameService.settingsObs.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(s => {
 			this.consequenceFieldOpacity = s?.visualOptions?.consequenceFieldOpacity ?? false;
 			this.cdRef.markForCheck();
 		});
-		this._sink.sink = this.gameService.highlightFieldObs.subscribe(fieldNumbers => {
+		this.gameService.highlightFieldObs.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(fieldNumbers => {
 			this._highlightedFields.forEach(o => this.svgFieldComponents?.find(s => s.field.id == o.id)?.removeHighlight());
 			this._highlightedFields = fieldNumbers;
 
@@ -67,12 +68,12 @@ export class SvgGameBoardComponent extends GameBoardBaseComponent implements Aft
 	}
 
 	ngAfterViewInit() {
-		this._sink.sink = this.gameService.selectedFieldsObs.subscribe(fields => {
+		this.gameService.selectedFieldsObs.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(fields => {
 			this._selectedFields = fields;
 			setTimeout(() => this.drawSelectedFields());
 		});
 
-		this._sink.sink = this.svgFieldComponents.changes.subscribe(_ => {
+		this.svgFieldComponents.changes.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(_ => {
 			setTimeout(() => this.drawSelectedFields());
 		});
 	}


### PR DESCRIPTION
`subsink@1.0.2` was the last stale runtime dependency — published **2022-05-18**, nothing since. Angular ships the equivalent as `takeUntilDestroyed` (`@angular/core/rxjs-interop`), so the wrapper buys nothing.

## The DestroyRef detail

`GameBoardBaseComponent` now holds `protected readonly destroyRef = inject(DestroyRef)`, because two subclasses subscribe from **`ngAfterViewInit`** — not an injection context, where the no-argument `takeUntilDestroyed()` throws.

| Component | Subscriptions migrated |
|---|---|
| `game-board-base` | 2 |
| `grid-field` | 2 |
| `grid-game-board` | 3 (one in the constructor, two in `ngAfterViewInit`) |
| `svg-game-board` | 4 (two and two) |

## Two leaks fixed along the way

These were never added to the sink, so they were never unsubscribed:

```ts
// game-board-base.component.ts
gameService.productionTypesObs.subscribe(...)   // untracked
// grid-field.component.ts
gameService.settingsObs.subscribe(...)          // untracked
```

Both now go through `takeUntilDestroyed`. Also dropped `GridFieldComponent.ngOnDestroy`, which existed only to flush the sink — the inherited `FieldBaseComponent.ngOnDestroy` already releases the renderer listeners.

## Verification

- build clean, **12/12** unit, **6/6** e2e, Lighthouse assertions pass
- The e2e run now includes the board-decode test from #48, so this is checked against a board that **actually rendered 2436 fields** — not an empty component that merely mounted
- No console errors when scripting clicks and hovers over the board
- Interactive behaviour matches master exactly on the same scripted clicks (I ran the identical script against both)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE