### PR TITLE
fix(tools/R): install geosapi at build time, not on every container start

### DIFF
--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -1,4 +1,4 @@
-name: Validate manifests
+name: Validate deploy artifacts
 
 # deploy/k8s had one commit and no gate: it was added, never re-run, and drifted
 # (GeoServer stayed on a rolling 2.24.x tag while both compose stacks moved to 2.28.4).
@@ -6,10 +6,10 @@ name: Validate manifests
 # a PR instead of waiting for someone to apply them to a real cluster.
 on:
   pull_request:
-    paths: ['deploy/**', '.github/workflows/manifests.yml']
+    paths: ['deploy/**', 'tools/R/**', '.github/workflows/manifests.yml']
   push:
     branches: [master]
-    paths: ['deploy/**', '.github/workflows/manifests.yml']
+    paths: ['deploy/**', 'tools/R/**', '.github/workflows/manifests.yml']
   schedule:
     # Mondays 06:20 UTC, offset from the CI job so both do not start at once.
     - cron: '20 6 * * 1'
@@ -50,3 +50,23 @@ jobs:
           if echo "$pins" | grep -q 'x$'; then
             echo "::error::GeoServer is on a rolling tag; pin a specific patch"; exit 1
           fi
+
+      - name: No run-time package installation in the R calculator
+        run: |
+          # calculator.r is what plumber executes on boot. It used to call
+          # remotes::install_github('eblondel/geosapi') there, which cost ~31s per start,
+          # pinned nothing (@HEAD), and made the container unable to start at all without
+          # GitHub reachable — it died on `library(remotes)`. Dependencies belong in the
+          # Dockerfile, which is where geosapi is installed now.
+          if grep -nE '^[^#]*(install_github|install\.packages|install_version|install_cran)' tools/R/calculator.r; then
+            echo "::error file=tools/R/calculator.r::installs a package at run time; add it to tools/R/Dockerfile instead"
+            exit 1
+          fi
+          echo "calculator.r installs nothing at run time"
+
+          # And the Dockerfile must actually provide geosapi, which calculator.r library()-s.
+          if ! grep -qE "^[^#]*install\.packages\('geosapi'\)" tools/R/Dockerfile; then
+            echo "::error file=tools/R/Dockerfile::calculator.r needs geosapi; install it here"
+            exit 1
+          fi
+          echo "Dockerfile installs geosapi at build time"

--- a/tools/R/Dockerfile
+++ b/tools/R/Dockerfile
@@ -15,7 +15,10 @@ RUN R -e "install.packages('ggpubr')"
 RUN R -e "install.packages('tidyverse')"
 RUN R -e "install.packages('tidyr')"
 RUN R -e "install.packages('jsonlite')"
-#RUN R -e "install.packages('geosapi')"
+# geosapi is on CRAN (0.8-1). It used to be installed at container START via
+# remotes::install_github in calculator.r, which cost ~31s per boot, needed GitHub
+# reachable at run time, and pulled whatever @HEAD happened to be.
+RUN R -e "install.packages('geosapi')"
 RUN R -e "install.packages('logger')"
 RUN R -e "install.packages('devtools')"
 

--- a/tools/R/calculator.r
+++ b/tools/R/calculator.r
@@ -1,5 +1,6 @@
-library(remotes)
-remotes::install_github('eblondel/geosapi')	
+# geosapi is installed at image build time (see Dockerfile). It was installed here,
+# from GitHub @HEAD, on every container start — which made startup depend on GitHub
+# being reachable and made two deployments of the same image differ.
 
 #NEW CODE --> ALLOW CORS REQUESTS
 #* @filter cors


### PR DESCRIPTION
**The R calculator — the backend `places` deploys — could not start without internet access to GitHub.**

`calculator.r` lines 1–2 were:

```r
library(remotes)
remotes::install_github('eblondel/geosapi')
```

So plumber's own boot script installed a dependency from GitHub `@HEAD` every time a container started. With no network, the container dies before serving anything:

```
Error on line #1: 'library(remotes)' - Failed to install 'unknown package' from GitHub:
  Couldn't resolve host name [api.github.com]
```

`geosapi` is **on CRAN** (0.8-1, 2026-07-22) and the Dockerfile already had the install line — *commented out*. Restored it there, removed the run-time install.

Same class of problem as the Google Fonts dependency fixed in #56: a container described as self-contained that needed the internet to do its job, on exactly the filtered networks this game is played on.

## Measured, both images, same host

| | before | after |
|---|---|---|
| cold start | **31s** | **7s** |
| start with `--network none` | **fails** — cannot resolve `api.github.com` | **plumber up in 9s**, zero GitHub contact |
| geosapi in image | absent | 0.8.1, `library()` ok |
| reproducible | no — `@HEAD` | yes — whatever the image baked |

## Endpoint still works

`/openapi.json` declares `/esgame`; `POST /esgame` reaches the handler (500 on an empty body, **not** 404); and `GEOSERVER` is read via `Sys.getenv` at `calculator.r:24`, matching what the k8s manifest injects (verified in #73).

## Guarded

`.github/workflows/manifests.yml` is now *"Validate deploy artifacts"* and also watches `tools/R/**`. It fails if `calculator.r` installs anything at run time, or if the Dockerfile stops providing `geosapi`.

Checked both directions: passes as committed, **fails** when the `install_github` line is put back, and **fails** when the Dockerfile line is re-commented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE