### PR TITLE
a11y: darken the brand blue to clear WCAG AA (accessibility 93 → 100)

### DIFF
--- a/perf/README.md
+++ b/perf/README.md
@@ -64,7 +64,7 @@ container's nginx), runs Lighthouse 3× under the `desktop` preset, and asserts:
 | `resource-summary:third-party:size` | **0 B** | **0 B** | all runs |
 | `resource-summary:total:size` | 1,150,000 B | 1,067,855 B | all runs |
 | `categories:performance` | ≥ 0.70 | ~0.87 | median |
-| `categories:accessibility` | ≥ 0.90 | 93 | all runs |
+| `categories:accessibility` | **= 1.00** | 100 | all runs |
 | `categories:seo` | ≥ 0.95 | 100 | all runs |
 | `categories:best-practices` | ≥ 0.95 | 100 | all runs |
 | `largest-contentful-paint` | ≤ 2500 ms | ~1,550 ms | median |
@@ -80,11 +80,13 @@ different day. The byte figures are stable to the byte.
 are held tight (~8-10% headroom) and will catch any real regression.
 
 The **accessibility / SEO / best-practices** scores are also byte-stable — identical on
-every run — so they are asserted tightly too. Accessibility sits at 93 rather than 100
-because of one remaining `color-contrast` failure: `$color-primary` (`#1e90ff`) gives
-3.23:1 against white, under the 4.5:1 WCAG AA threshold, both as link text and as a
-button background. Fixing it means darkening the brand colour, which is a design
-decision rather than a maintenance one, so it is deliberately left open.
+every run — so they are asserted tightly too. Accessibility is now **100 with no failing
+audits**, so its assertion is pinned at exactly 1.00: any new component that introduces
+a violation fails CI rather than quietly eroding the score.
+
+Getting there needed a brand change. `$color-primary` was `#1e90ff`, which is 3.24:1
+against white — under the 4.5:1 WCAG AA threshold — as both link text and a
+white-on-blue button background. It is now `#0b5ed7` at **5.84:1**.
 
 **The timing assertions are a smoke alarm, not a gate.** They aggregate on the *median*
 of the three runs, because a single noisy run is otherwise enough to fail the build —

--- a/v2/lighthouserc.json
+++ b/v2/lighthouserc.json
@@ -68,7 +68,7 @@
         "categories:accessibility": [
           "error",
           {
-            "minScore": 0.9
+            "minScore": 1.0
           }
         ],
         "categories:seo": [

--- a/v2/src/styles/variables.scss
+++ b/v2/src/styles/variables.scss
@@ -4,7 +4,10 @@ $color-negative: #DE4949;
 $color-green: #5BCF00;
 $color-black: #000000;
 $color-backdrop: #000000b0;
-$color-primary: #1E90FF;
+// 5.84:1 against white — clears WCAG AA (4.5:1) for both the link text and the white
+// text on .button. The previous #1E90FF was 3.24:1 and was the only remaining
+// accessibility failure, holding the Lighthouse score at 93.
+$color-primary: #0B5ED7;
 
 $border-radius-default: 10px;
 


### PR DESCRIPTION
`$color-primary` was `#1E90FF` — **3.24:1** against white, under the 4.5:1 WCAG AA threshold. It was the last failing accessibility audit, holding Lighthouse at 93. It appears as link text *and* as a white-on-blue button background, so both usages failed.

Now `#0B5ED7` at **5.84:1**.

```
before  #1E90FF  3.24:1  ✗
after   #0B5ED7  5.84:1  ✓
```

Chosen over the closer `#1976D2` (4.60:1) for the extra headroom — future tweaks to the shade won't silently drop back under the line.

## Result

| | before | after |
|---|---|---|
| accessibility | 93 | **100** |
| failing a11y audits | `color-contrast` | **none** |

Also affects the `.button` background, the production-type button border/text, the level indicator border, and the SVG level border — everything already derived from the one variable, so it's a single-line change.

## Gate tightened

`categories:accessibility` moves from `>= 0.90` to **exactly `1.00`**. The score is identical on every run, so there's no flake risk, and pinning it means a new component that introduces a violation fails CI rather than quietly eroding the number.

Verified visually — buttons render a deeper blue with white text clearly legible. **37/37** unit, **7/7** e2e, Lighthouse green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE