### PR TITLE
perf: lazy-load /configurator, bringing the bundle under budget

### DIFF
--- a/perf/README.md
+++ b/perf/README.md
@@ -20,21 +20,25 @@ break to find the per-replica ceiling. Install k6: https://k6.io/docs/get-starte
 
 ## Frontend load — Lighthouse CI
 
-The production build exceeds its `initial` bundle budget on every run. Measured on
-Angular 22.0.8 (`ng build --configuration production`):
+The production build is **within** its `initial` budget. Measured on Angular 22.0.8
+(`ng build --configuration production`):
 
 | Entry-point file | Size |
 |---|---|
-| `main-*.js` | 966,182 B (943 KiB) |
-| `styles-*.css` | 104,990 B (103 KiB) |
-| `polyfills-*.js` | 35,784 B (35 KiB) |
-| **initial total** | **1,106,956 B — 1.11 MB** |
+| `main-*.js` | 835,862 B |
+| `styles-*.css` | 105,077 B |
+| `polyfills-*.js` | 35,784 B |
+| **initial total** | **976,723 B** |
 
-The budgets in `v2/angular.json` are `maximumWarning: 1mb` / `maximumError: 2mb`, so the
-build **warns** by ~107 kB but does not fail — the 2 MB error threshold is what would
-actually break CI. (Angular reports budgets in decimal units: 1 mb = 1,000,000 bytes.)
+The budgets in `v2/angular.json` are `maximumWarning: 1mb` / `maximumError: 2mb`, and
+Angular reports them in decimal units (1 mb = 1,000,000 bytes). The build emitted the
+warning on every run until `/configurator` was made lazy — that moved 130,233 B out of
+the entry point (1,106,956 → 976,723) and the warning stopped.
 
-`main` is 87% of the payload, and the heavy client op is GeoTIFF decode → SVG.
+That headroom is only ~23 kB, so the budget is now a live gate rather than background
+noise: the next thing added to the eager graph will trip it.
+
+The heavy client op is GeoTIFF decode → SVG.
 
 A perpetual warning is not a gate, so **Lighthouse CI** (`v2/lighthouserc.json`) is what
 actually fails a regression. It runs in CI after the e2e step and locally with:
@@ -48,13 +52,13 @@ container's nginx), runs Lighthouse 3× under the `desktop` preset, and asserts:
 
 | Assertion | Budget | Measured |
 |---|---|---|
-| `resource-summary:script:size` | 1,100,000 B | 1,002,152 B |
+| `resource-summary:script:size` | 1,000,000 B | 938,017 B |
 | `resource-summary:stylesheet:size` | 120,000 B | 105,159 B |
-| `resource-summary:font:size` | **125,000 B** | **108,429 B** |
-| `resource-summary:total:size` | **1,450,000 B** | **1,358,202 B** |
-| `categories:performance` | ≥ 0.80 | 0.82 |
-| `largest-contentful-paint` | ≤ 2500 ms | ~1,757 ms |
-| `total-blocking-time` | ≤ 300 ms | ~206 ms |
+| `resource-summary:font:size` | 125,000 B | 108,429 B |
+| `resource-summary:total:size` | 1,380,000 B | 1,294,040 B |
+| `categories:performance` | ≥ 0.80 | 0.83 |
+| `largest-contentful-paint` | ≤ 2500 ms | ~1,790 ms |
+| `total-blocking-time` | ≤ 300 ms | ~175 ms |
 | `cumulative-layout-shift` | ≤ 0.1 | 0 |
 
 The timing figures above were taken on a loaded desktop. They move a lot with machine
@@ -70,7 +74,13 @@ shared CI runner is noisy, and flaky perf gates get ignored. Reports upload as t
 Fonts were the first thing fixed here: `Roboto-Regular` was served as a 164 kB TTF and
 the other eleven Roboto weights were shipped but never referenced. Converting the one
 used face to WOFF2 cut it 62% (168,260 → 63,608 B) and deleting the unused weights took
-~1.8 MB off the build output. `main` is now ~74% of the transfer, so route-level lazy
-loading is the next lever.
+~1.8 MB off the build output. Route-level lazy loading came next: `/configurator` is an authoring tool, not on the
+path to the game, and the only consumer of MatStepper / MatInput / MatCheckbox /
+MatSlider. Moving it behind `loadChildren` took 130,233 B out of the entry point.
+
+The remaining levers, roughly by size: Angular Material is still ~29% of `main`, and
+nine of its ten modules are genuinely used by eagerly-loaded components;
+`@angular/animations` is ~63 kB and only present because `app.module.ts` imports
+`BrowserAnimationsModule` (see the dependency review).
 
 The Playwright suite (`v2/e2e`) can also assert time-to-first-board-render.

--- a/v2/e2e/app.spec.ts
+++ b/v2/e2e/app.spec.ts
@@ -46,6 +46,20 @@ test('the grid board decodes its GeoTIFFs into fields', async ({ page }) => {
 	expect(errors).toEqual([]);
 });
 
+// /configurator is lazy-loaded. A broken chunk shows up as a blank route rather than
+// a build error, so assert the component and its heaviest widget actually mount.
+test('the lazy /configurator route loads its chunk and renders', async ({ page }) => {
+	const errors: string[] = [];
+	page.on('pageerror', e => errors.push(e.message));
+	page.on('console', m => { if (m.type() === 'error') errors.push(m.text()); });
+
+	await page.goto('/configurator');
+	await expect(page.locator('tro-configurator')).toBeVisible();
+	// MatStepper lives only in the lazy chunk — if it rendered, the chunk resolved.
+	await expect(page.locator('mat-stepper')).toBeVisible();
+	expect(errors).toEqual([]);
+});
+
 test('runtime config.json is served and selects the static default', async ({ request }) => {
 	const res = await request.get('/assets/config.json');
 	expect(res.ok()).toBeTruthy();

--- a/v2/lighthouserc.json
+++ b/v2/lighthouserc.json
@@ -3,7 +3,9 @@
     "collect": {
       "startServerCommand": "node e2e/serve.mjs",
       "startServerReadyPattern": "e2e server:",
-      "url": ["http://localhost:4173/"],
+      "url": [
+        "http://localhost:4173/"
+      ],
       "numberOfRuns": 3,
       "settings": {
         "preset": "desktop"
@@ -11,15 +13,54 @@
     },
     "assert": {
       "assertions": {
-        "resource-summary:script:size": ["error", { "maxNumericValue": 1100000 }],
-        "resource-summary:stylesheet:size": ["error", { "maxNumericValue": 120000 }],
-        "resource-summary:font:size": ["error", { "maxNumericValue": 125000 }],
-        "resource-summary:total:size": ["error", { "maxNumericValue": 1450000 }],
-
-        "categories:performance": ["error", { "minScore": 0.8 }],
-        "largest-contentful-paint": ["error", { "maxNumericValue": 2500 }],
-        "total-blocking-time": ["error", { "maxNumericValue": 300 }],
-        "cumulative-layout-shift": ["error", { "maxNumericValue": 0.1 }]
+        "resource-summary:script:size": [
+          "error",
+          {
+            "maxNumericValue": 1000000
+          }
+        ],
+        "resource-summary:stylesheet:size": [
+          "error",
+          {
+            "maxNumericValue": 120000
+          }
+        ],
+        "resource-summary:font:size": [
+          "error",
+          {
+            "maxNumericValue": 125000
+          }
+        ],
+        "resource-summary:total:size": [
+          "error",
+          {
+            "maxNumericValue": 1380000
+          }
+        ],
+        "categories:performance": [
+          "error",
+          {
+            "minScore": 0.8
+          }
+        ],
+        "largest-contentful-paint": [
+          "error",
+          {
+            "maxNumericValue": 2500
+          }
+        ],
+        "total-blocking-time": [
+          "error",
+          {
+            "maxNumericValue": 300
+          }
+        ],
+        "cumulative-layout-shift": [
+          "error",
+          {
+            "maxNumericValue": 0.1
+          }
+        ]
       }
     },
     "upload": {

--- a/v2/src/app/app-routing.module.ts
+++ b/v2/src/app/app-routing.module.ts
@@ -1,6 +1,5 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
-import { ConfiguratorComponent } from './configurator/configurator.component';
 import { GridLevelComponent } from './level/grid-level/grid-level.component';
 import { SvgLevelComponent } from './level/svg-level/svg-level.component';
 import { StartComponent } from './start/start.component';
@@ -26,8 +25,10 @@ const routes: Routes = [
 		component: SvgLevelComponent
 	},
 	{
+		// Lazy: the configurator is an authoring tool, not on the path to the game,
+		// and it owns the heaviest Material widgets (stepper/input/checkbox/slider).
 		path: 'configurator',
-		component: ConfiguratorComponent
+		loadChildren: () => import('./configurator/configurator.module').then(m => m.ConfiguratorModule)
 	},
 	{
 		// Unknown paths fall back to the game.

--- a/v2/src/app/app.module.ts
+++ b/v2/src/app/app.module.ts
@@ -12,20 +12,14 @@ import { ButtonDirective } from './shared/button.directive';
 import { HelpComponent } from './help/help.component';
 import { ScoreIndicatorComponent } from './score-indicator/score-indicator.component';
 import { MatSelectModule } from '@angular/material/select';
-import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
-import { MatDividerModule } from '@angular/material/divider';
 import { MatButtonModule } from '@angular/material/button';
-import { MatStepperModule } from '@angular/material/stepper';
-import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatSliderModule } from '@angular/material/slider';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MissingTranslationHandler, MissingTranslationHandlerParams, provideMissingTranslationHandler, provideTranslateService, TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { provideTranslateHttpLoader } from '@ngx-translate/http-loader';
 import { HttpClientModule } from '@angular/common/http';
-import { ConfiguratorComponent } from './configurator/configurator.component';
 import { SvgGameBoardComponent } from './game-board/svg-game-board/svg-game-board.component';
 import { GridGameBoardComponent } from './game-board/grid-game-board/grid-game-board.component';
 import { SvgFieldComponent } from './field/svg-field/svg-field.component';
@@ -55,7 +49,6 @@ export class MyMissingTranslationHandler implements MissingTranslationHandler {
 		ButtonDirective,
 		HelpComponent,
 		ScoreIndicatorComponent,
-		ConfiguratorComponent,
 		SvgFieldComponent,
 		SvgGameBoardComponent,
 		GridGameBoardComponent,
@@ -73,17 +66,12 @@ export class MyMissingTranslationHandler implements MissingTranslationHandler {
 		AppRoutingModule,
 		HttpClientModule,
 		MatSelectModule,
-		MatInputModule,
 		MatIconModule,
-		MatDividerModule,
 		MatButtonModule,
-		MatSliderModule,
 		MatFormFieldModule,
 		MatProgressSpinnerModule,
-		MatCheckboxModule,
 		FormsModule,
 		ReactiveFormsModule,
-		MatStepperModule,
 		TranslatePipe,
 		TranslateDirective,
 	],

--- a/v2/src/app/configurator/configurator.module.ts
+++ b/v2/src/app/configurator/configurator.module.ts
@@ -1,0 +1,48 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
+import { RouterModule, Routes } from '@angular/router';
+import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
+
+import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSliderModule } from '@angular/material/slider';
+import { MatStepperModule } from '@angular/material/stepper';
+
+import { ConfiguratorComponent } from './configurator.component';
+
+// Lazy-loaded route module for /configurator.
+//
+// The configurator is the only consumer of MatStepper, MatInput, MatCheckbox and
+// MatSlider, and it is not on the path any player takes to the game — it is an
+// authoring tool. Keeping it out of the initial bundle is what brings the app back
+// under its 1 MB budget. MatFormField / MatSelect / MatIcon / MatButton are shared
+// with eagerly-loaded components, so they stay in the common chunk; importing them
+// here does not duplicate them.
+const routes: Routes = [
+	{ path: '', component: ConfiguratorComponent },
+];
+
+@NgModule({
+	declarations: [ConfiguratorComponent],
+	imports: [
+		CommonModule,
+		ReactiveFormsModule,
+		RouterModule.forChild(routes),
+		MatButtonModule,
+		MatCheckboxModule,
+		MatFormFieldModule,
+		MatIconModule,
+		MatInputModule,
+		MatSelectModule,
+		MatSliderModule,
+		MatStepperModule,
+		TranslatePipe,
+		TranslateDirective,
+	],
+})
+export class ConfiguratorModule { }


### PR DESCRIPTION
The production build had warned `bundle initial exceeded maximum budget` on **every run**. It no longer does.

`/configurator` is an authoring tool — not on the path any player takes to the game — and it is the only consumer of `MatStepper`, `MatInput`, `MatCheckbox` and `MatSlider`. Moving it behind `loadChildren` takes all of that out of the entry point:

| | before | after |
|---|---|---|
| `main` | 965,728 B | **835,862 B** |
| `styles` | 104,990 B | 105,077 B |
| `polyfills` | 35,784 B | 35,784 B |
| **initial** | **1,106,956 B** | **976,723 B** |

−130,233 B (−11.8%), under the `1mb` warning threshold in `angular.json` — so the build is quiet for the first time.

## Changes

- New `ConfiguratorModule` declaring `ConfiguratorComponent` and importing what its template needs, with `RouterModule.forChild`.
- `AppModule` drops the component and the four now-unused Material modules, plus **`MatDividerModule`, which nothing referenced at all** (`grep -rE 'mat-divider' src` was empty).
- `MatFormField` / `MatSelect` / `MatIcon` / `MatButton` stay in `AppModule` since eager components use them; the lazy module imports them too, which shares rather than duplicates.

## The budget is now a real gate

Headroom is only ~23 kB, so the next thing added to the eager graph trips it — that's the point. Ratcheted the Lighthouse budgets to match: script `1,100,000 → 1,000,000 B` (now 938,017) and total `1,450,000 → 1,380,000 B` (now 1,294,040).

## New e2e test

A lazy chunk that fails to resolve renders a **blank page** rather than failing the build. The test asserts both `tro-configurator` and `mat-stepper` mount and the console stays clean — `mat-stepper` lives only in the lazy chunk, so if it rendered, the chunk resolved.

## Verification

Build clean with **no budget warning**, **12/12** unit, **7/7** e2e, Lighthouse green against the tightened budgets. `/configurator` fetches one **138,885 B** chunk on demand and renders with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE