### PR TITLE
docs: record that the app has no external runtime dependencies

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,10 @@ pygments_style = "sphinx"
 
 # -- HTML output -------------------------------------------------------------
 html_theme = "furo"
-html_static_path = ["_static"]
+# No custom static assets yet. Pointing this at a non-existent "_static" made every
+# docs build — including the Pages deploy — warn "html_static_path entry '_static'
+# does not exist". Re-add the path when there is something to put in it.
+html_static_path = []
 html_title = "esgame documentation"
 
 # MyST niceties

--- a/docs/dependency-review.rst
+++ b/docs/dependency-review.rst
@@ -151,6 +151,35 @@ rule but means two builds a month apart are not the same build.
        without a code change here.
 
 
+Runtime dependencies on external hosts
+---------------------------------------
+
+**There are none, and that is now enforced.**
+
+The app used to fetch Roboto and Material Icons from Google Fonts (declared in
+:file:`index.html`) and two production-type icons from ``raw.githubusercontent.com``
+(referenced by :file:`assets/dataGridExample.json`, the *default* dataset). The
+container image is described as self-contained, but could not render text or icons
+correctly without reaching the internet — a real problem on the offline and filtered
+school networks this game is played on.
+
+All of it is vendored now:
+
+* Roboto 300/400/500 as WOFF2 in :file:`src/assets/fonts/Roboto`.
+* Material Icons subset to the four ligatures the app uses
+  (``open_in_full``, ``close_fullscreen``, ``delete``, ``add``) — 356,840 B TTF down to
+  23,336 B WOFF2 — in :file:`src/assets/fonts/MaterialIcons`.
+* ``corn.png`` / ``cow.png`` copied from the repository's own :file:`images/` into
+  :file:`src/assets/images`.
+
+:file:`v2/lighthouserc.json` asserts ``resource-summary:third-party:size <= 0``, so any
+new external asset fails CI. Verified by loading the container with every non-localhost
+origin blocked: no request is even attempted, and icons, fonts and images all render.
+
+**Vendored font licensing:** Roboto and Material Icons are both Apache-2.0.
+:file:`src/assets/fonts/Roboto/LICENSE.txt` is retained.
+
+
 Superseded but maintained
 -------------------------
 


### PR DESCRIPTION
Two loose ends from today's work.

## 1. `dependency-review.rst` gains a *Runtime dependencies on external hosts* section

The review covered build-time dependencies but said nothing about what the app reaches for **at runtime** — which turned out to be the more interesting answer. It now records that there are none, why that matters (offline and filtered school networks), what was vendored (Roboto 300/400/500, a 4-ligature Material Icons subset, `corn.png`/`cow.png`), that `resource-summary:third-party:size <= 0` enforces it, and that both fonts are Apache-2.0.

## 2. Fixed a warning on every docs build

`conf.py` set `html_static_path = ["_static"]`, but `docs/_static` doesn't exist — so every build, including the Pages deploy, printed:

```
WARNING: html_static_path entry '_static' does not exist
```

Set to `[]` with a note to re-add it when there's something to put there. This is pre-existing, not from today — I confirmed master warns identically.

`sphinx-build` now reports `build succeeded` with **no warnings at all**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE