### PR TITLE
ci: run weekly, so a red gate can't hide behind the path filter again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,23 @@
 name: CI
 
-# Build + unit + e2e gate for the v2 app on pull requests and pushes to master.
+# Build + unit + e2e + Lighthouse gate for the v2 app.
+#
+# The path filter keeps PRs fast, but it is also how this gate once stayed red for
+# seven weeks unnoticed: CI never ran on the docs and examples PRs that were merged
+# during that period, so nothing reported the failure. The weekly schedule exists to
+# close that hole — master gets exercised whether or not anyone touches v2/, and
+# breakage that arrives from outside the repo (a runner image change, a deprecated
+# action, a new advisory) surfaces on its own.
 on:
   pull_request:
     paths: ['v2/**', '.github/workflows/ci.yml']
   push:
     branches: [master]
     paths: ['v2/**', '.github/workflows/ci.yml']
+  schedule:
+    # Mondays 06:00 UTC.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
 
 jobs:
   build-test:
@@ -62,3 +73,10 @@ jobs:
           name: lighthouse-reports
           path: v2/.lighthouseci/reports
           retention-days: 7
+
+      # Scheduled runs only: a new advisory against a shipped dependency should surface
+      # on its own, but should not block an unrelated PR that happens to be open when it
+      # lands. Production dependencies are at 0 — this defends that.
+      - name: Production dependency audit
+        if: github.event_name == 'schedule'
+        run: npm audit --omit=dev --audit-level=high

--- a/docs/guides/builder.rst
+++ b/docs/guides/builder.rst
@@ -432,6 +432,15 @@ jsdom. A pull request must pass build + unit + e2e + Lighthouse to be mergeable.
    outright, and the Build step failed on every run for roughly seven weeks before
    it was noticed. Keep the two workflows in step.
 
+   That outage went unnoticed because of the ``paths`` filter: CI never ran on the
+   docs and examples PRs merged during the period, so nothing surfaced the failure.
+   The workflow therefore also runs **weekly (Mondays 06:00 UTC)** and on
+   ``workflow_dispatch``, so master is exercised whether or not anyone touches
+   :file:`v2/`. Scheduled runs additionally execute
+   ``npm audit --omit=dev --audit-level=high``, which is deliberately *not* part of
+   the PR gate — a new advisory should surface on its own without blocking an
+   unrelated PR that happens to be open when it lands.
+
 
 Publishing the container image (ghcr)
 =====================================


### PR DESCRIPTION
CI is path-filtered to `v2/**`. That keeps PRs fast — and it is also exactly how this gate **stayed red for seven weeks unnoticed**: the PRs merged during that period (#30–#34) were all docs and examples, so CI never ran on any of them and nothing reported the failure.

The filter isn't wrong; the missing piece was any trigger that doesn't depend on someone touching `v2/`.

## Changes

- **`schedule: cron: '0 6 * * 1'`** — master gets exercised every Monday regardless of what's been committed. This also catches breakage that arrives from *outside* the repo: a runner image change, a deprecated action, a new advisory.
- **`workflow_dispatch`** — the gate can now be run on demand, which it couldn't before.
- **A production audit on scheduled runs only:**
  ```yaml
  - name: Production dependency audit
    if: github.event_name == 'schedule'
    run: npm audit --omit=dev --audit-level=high
  ```
  Deliberately *not* part of the PR gate. Production dependencies are at 0 and worth defending, but a new CVE landing upstream shouldn't fail an unrelated PR that happens to be open at the time. On a schedule it surfaces on its own.

Placed last so a failing audit doesn't also trigger the `if: failure()` artifact uploads above it.

## Verification

- YAML parses; all four triggers register (`pull_request`, `push`, `schedule`, `workflow_dispatch`).
- Step order confirmed — audit runs after the artifact-upload steps.
- `npm audit --omit=dev --audit-level=high` exits 0 against the current tree, so the first scheduled run won't fail on day one.
- `builder.rst` documents both the outage and the mitigation; `sphinx-build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE