### PR TITLE
fix(tools/R): drop two install lines that never did anything

### DIFF
--- a/tools/R/Dockerfile
+++ b/tools/R/Dockerfile
@@ -6,12 +6,14 @@ RUN R -e "install.packages('Rcpp')"
 RUN R -e "install.packages('sf')"
 RUN R -e "install.packages('sp')"
 RUN R -e "install.packages('raster')"
-RUN R -e "install.packages('rgdal')"
+# NOTE: rgdal is intentionally absent. It was retired from CRAN in Oct 2023, so
+# install.packages('rgdal') resolves to nothing while still exiting 0 — the image
+# built "successfully" without it for years. calculator.r does not use it.
+# 'grid' is likewise absent: it ships with R as a base package.
 RUN R -e "install.packages('ggplot2')"
 RUN R -e "install.packages('ggpubr')"
 RUN R -e "install.packages('tidyverse')"
 RUN R -e "install.packages('tidyr')"
-RUN R -e "install.packages('grid')"
 RUN R -e "install.packages('jsonlite')"
 #RUN R -e "install.packages('geosapi')"
 RUN R -e "install.packages('logger')"


### PR DESCRIPTION
The R calculator image ran two installs that silently no-op:

| Line | Reality |
|---|---|
| `install.packages('rgdal')` | **Archived on CRAN since Oct 2023**, so it resolves to nothing — and R still exits 0, so `docker build` reported success while the image simply never had rgdal |
| `install.packages('grid')` | `grid` ships with R as a **base package** |

Confirmed by inspecting the image built from the *current* Dockerfile:

```
rgdal   FALSE
grid    TRUE      # present because it is base R, not because of the install line
```

`calculator.r` already carries a comment noting rgdal was retired and is unused — the Dockerfile was just never updated to match.

## Verification

Rebuilt without both lines. Identical package availability:

```
rgdal FALSE | grid TRUE | sf TRUE | sp TRUE | raster TRUE | terra TRUE
plumber TRUE | jsonlite TRUE | ggpubr TRUE | tidyverse TRUE | logger TRUE
```

Container still starts: `Running plumber API at http://0.0.0.0:8000`.

## Base image left alone, deliberately

`rstudio/plumber` is untagged, i.e. `latest` (currently R 4.6.1). That **is** the newest, and pinning a plumber version tag (`v1.3.0` is the newest concrete one) risks pinning an older R alongside it. The reproducibility-vs-newest tradeoff is written up in the dependency review rather than changed blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE