### PR TITLE
fix(k8s): pin GeoServer, surface the ingress class, and gate the manifests

### DIFF
--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -1,0 +1,52 @@
+name: Validate manifests
+
+# deploy/k8s had one commit and no gate: it was added, never re-run, and drifted
+# (GeoServer stayed on a rolling 2.24.x tag while both compose stacks moved to 2.28.4).
+# This renders the Kustomize base and schema-checks the result, so drift and typos fail
+# a PR instead of waiting for someone to apply them to a real cluster.
+on:
+  pull_request:
+    paths: ['deploy/**', '.github/workflows/manifests.yml']
+  push:
+    branches: [master]
+    paths: ['deploy/**', '.github/workflows/manifests.yml']
+  schedule:
+    # Mondays 06:20 UTC, offset from the CI job so both do not start at once.
+    - cron: '20 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Render the Kustomize base
+        run: |
+          curl -sSfL -o kustomize.tar.gz \
+            https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.7.1/kustomize_v5.7.1_linux_amd64.tar.gz
+          tar -xzf kustomize.tar.gz
+          ./kustomize build deploy/k8s/base > rendered.yaml
+          echo "rendered $(grep -c '^kind:' rendered.yaml) resources"
+
+      - name: Schema-check against the Kubernetes API
+        run: |
+          curl -sSfL -o kubeconform.tar.gz \
+            https://github.com/yannh/kubeconform/releases/download/v0.7.0/kubeconform-linux-amd64.tar.gz
+          tar -xzf kubeconform.tar.gz
+          ./kubeconform -strict -summary -kubernetes-version 1.31.0 rendered.yaml
+
+      - name: Check the GeoServer pin matches the compose stacks
+        run: |
+          # One version of GeoServer across k8s and both compose files, and never a
+          # rolling tag — the drift this workflow exists to catch.
+          pins=$(grep -rhoE 'docker\.osgeo\.org/geoserver:[0-9.x]+' \
+                   deploy/k8s/base v2/docker-compose.dynamic.yml \
+                   examples/esgame-dynamic/docker-compose.yml | sort -u)
+          echo "$pins"
+          if [ "$(echo "$pins" | wc -l)" -ne 1 ]; then
+            echo "::error::GeoServer pins disagree across k8s and the compose stacks"; exit 1
+          fi
+          if echo "$pins" | grep -q 'x$'; then
+            echo "::error::GeoServer is on a rolling tag; pin a specific patch"; exit 1
+          fi

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -27,6 +27,9 @@ deploy/k8s/base/          # this Kustomize base (angular + calculation + geoserv
    - `esgame-angular` → your published frontend tag (defaults to `ghcr.io/mlacayoemery/esgame:master`).
    - `esgame-calculation` → build [`../../tools/R`](../../tools/R) and push it, then point here (or override in an overlay).
 2. **Hosts** — replace the `CHANGE-ME-*.example.com` hosts in the three `*-ingress.yaml` files.
+   **Ingress class** — check `kubectl get ingressclass`. If none is marked default, uncomment
+   `ingressClassName` in all three files and set your controller's class. An Ingress with neither
+   applies without error and is then silently ignored: nothing routes, and nothing says why.
 3. **Backend URL** — in `base/configmap.yaml` set `CALC_URL` to the **public** calculation ingress
    host from step 2 (the browser posts there client-side, so it must be externally reachable, not the
    in-cluster service name). Set `CALC_URL: ""` for a client-side-only (grid) deployment.

--- a/deploy/k8s/base/angular-ingress.yaml
+++ b/deploy/k8s/base/angular-ingress.yaml
@@ -8,6 +8,11 @@ metadata:
     kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
 spec:
+  # An Ingress with no ingressClassName is only picked up if the cluster has an
+  # IngressClass marked as default. Without one, this Ingress is silently ignored —
+  # it applies cleanly and nothing ever routes. Uncomment and set your controller's
+  # class if `kubectl get ingressclass` shows no default.
+  # ingressClassName: nginx
   rules:
     - host: CHANGE-ME-esgame.example.com
       http:

--- a/deploy/k8s/base/calculation-ingress.yaml
+++ b/deploy/k8s/base/calculation-ingress.yaml
@@ -10,6 +10,11 @@ metadata:
     # The browser posts here cross-origin, so CORS must allow the frontend origin.
     nginx.ingress.kubernetes.io/enable-cors: "true"
 spec:
+  # An Ingress with no ingressClassName is only picked up if the cluster has an
+  # IngressClass marked as default. Without one, this Ingress is silently ignored —
+  # it applies cleanly and nothing ever routes. Uncomment and set your controller's
+  # class if `kubectl get ingressclass` shows no default.
+  # ingressClassName: nginx
   rules:
     # Must match CALC_URL in configmap.yaml (this is the public URL the browser posts to).
     - host: CHANGE-ME-esgame-calculation.example.com

--- a/deploy/k8s/base/geoserver-deployment.yaml
+++ b/deploy/k8s/base/geoserver-deployment.yaml
@@ -17,7 +17,9 @@ spec:
       containers:
         - name: esgame-geoserver
           # Pin to a specific patch (e.g. 2.24.4) for reproducible deploys instead of rolling 2.24.x.
-          image: docker.osgeo.org/geoserver:2.24.x
+          # Pinned to a specific patch, matching v2/docker-compose.dynamic.yml and
+          # examples/esgame-dynamic/docker-compose.yml. 2.24.x was a rolling tag.
+          image: docker.osgeo.org/geoserver:2.28.4
           imagePullPolicy: Always
           env:
             - name: CORS_ENABLED

--- a/deploy/k8s/base/geoserver-ingress.yaml
+++ b/deploy/k8s/base/geoserver-ingress.yaml
@@ -10,6 +10,11 @@ metadata:
     nginx.ingress.kubernetes.io/app-root: /geoserver
     nginx.ingress.kubernetes.io/enable-cors: "true"
 spec:
+  # An Ingress with no ingressClassName is only picked up if the cluster has an
+  # IngressClass marked as default. Without one, this Ingress is silently ignored —
+  # it applies cleanly and nothing ever routes. Uncomment and set your controller's
+  # class if `kubectl get ingressclass` shows no default.
+  # ingressClassName: nginx
   rules:
     - host: CHANGE-ME-esgame-geoserver.example.com
       http:


### PR DESCRIPTION
`deploy/k8s` had **one commit** — added and never re-run. Validating it turned up two things, and confirmed the rest is sound.

## 1. GeoServer was on a stale rolling tag

`docker.osgeo.org/geoserver:2.24.x` while both compose stacks moved to **2.28.4**. That drift is mine: #41 pinned `v2/docker-compose.dynamic.yml` and missed this file. Now 2.28.4 everywhere.

## 2. No Ingress sets `ingressClassName`

An Ingress with neither that field nor a cluster default `IngressClass` **applies without error and is then ignored** — nothing routes, and nothing says why. Exactly the silent-success failure mode this repo keeps producing.

Added the field commented out at the point of use with the reason, plus a README step to check `kubectl get ingressclass` before applying. Hardcoding `nginx` would have been a guess about someone else's cluster.

## 3. A gate, so it can't rot again

New `.github/workflows/manifests.yml` renders the Kustomize base, schema-checks it with `kubeconform -strict`, and asserts the GeoServer pin is **identical across k8s and both compose files** and **not a rolling tag**. Runs on `deploy/**`, weekly, and on demand — offset to 06:20 so it doesn't start alongside the CI job.

## Verified, not assumed

| Check | Result |
|---|---|
| `kustomize build deploy/k8s/base` | 10 resources, exit 0 |
| `kubeconform -strict` (k8s 1.31) | **10 valid, 0 invalid, 0 errors** |
| `configMapKeyRef` keys | `GEOSERVER` ← `GEOSERVER_URL`, `CALC_URL` ← `CALC_URL` both resolve — and `calculator.r:24` reads `Sys.getenv("GEOSERVER")`, so the env name matches the code |
| Service/Deployment selectors | `app` labels match on all three |
| Ingress backends and ports | resolve to the right services |
| New pin check, both directions | passes as committed; **fails** when k8s drifts to 2.27.5, and **fails again** if everything moves to a rolling `2.28.x` |

## Not a defect

`ghcr.io/mlacayoemery/esgame-calculation` is published by no workflow — but both the README and `kustomization.yaml` say to build it from `tools/R` or override it in an overlay. Flagging it only so the next reader doesn't re-investigate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE