### PR TITLE
docs: the documented compose commands were missing a prerequisite build

### DIFF
--- a/docs/guides/deployer.rst
+++ b/docs/guides/deployer.rst
@@ -321,6 +321,7 @@ base image; it defaults to ``ghcr.io/mlacayoemery/esgame:master``):
 
 .. code-block:: console
 
+   $ docker build -t local/esgame-core:latest v2
    $ ESGAME_IMAGE=local/esgame-core:latest \
        docker compose -p esgame-dynamic-example up -d --build
 

--- a/docs/reference/containers.rst
+++ b/docs/reference/containers.rst
@@ -239,6 +239,7 @@ serves the consequence rasters. Bring it up with:
 
 .. code-block:: console
 
+   $ docker build -t local/esgame-core:latest v2
    $ ESGAME_IMAGE=local/esgame-core:latest \
        docker compose -p esgame-dynamic-example up -d --build
 

--- a/examples/esgame-dynamic/README.md
+++ b/examples/esgame-dynamic/README.md
@@ -76,9 +76,12 @@ as a GeoTIFF at `…/collections/<name>/coverage?f=GTiff` — the drop-in equiva
 ```sh
 make esgame-dynamic-pygeoapi-up      # http://localhost:81/  (calculator :8000, pygeoapi :5005)
 make esgame-dynamic-pygeoapi-down
-# or directly:
+# or directly (ESGAME_IMAGE must already exist locally — the make target builds it):
+docker build -t local/esgame-core:latest v2
 ESGAME_IMAGE=local/esgame-core:latest \
   docker compose -p esgame-dynamic-pygeoapi -f docker-compose.pygeoapi.yml up -d --build
+
+# or omit ESGAME_IMAGE to build against the published ghcr.io/mlacayoemery/esgame:master
 ```
 
 **It is a true drop-in:** the frontend bundle and the calculator *image* are identical to the

--- a/examples/esgame-dynamic/docker-compose.pygeoapi.yml
+++ b/examples/esgame-dynamic/docker-compose.pygeoapi.yml
@@ -9,8 +9,14 @@
 # the calculator's RASTER_URL_TEMPLATE and the raster backend differ. Run EITHER this or the GeoServer
 # compose (they share the 81/8000 ports) — not both at once.
 #
+# `make esgame-dynamic-pygeoapi-up` from the repo root does the whole thing. Directly:
+#
+#   docker build -t local/esgame-core:latest v2          # ESGAME_IMAGE must already exist
 #   ESGAME_IMAGE=local/esgame-core:latest \
 #     docker compose -p esgame-dynamic-pygeoapi -f docker-compose.pygeoapi.yml up -d --build
+#
+# Or omit ESGAME_IMAGE entirely to build against the published
+# ghcr.io/mlacayoemery/esgame:master instead of a local build.
 #
 # READ-ONLY caveat: pygeoapi publishes the rasters from a static config; there is no run-time
 # publish/REST API. Fine here because the example rasters never change. A deployment that must add or

--- a/examples/esgame-dynamic/docker-compose.yml
+++ b/examples/esgame-dynamic/docker-compose.yml
@@ -4,7 +4,12 @@
 #   geoserver        - serves the consequence rasters; persistent data dir, reloaded on every boot
 #   geoserver-seed   - one-shot job that registers the rasters as external coverages (runs once)
 #
+# `make esgame-dynamic-example-up` from the repo root does the whole thing. Directly:
+#
+#   docker build -t local/esgame-core:latest v2          # ESGAME_IMAGE must already exist
 #   ESGAME_IMAGE=local/esgame-core:latest docker compose -p esgame-dynamic-example up -d --build
+#
+# Or omit ESGAME_IMAGE to build against the published ghcr.io/mlacayoemery/esgame:master.
 name: esgame-dynamic-example
 
 volumes:


### PR DESCRIPTION
Running the pygeoapi example **exactly as documented** fails:

```
$ ESGAME_IMAGE=local/esgame-core:latest \
    docker compose -p esgame-dynamic-pygeoapi -f docker-compose.pygeoapi.yml up -d --build
target frontend: failed to solve: local/esgame-core:latest:
  pull access denied, repository does not exist
```

`local/esgame-core:latest` isn't published anywhere — it's built from `v2/` by the Makefile. `make esgame-dynamic-pygeoapi-up` works because its build target runs `docker build -t $(ESGAME_BASE) v2` first. The **direct** command omits that step, so it tries to pull a local-only tag.

## Five call sites said the same thing

| File | |
|---|---|
| `examples/esgame-dynamic/docker-compose.pygeoapi.yml` | header |
| `examples/esgame-dynamic/docker-compose.yml` | header — **same bug in the GeoServer variant** |
| `examples/esgame-dynamic/README.md` | pygeoapi section |
| `docs/reference/containers.rst` | |
| `docs/guides/deployer.rst` | |

`docs/guides/builder.rst` already had it right, which is where the corrected form comes from. Each site now shows the build step, points at the make target that handles it, and notes that **omitting `ESGAME_IMAGE` entirely** builds against the published ghcr image instead.

## The stack itself is fine

Verified end to end **twice** — once via the make target, then again via the corrected direct command *after deleting the base image*, to prove the missing prerequisite was the whole problem:

| | |
|---|---|
| pygeoapi | root 200, **8 collections** advertised |
| coverages | **8/8** return a GeoTIFF from `/collections/<name>/coverage?f=GTiff` |
| calculator | `{"status":"ok"}`, 8 results, **every url a pygeoapi coverage, none mentioning WCS** — so the documented *"true drop-in"* claim holds |
| frontend | 200, `config.json` `calcUrl`/`defaultMode` correct |
| browser | 3 boards, **2,436 svg paths**, **zero external origins**, no console errors |

`sphinx-build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE