### PR TITLE
test: cover the configurator's form rules and config import

### DIFF
--- a/v2/src/app/configurator/configurator.component.spec.ts
+++ b/v2/src/app/configurator/configurator.component.spec.ts
@@ -1,0 +1,223 @@
+import { ConfiguratorComponent } from './configurator.component';
+// Pulled in so the compiler has the component's NgModule scope; its template uses
+// routerLink, the translate pipe and Material directives that ConfiguratorModule supplies.
+import './configurator.module';
+
+// The configurator builds the reactive form that produces a game configuration, and
+// imports one back from a file. It was the largest untested unit in the app, and a bug
+// in the import path silently loses whatever a teacher had built.
+//
+// The component only touches TranslateService.getLangs(), so it is instantiated plainly
+// (same style as score.service.spec.ts) rather than through TestBed.
+const translateStub = (langs: string[] = ['en', 'de']): any => ({ getLangs: () => langs });
+const newComponent = (langs?: string[]) => new ConfiguratorComponent(translateStub(langs));
+
+describe('ConfiguratorComponent form scaffolding', () => {
+	it('creates one control per registered language for every translatable field', () => {
+		const c = newComponent(['en', 'de', 'nl']);
+
+		for (const field of ['title', 'basicInstructions', 'advancedInstructions']) {
+			expect(Object.keys(c.formGroup.get(field)!.value).sort()).toEqual(['de', 'en', 'nl']);
+		}
+	});
+
+	it('copes with no languages registered', () => {
+		const c = newComponent([]);
+
+		expect(c.formGroup.get('title')!.value).toEqual({});
+	});
+});
+
+describe('ConfiguratorComponent map mode', () => {
+	// mapMode is wired to toggleMapMode through valueChanges, so setting the control is
+	// what a user does and is what these assert against.
+	it('defaults to svg, with the grid-only fields disabled', () => {
+		const c = newComponent();
+
+		expect(c.formGroup.get('mapMode')!.value).toBe('svg');
+		expect(c.formGroup.get('elementSize')!.disabled).toBe(true);
+		expect(c.formGroup.get('gameBoardRows')!.disabled).toBe(true);
+		expect(c.formGroup.get('gameBoardColumns')!.disabled).toBe(true);
+		// svg scores through a backend, so calcUrl and the value range are live
+		expect(c.formGroup.get('calcUrl')!.enabled).toBe(true);
+		expect(c.formGroup.get('minValue')!.enabled).toBe(true);
+		expect(c.formGroup.get('maxValue')!.enabled).toBe(true);
+		expect(c.formGroup.get('infiniteLevels')!.value).toBe(true);
+	});
+
+	it('switching to grid flips which fields are live and resets their values', () => {
+		const c = newComponent();
+
+		c.formGroup.get('mapMode')!.setValue('grid');
+
+		expect(c.formGroup.get('elementSize')!.enabled).toBe(true);
+		expect(c.formGroup.get('gameBoardRows')!.enabled).toBe(true);
+		expect(c.formGroup.get('gameBoardColumns')!.enabled).toBe(true);
+		// grid scores client-side, so there is no backend and no configurable range
+		expect(c.formGroup.get('calcUrl')!.disabled).toBe(true);
+		expect(c.formGroup.get('minSelected')!.disabled).toBe(true);
+		expect(c.formGroup.get('minSelected')!.value).toBe(0);
+		expect(c.formGroup.get('minValue')!.value).toBe(0);
+		expect(c.formGroup.get('maxValue')!.value).toBe(100);
+		expect(c.formGroup.get('infiniteLevels')!.value).toBe(false);
+	});
+
+	it('switching back to svg restores the svg field set', () => {
+		const c = newComponent();
+
+		c.formGroup.get('mapMode')!.setValue('grid');
+		c.formGroup.get('mapMode')!.setValue('svg');
+
+		expect(c.formGroup.get('elementSize')!.disabled).toBe(true);
+		expect(c.formGroup.get('elementSize')!.value).toBe(1);
+		expect(c.formGroup.get('calcUrl')!.enabled).toBe(true);
+		expect(c.formGroup.get('infiniteLevels')!.value).toBe(true);
+	});
+});
+
+describe('ConfiguratorComponent collections', () => {
+	it('numbers maps and production types as it adds them', () => {
+		const c = newComponent();
+
+		c.addMap();
+		c.addMap();
+		c.addProductionType();
+		c.addProductionType();
+
+		expect(c.maps.controls.map(m => m.get('id')!.value)).toEqual([10, 20]);
+		expect(c.productionTypes.controls.map(p => p.get('id')!.value)).toEqual([11, 22]);
+	});
+
+	it('removes a map by index', () => {
+		const c = newComponent();
+		c.addMap();
+		c.addMap();
+
+		c.removeMap(0);
+
+		expect(c.maps.length).toBe(1);
+		expect(c.maps.controls[0].get('id')!.value).toBe(20);
+	});
+
+	it('removes a production type by index', () => {
+		const c = newComponent();
+		c.addProductionType();
+		c.addProductionType();
+
+		c.removeProductionType(0);
+
+		expect(c.productionTypes.length).toBe(1);
+		expect(c.productionTypes.controls[0].get('id')!.value).toBe(22);
+	});
+
+	it('enables customColorId only while a map uses the custom gradient', () => {
+		const c = newComponent();
+		c.addMap();
+		const map = c.maps.controls[0];
+
+		expect(map.get('customColorId')!.disabled).toBe(true);
+
+		map.get('gradient')!.setValue('custom');
+		expect(map.get('customColorId')!.enabled).toBe(true);
+
+		map.get('gradient')!.setValue('blue');
+		expect(map.get('customColorId')!.disabled).toBe(true);
+	});
+
+	it('gives a new colour set one colour, or none when asked for an empty one', () => {
+		const c = newComponent();
+
+		c.addCustomColors();
+		expect(c.getColorsArray(c.customColors.controls[0]).length).toBe(1);
+
+		c.addCustomColors(true);
+		expect(c.getColorsArray(c.customColors.controls[1]).length).toBe(0);
+	});
+
+	it('adds and removes individual colours within a set', () => {
+		const c = newComponent();
+		c.addCustomColors();
+		const set = c.customColors.controls[0];
+
+		c.addColor(set);
+		c.addColor(set);
+		expect(c.getColorsArray(set).length).toBe(3);
+
+		c.removeColor(set, 1);
+		expect(c.getColorsArray(set).length).toBe(2);
+
+		c.removeColorSet(0);
+		expect(c.customColors.length).toBe(0);
+	});
+
+	it('gives every colour set a distinct id', () => {
+		const c = newComponent();
+
+		c.addCustomColors();
+		c.addCustomColors();
+
+		const ids = c.customColors.controls.map(s => s.get('id')!.value);
+		expect(ids[0]).toBeTruthy();
+		expect(ids[0]).not.toBe(ids[1]);
+	});
+});
+
+describe('ConfiguratorComponent import', () => {
+	// Reads a File the way the template does. FileReader.onload is async and there is no
+	// hook to await, so the caller supplies the condition that means the import landed.
+	const importInto = (c: ConfiguratorComponent, value: unknown, done: () => boolean) => {
+		const file = new File([JSON.stringify(value)], 'configuration.json', { type: 'application/json' });
+		c.onFileSelected({ target: { files: [file] } } as unknown as Event);
+		return new Promise<void>((resolve, reject) => {
+			const started = Date.now();
+			const tick = () => {
+				if (done()) return resolve();
+				if (Date.now() - started > 5000) return reject(new Error('import did not complete'));
+				setTimeout(tick, 10);
+			};
+			tick();
+		});
+	};
+
+	it('rebuilds the maps, production types and colour sets an exported file describes', async () => {
+		const source = newComponent();
+		source.formGroup.get('mapMode')!.setValue('grid');
+		source.addMap();
+		source.addMap();
+		source.addProductionType();
+		source.addCustomColors();
+		source.formGroup.get('gameBoardColumns')!.setValue(12);
+		source.formGroup.get('title')!.patchValue({ en: 'My Game' });
+		const exported = source.formGroup.getRawValue();
+
+		// A fresh configurator starts with all three collections empty.
+		const target = newComponent();
+		expect([target.maps.length, target.productionTypes.length, target.customColors.length]).toEqual([0, 0, 0]);
+
+		await importInto(target, exported, () => target.maps.length === 2);
+
+		expect(target.maps.length).toBe(2);
+		expect(target.productionTypes.length).toBe(1);
+		expect(target.customColors.length).toBe(1);
+		expect(target.formGroup.get('gameBoardColumns')!.value).toBe(12);
+		expect(target.formGroup.get('title')!.value.en).toBe('My Game');
+	});
+
+	it('imports a config with no collections without throwing', async () => {
+		const c = newComponent();
+
+		await importInto(c, { mapMode: 'svg', gameBoardColumns: 5 },
+			() => c.formGroup.get('gameBoardColumns')!.value === 5);
+
+		expect(c.formGroup.get('gameBoardColumns')!.value).toBe(5);
+	});
+});
+
+describe('ConfiguratorComponent formatLabel', () => {
+	it('renders slider values as a percentage', () => {
+		const c = newComponent();
+
+		expect(c.formatLabel(0)).toBe('0%');
+		expect(c.formatLabel(50)).toBe('50%');
+	});
+});


### PR DESCRIPTION
`configurator.component.ts` was the **largest untested unit** in the app at 222 lines. It builds the form that produces a game configuration and imports one back from a file — and a bug in the import path silently loses whatever a teacher had built.

## 15 specs

- **Languages** — one control per registered language on every translatable field, including the zero-languages case.
- **`toggleMapMode` both ways** — `svg` disables `elementSize`/`gameBoardRows`/`gameBoardColumns` and enables `calcUrl` and the value range; `grid` does the inverse and resets `minSelected`/`minValue`/`maxValue`/`infiniteLevels`. Driven by *setting the `mapMode` control*, which is what a user does — the toggle runs through `valueChanges`.
- **Collections** — id numbering for maps (10, 20) and production types (11, 22), removal by index, and that `customColorId` is live only while a map uses the `custom` gradient.
- **Colour sets** — default one colour, `addEmpty` for none, add/remove of individual colours, distinct uuid per set.
- **Export → import round trip** — a config built in one component rebuilds its maps, production types and colour sets in a fresh one, and scalars survive.
- A config with **no collections** imports without throwing.

## Mutation-tested

| Mutation | Result |
|---|---|
| import stops rebuilding maps | **1 test fails** |
| `toggleMapMode` stops enabling `calcUrl` | **2 tests fail** |
| restored | 52/52 pass |

## Two notes on method

The spec imports `configurator.module` so the compiler has the component's NgModule scope — the template uses `routerLink`, the `translate` pipe and Material directives, and without it the test build fails on `NG8004: No pipe found with name 'translate'`.

`FileReader.onload` has no awaitable hook, so the import helper takes a predicate for *"the import landed"* rather than assuming a fixed delay. My first version resolved early and correctly failed the no-collections case — the test was wrong, and fixing it properly was the point.

Unit tests: **37 → 52**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE