### PR TITLE
fix(a11y,seo): add image alt, meta description and robots.txt

### DIFF
--- a/perf/README.md
+++ b/perf/README.md
@@ -62,7 +62,10 @@ container's nginx), runs Lighthouse 3× under the `desktop` preset, and asserts:
 | `resource-summary:stylesheet:size` | 120,000 B | 105,159 B | all runs |
 | `resource-summary:font:size` | 125,000 B | 108,429 B | all runs |
 | `resource-summary:total:size` | 1,150,000 B | 1,070,303 B | all runs |
-| `categories:performance` | ≥ 0.70 | ~0.85 | median |
+| `categories:performance` | ≥ 0.70 | ~0.87 | median |
+| `categories:accessibility` | ≥ 0.90 | 93 | all runs |
+| `categories:seo` | ≥ 0.95 | 100 | all runs |
+| `categories:best-practices` | ≥ 0.95 | 100 | all runs |
 | `largest-contentful-paint` | ≤ 2500 ms | ~1,550 ms | median |
 | `total-blocking-time` | ≤ 500 ms | ~160 ms | median |
 | `cumulative-layout-shift` | ≤ 0.1 | 0 | median |
@@ -74,6 +77,13 @@ different day. The byte figures are stable to the byte.
 
 **The byte budgets are the gate.** Transfer sizes are byte-identical across runs, so they
 are held tight (~8-10% headroom) and will catch any real regression.
+
+The **accessibility / SEO / best-practices** scores are also byte-stable — identical on
+every run — so they are asserted tightly too. Accessibility sits at 93 rather than 100
+because of one remaining `color-contrast` failure: `$color-primary` (`#1e90ff`) gives
+3.23:1 against white, under the 4.5:1 WCAG AA threshold, both as link text and as a
+button background. Fixing it means darkening the brand colour, which is a design
+decision rather than a maintenance one, so it is deliberately left open.
 
 **The timing assertions are a smoke alarm, not a gate.** They aggregate on the *median*
 of the three runs, because a single noisy run is otherwise enough to fail the build —

--- a/v2/angular.json
+++ b/v2/angular.json
@@ -39,6 +39,7 @@
             "assets": [
               "src/favicon.ico",
               "src/404.html",
+              "src/robots.txt",
               "src/assets"
             ],
             "styles": [

--- a/v2/lighthouserc.json
+++ b/v2/lighthouserc.json
@@ -64,6 +64,24 @@
             "aggregationMethod": "median",
             "maxNumericValue": 0.1
           }
+        ],
+        "categories:accessibility": [
+          "error",
+          {
+            "minScore": 0.9
+          }
+        ],
+        "categories:seo": [
+          "error",
+          {
+            "minScore": 0.95
+          }
+        ],
+        "categories:best-practices": [
+          "error",
+          {
+            "minScore": 0.95
+          }
         ]
       }
     },

--- a/v2/src/app/product-type-button/production-type-button.component.html
+++ b/v2/src/app/product-type-button/production-type-button.component.html
@@ -1,5 +1,8 @@
 <div class="img-wrapper" [ngStyle]="{ backgroundColor: productionType.fieldColor }">
-	<img class="img"  [src]="productionType.image"
+	<!-- alt="" on purpose: the <p> below already announces the production type, so a
+	     description here would make screen readers say it twice. The empty alt is what
+	     marks it decorative — omitting the attribute entirely is the accessibility bug. -->
+	<img class="img" alt="" [src]="productionType.image"
 		*ngIf="productionType.image" />
 	<div class="img" *ngIf="!productionType.image" [ngStyle]="{ backgroundColor: productionType.fieldColor }">{{
 		("production_type_" + productionType.id | translate).split(' ')[0].charAt(0) }} {{ ("production_type_" +

--- a/v2/src/index.html
+++ b/v2/src/index.html
@@ -17,6 +17,8 @@
     }(window.location));
   </script>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description"
+    content="An ecosystem-services trade-off game: allocate farm types across a landscape and see the effect on carbon, water, habitat and hunting.">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">

--- a/v2/src/robots.txt
+++ b/v2/src/robots.txt
@@ -1,0 +1,4 @@
+# Without this file the SPA fallback answers /robots.txt with index.html, which
+# crawlers (and Lighthouse) then try to parse as robots syntax and reject.
+User-agent: *
+Allow: /


### PR DESCRIPTION
Lighthouse was only ever asserting **performance**, so three deterministic failures had gone unnoticed.

**Accessibility 82 → 93. SEO 75 → 100.**

| Audit | Fix |
|---|---|
| `image-alt` | The production-type `<img>` had no `alt`. Set `alt=""` — the `<p>` beneath already announces the production type, so describing the image would make screen readers say it twice. The **empty** attribute is what marks it decorative; omitting it was the bug. |
| `meta-description` | Added one to `index.html`. |
| `robots-txt` | `/robots.txt` hit the SPA fallback and returned `index.html`, which crawlers parse as robots syntax and reject (`Syntax not understood: <!doctype html>`). Added `src/robots.txt` to the assets list. |

## New gates

These four categories score **identically on every run**, unlike the timing metrics, so they're asserted tightly:

```
categories:accessibility   >= 0.90   (93)
categories:seo             >= 0.95   (100)
categories:best-practices  >= 0.95   (100)
```

## One failure deliberately left open

`color-contrast`: `$color-primary` (`#1e90ff`) is **3.23:1** against white — under the 4.5:1 WCAG AA threshold — both as link text and as a button background. Fixing it means darkening the brand colour, which is a **design decision, not a maintenance one**, so I've documented it in `perf/README.md` rather than changing it unilaterally. That's why accessibility is 93 and not 100.

## Verification

`robots.txt` is served for real (not the SPA fallback), Lighthouse passes the new assertions, **12/12** unit, **7/7** e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE