### PR TITLE
fix(svg): apply offsets to the moveto, and cover tiffToSvgPaths

### DIFF
--- a/v2/src/app/shared/helpers/svg/tiffToSvgPaths.js
+++ b/v2/src/app/shared/helpers/svg/tiffToSvgPaths.js
@@ -193,7 +193,9 @@ export default function tiffToSvgPaths(data, options = {}) {
         const groups = valueGroups.get(key).set;
         let path = '';
         for (const edge of groups) {
-            path += `M${edge.x * scale},${edge.y * scale}`;
+            // Offsets belong on the moveto too: H/V below add them, so omitting them
+            // here put the subpath start in a different coordinate space from its own edges.
+            path += `M${(edge.x * scale) + offsetX},${(edge.y * scale) + offsetY}`;
             for (let itr = edge.next; itr != edge; itr = itr === null || itr === void 0 ? void 0 : itr.next) {
                 if ((itr === null || itr === void 0 ? void 0 : itr.type) == 'H') {
                     path += `H${((itr === null || itr === void 0 ? void 0 : itr.x) * scale) + offsetX}`;

--- a/v2/src/app/shared/helpers/svg/tiffToSvgPaths.spec.ts
+++ b/v2/src/app/shared/helpers/svg/tiffToSvgPaths.spec.ts
@@ -1,0 +1,87 @@
+import tiffToSvgPaths, { toIndex } from './tiffToSvgPaths';
+
+// tiffToSvgPaths turns a raster of values into one SVG path per distinct value — it is
+// what draws the SVG board (~3,200 <path> elements on /dynamic-game) and had no tests.
+// It is pure, so these are plain input/output checks.
+
+describe('toIndex', () => {
+	it('maps (x, y) to a row-major offset', () => {
+		expect(toIndex(0, 0, 10)).toBe(0);
+		expect(toIndex(2, 3, 10)).toBe(32);
+		expect(toIndex(9, 0, 10)).toBe(9);
+	});
+});
+
+describe('tiffToSvgPaths', () => {
+	it('returns one entry per distinct value in the raster', () => {
+		const paths = tiffToSvgPaths([[1, 2], [1, 2]]);
+
+		expect([...paths.keys()].sort()).toEqual([1, 2]);
+	});
+
+	it('traces a uniform block as a single closed rectangle', () => {
+		const paths = tiffToSvgPaths([[1, 1], [1, 1]]);
+
+		// (0,0)-(2,2) square: move to the corner, three sides, close.
+		expect(paths.get(1)).toBe('M2,2H0V0H2Z');
+	});
+
+	it('separates adjacent values into their own paths', () => {
+		const paths = tiffToSvgPaths([[1, 2], [1, 2]]);
+
+		expect(paths.get(1)).toBe('M1,2H0V0H1Z'); // left column
+		expect(paths.get(2)).toBe('M2,2H1V0H2Z'); // right column
+	});
+
+	it('accepts a flat array when given options.width', () => {
+		const flat = tiffToSvgPaths([1, 1, 1, 1], { width: 2 });
+		const nested = tiffToSvgPaths([[1, 1], [1, 1]]);
+
+		expect(flat.get(1)).toBe(nested.get(1));
+	});
+
+	it('rejects a flat array with no width', () => {
+		expect(() => tiffToSvgPaths([1, 1, 1]))
+			.toThrowError('options.width is required for 1 dimensional array.');
+	});
+
+	it('rejects a width that does not divide the data evenly', () => {
+		expect(() => tiffToSvgPaths([1, 1, 1], { width: 2 }))
+			.toThrowError('Invalid bitmask width. 1.5 = 3 / 2');
+	});
+
+	it('multiplies every coordinate by scale', () => {
+		const paths = tiffToSvgPaths([[1, 1], [1, 1]], { scale: 2 });
+
+		expect(paths.get(1)).toBe('M4,4H0V0H4Z');
+	});
+
+	// Regression: the moveto used to be emitted without the offsets while the H/V
+	// commands added them, so an offset path started in a different coordinate space
+	// from its own edges — "M2,2H10V5H12Z" instead of "M12,7H10V5H12Z".
+	it('applies offsets to the moveto as well as the edges', () => {
+		const paths = tiffToSvgPaths([[1, 1], [1, 1]], { offsetX: 10, offsetY: 5 });
+
+		expect(paths.get(1)).toBe('M12,7H10V5H12Z');
+	});
+
+	it('translates the shape without changing its size', () => {
+		const base = tiffToSvgPaths([[1, 1], [1, 1]]).get(1)!;
+		// Equal offsets on both axes, so every coordinate shifts by the same amount
+		// regardless of whether the path grammar puts an x or a y in that position.
+		const moved = tiffToSvgPaths([[1, 1], [1, 1]], { offsetX: 3, offsetY: 3 }).get(1)!;
+
+		const coords = (p: string) => (p.match(/-?\d+(\.\d+)?/g) ?? []).map(Number);
+		const [b, m] = [coords(base), coords(moved)];
+
+		expect(m.length).toBe(b.length);
+		expect(m).toEqual(b.map(n => n + 3));
+	});
+
+	it('leaves output unchanged for the options the app actually passes', () => {
+		// tiff.service.ts calls it with { width, height: undefined, scale: 1 } and no offsets.
+		const withOpts = tiffToSvgPaths([1, 1, 1, 1], { width: 2, height: undefined, scale: 1 });
+
+		expect(withOpts.get(1)).toBe('M2,2H0V0H2Z');
+	});
+});


### PR DESCRIPTION
`tiffToSvgPaths` draws the SVG board — ~3,200 `<path>` elements on `/dynamic-game` — and had **no tests**. Writing them surfaced a latent bug.

## The bug

The path builder added `offsetX`/`offsetY` to every `H` and `V` command but **not to the opening `M`**, so an offset subpath started in a different coordinate space from its own edges:

```js
tiffToSvgPaths([[1,1],[1,1]], { offsetX: 10, offsetY: 5 })
// was  "M2,2H10V5H12Z"     ← start not offset
// now  "M12,7H10V5H12Z"
```

**Latent, not live.** The only caller is `tiff.service.ts`, which passes `{ width, height: undefined, scale: 1 }` and no offsets — so `offsetX`/`offsetY` are both 0 and the expression is unchanged.

## Proved inert rather than assumed

Rendering `/dynamic-game` from both builds gives byte-identical geometry:

| | paths | hash |
|---|---|---|
| master | 3262 | 4171042874 |
| this branch | 3262 | 4171042874 |

## Tests

11 specs covering `toIndex`, one entry per distinct raster value, tracing a uniform block, separating adjacent values, flat-array input with `options.width`, both error paths, `scale`, the offset regression, uniform translation preserving shape, and the exact option set the app actually passes.

Unit tests: **26 → 37**.

One note on method: my first version of the translation test asserted that consecutive coordinate deltas survive an offset. That failed — correctly. The path grammar alternates x and y (`M x,y H x V y`), so unequal offsets legitimately change those deltas. The test was wrong, not the code; it now uses an equal offset on both axes, where the property genuinely holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE