### PR TITLE
perf: drop @angular/animations — Material 22 no longer needs it

### DIFF
--- a/perf/README.md
+++ b/perf/README.md
@@ -25,10 +25,10 @@ The production build is **within** its `initial` budget. Measured on Angular 22.
 
 | Entry-point file | Size |
 |---|---|
-| `main-*.js` | 676,273 B |
-| `styles-*.css` | 105,077 B |
+| `main-*.js` | 610,307 B |
+| `styles-*.css` | 105,750 B |
 | `polyfills-*.js` | 35,784 B |
-| **initial total** | **817,134 B** |
+| **initial total** | **751,841 B** |
 
 The budgets in `v2/angular.json` are `maximumWarning: 1mb` / `maximumError: 2mb`, and
 Angular reports them in decimal units (1 mb = 1,000,000 bytes). The build emitted the
@@ -38,9 +38,10 @@ warning on every run until the two non-game routes were made lazy:
 |---|---|
 | (before) | 1,106,956 B |
 | `/configurator` lazy | 976,723 B |
-| `/config` lazy | **817,134 B** |
+| `/config` lazy | 817,134 B |
+| `@angular/animations` dropped | **751,841 B** |
 
-a 289,822 B reduction (−26%). There is now ~183 kB of headroom under the warning.
+a 355,115 B reduction (−32%). There is now ~248 kB of headroom under the warning.
 
 The heavy client op is GeoTIFF decode → SVG.
 
@@ -58,11 +59,11 @@ container's nginx), runs Lighthouse 3× under the `desktop` preset, and asserts:
 |---|---|---|
 | Assertion | Budget | Measured | Aggregation |
 |---|---|---|---|
-| `resource-summary:script:size` | 780,000 B | 714,299 B | all runs |
+| `resource-summary:script:size` | 700,000 B | 648,333 B | all runs |
 | `resource-summary:stylesheet:size` | 120,000 B | 105,159 B | all runs |
 | `resource-summary:font:size` | 150,000 B | 130,139 B | all runs |
 | `resource-summary:third-party:size` | **0 B** | **0 B** | all runs |
-| `resource-summary:total:size` | 1,150,000 B | 1,067,855 B | all runs |
+| `resource-summary:total:size` | 1,080,000 B | 1,001,871 B | all runs |
 | `categories:performance` | ≥ 0.70 | ~0.87 | median |
 | `categories:accessibility` | **= 1.00** | 100 | all runs |
 | `categories:seo` | ≥ 0.95 | 100 | all runs |
@@ -116,9 +117,13 @@ Self-hosting then added the 300/500 Roboto weights and a subset Material Icons f
 third-party went 43,168 → 0, so total transfer is marginally *lower* than before and the
 app makes no external request at all.
 
-The remaining levers, roughly by size: Angular Material is still ~29% of `main`, and
-nine of its ten modules are genuinely used by eagerly-loaded components;
-`@angular/animations` is ~63 kB and only present because `app.module.ts` imports
-`BrowserAnimationsModule` (see the dependency review).
+`@angular/animations` went next: Angular Material 22 no longer needs it, so dropping
+`BrowserAnimationsModule` took another 65,988 B off `main`. Most Material motion is
+CSS-based and survives — the built output goes from 110 `transition`/`animation`/
+`@keyframes` declarations to 102.
+
+The main remaining lever is Angular Material itself, still ~29% of `main`, with nine of
+its ten modules genuinely used by eagerly-loaded components. Going further means
+component-level changes rather than configuration.
 
 The Playwright suite (`v2/e2e`) can also assert time-to-first-board-render.

--- a/v2/lighthouserc.json
+++ b/v2/lighthouserc.json
@@ -16,7 +16,7 @@
         "resource-summary:script:size": [
           "error",
           {
-            "maxNumericValue": 780000
+            "maxNumericValue": 700000
           }
         ],
         "resource-summary:stylesheet:size": [
@@ -34,7 +34,7 @@
         "resource-summary:total:size": [
           "error",
           {
-            "maxNumericValue": 1150000
+            "maxNumericValue": 1080000
           }
         ],
         "categories:performance": [

--- a/v2/package-lock.json
+++ b/v2/package-lock.json
@@ -8,7 +8,6 @@
       "name": "tradeoff-v2",
       "version": "2.0.0",
       "dependencies": {
-        "@angular/animations": "22.0.8",
         "@angular/cdk": "22.0.6",
         "@angular/common": "22.0.8",
         "@angular/compiler": "22.0.8",
@@ -323,22 +322,6 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@angular/animations": {
-      "version": "22.0.8",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-22.0.8.tgz",
-      "integrity": "sha512-hdBlckl5mARzuc5gt2siydIAxeJbBiRneg8V0kazEDH6xNkNp/1siro68ZaHgTY5dCUEOec/eC4zbhB8AlSLhQ==",
-      "deprecated": "@angular/animations is deprecated. Use `animate.enter` and `animate.leave` instead. For more information see: https://v22.angular.dev/guide/animations.",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "22.0.8"
       }
     },
     "node_modules/@angular/build": {

--- a/v2/package.json
+++ b/v2/package.json
@@ -12,7 +12,6 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "22.0.8",
     "@angular/cdk": "22.0.6",
     "@angular/common": "22.0.8",
     "@angular/compiler": "22.0.8",

--- a/v2/src/app/app.module.ts
+++ b/v2/src/app/app.module.ts
@@ -14,7 +14,6 @@ import { ScoreIndicatorComponent } from './score-indicator/score-indicator.compo
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MissingTranslationHandler, MissingTranslationHandlerParams, provideMissingTranslationHandler, provideTranslateService, TranslateDirective, TranslatePipe } from '@ngx-translate/core';
 import { provideTranslateHttpLoader } from '@ngx-translate/http-loader';
 import { HttpClientModule } from '@angular/common/http';
@@ -56,7 +55,6 @@ export class MyMissingTranslationHandler implements MissingTranslationHandler {
 	],
 	imports: [
 		BrowserModule,
-		BrowserAnimationsModule,
 		AppRoutingModule,
 		HttpClientModule,
 		MatIconModule,


### PR DESCRIPTION
`@angular/animations` is deprecated upstream (*"use `animate.enter` and `animate.leave`"*) and was the last deprecated package left. It couldn't be removed while `app.module.ts` imported `BrowserAnimationsModule`, which pulls in `@angular/animations/browser`.

**Angular Material 22 requires neither.** Removing the module import and the package builds clean.

| | before | after |
|---|---|---|
| `main` | 676,295 B | **610,307 B** |
| **initial** | **817,134 B** | **751,841 B** |

−65,293 B. **Cumulative across the session: 1,106,956 → 751,841 B, −32%.**

## What actually changes visually

You accepted transition changes, so here's the precise answer rather than a guess: most Material motion is **CSS-based now and survives**. The built output goes from **110** `transition`/`animation`/`@keyframes` declarations to **102** — eight go with the package, not all of them.

## Components verified working, not just building

| | |
|---|---|
| `mat-select` | opens (4 options render), closes on Escape |
| `mat-stepper` | advances `1 General` → `2 Gameboard` |
| `mat-spinner` | renders on `/dynamic-game` |
| console | no errors on any route |

## Budgets ratcheted

script `780,000 → 700,000 B` (now 648,333), total `1,150,000 → 1,080,000 B` (now 1,001,871).

**37/37** unit, **7/7** e2e, Lighthouse green, build clean with no budget warning.

With this merged, `dependency-review.rst` has no deprecated packages left — only the TypeScript cap and the `@angular/cli` advisories, both of which need upstream releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE