### PR TITLE
docs(k8s): overlays must key images on the rewritten name, not the logical one

### DIFF
--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -50,7 +50,27 @@ reload). See [../../docs/ARCHITECTURE.md](../../docs/ARCHITECTURE.md).
 Create an overlay `kustomization.yaml` with `resources: [../esgame/deploy/k8s/base]` (or a vendored
 copy) and layer on only what differs — no forked manifests:
 
-- **Images** — one `images:` entry to point `esgame-angular`/`esgame-calculation` at your registry.
+- **Images** — one `images:` entry per image. **Match the name this base rewrites them *to*, not the
+  logical name.** Kustomize applies the base's transformers first, so by the time an overlay runs,
+  `esgame-angular` no longer appears anywhere and an entry keyed on it matches nothing — silently,
+  with no error, leaving the upstream image deployed:
+
+  ```yaml
+  images:
+    # ✗ matches nothing — the base already rewrote esgame-angular
+    - name: esgame-angular
+      newName: my-registry/places-frontend
+    # ✓ matches what the base produced
+    - name: ghcr.io/mlacayoemery/esgame
+      newName: my-registry/places-frontend
+      newTag: latest
+    - name: ghcr.io/mlacayoemery/esgame-calculation
+      newName: my-registry/places-calculation
+      newTag: latest
+  ```
+
+  Check with `kustomize build <overlay> | grep image:` before deploying — a wrong key here produces
+  a clean render of the wrong application.
 - **Hosts / TLS** — patch the ingress hosts.
 - **Config/theming** — a ConfigMap with the deployment's `data.json` (setting `visualOptions` /
   `gradientOverrides`) mounted onto the frontend's `assets/`.

--- a/deploy/k8s/base/kustomization.yaml
+++ b/deploy/k8s/base/kustomization.yaml
@@ -22,8 +22,12 @@ resources:
   - geoserver-service.yaml
   - geoserver-ingress.yaml
 
-# Logical image names are referenced by the deployments and rewritten here, so an overlay can
-# repoint them with one `images:` entry instead of patching each manifest.
+# The deployments reference logical names (esgame-angular, esgame-calculation); the entries below
+# rewrite them so this base is deployable as-is.
+#
+# NOTE FOR OVERLAYS: because these run first, an overlay's `images:` entry must key on the name
+# produced here (e.g. ghcr.io/mlacayoemery/esgame), NOT on the logical name — which no longer
+# exists by then. Keying on the logical name matches nothing and does not warn. See ../README.md.
 images:
   - name: esgame-angular
     newName: ghcr.io/mlacayoemery/esgame

--- a/docs/guides/deployer.rst
+++ b/docs/guides/deployer.rst
@@ -503,20 +503,34 @@ The base (:file:`esgame/deploy/k8s/base`) ships three components — the
 dynamic mode only) and ``esgame-geoserver`` — plus an ``esgame-config``
 ConfigMap, services and ingresses. The overlay does four things:
 
-#. **Repoints images** to the places registry via a single ``images:`` block
-   (the base references *logical* image names ``esgame-angular`` /
-   ``esgame-calculation`` so they can be rewritten without patching each
-   manifest):
+#. **Repoints images** to the places registry via a single ``images:`` block:
 
    .. code-block:: yaml
 
       images:
-        - name: esgame-angular
+        - name: ghcr.io/mlacayoemery/esgame
           newName: CHANGE-ME-registry/places-frontend     # built from ../../frontend
           newTag: latest
-        - name: esgame-calculation
+        - name: ghcr.io/mlacayoemery/esgame-calculation
           newName: CHANGE-ME-registry/places-calculation   # built from ../../calculation
           newTag: latest
+
+   .. warning::
+
+      Key these on the image the **base already rewrote them to**, as above — not on
+      the base's logical names (``esgame-angular`` / ``esgame-calculation``). Kustomize
+      applies the base's own ``images:`` transformer first, so by the time the overlay
+      runs those logical names no longer appear and an entry keyed on them matches
+      nothing. It does not warn: the overlay renders cleanly and deploys the **upstream
+      esgame images** instead of the places ones.
+
+      Verified against esgame's base — keying on ``esgame-angular`` leaves
+      ``ghcr.io/mlacayoemery/esgame:master`` in the output, while keying on
+      ``ghcr.io/mlacayoemery/esgame`` produces the intended image. Always confirm with:
+
+      .. code-block:: console
+
+         $ kustomize build deploy/k8s | grep 'image:'
 
 #. **Overrides the config** (``patch-config.yaml``) — the places backend
    ``CALC_URL`` and ``GEOSERVER_URL`` in the ConfigMap. ``CALC_URL`` must be the


### PR DESCRIPTION
Rendering the **real places overlay** (`../places`, `feature/esgame-overlay`) against this base shows its image overrides silently doing nothing. It declares:

```yaml
images:
  - name: esgame-angular
    newName: CHANGE-ME-registry/places-frontend
```

…and renders `ghcr.io/mlacayoemery/esgame:master` — the **upstream** image, not the places one.

## Why

Kustomize applies the base's transformers *before* the overlay's. This base's own `images:` block rewrites `esgame-angular` → `ghcr.io/mlacayoemery/esgame`, so by the time an overlay runs the logical name is gone and an entry keyed on it matches nothing. **No warning** — the overlay renders cleanly and deploys the wrong application.

Verified with two minimal overlays over this base:

```
images: [{name: esgame-angular}]              → ghcr.io/mlacayoemery/esgame:master
images: [{name: ghcr.io/mlacayoemery/esgame}] → my-registry/places-frontend:v1
```

## Three places said to key on the logical name — all wrong

| | |
|---|---|
| `deploy/k8s/README.md` | *"one `images:` entry to point `esgame-angular`/… at your registry"* |
| `deploy/k8s/base/kustomization.yaml` | the comment above the `images:` block |
| `docs/guides/deployer.rst` | reproduced the places overlay's non-working block **as the example** |

All now show the working form, say why the obvious one fails, and tell readers to confirm with `kustomize build <overlay> | grep image:` — because a wrong key here produces a clean render of the wrong thing.

**Not changed:** the base still rewrites the images, so it stays deployable standalone as its README quickstart assumes.

## Also verified while in there

The places overlay renders **11 resources**, all valid under `kubeconform -strict` against k8s 1.31, its three ingress-host patches apply, and the GeoServer pin from #73 reaches it (**2.28.4**, no `2.24.x`) — so consuming the base by remote ref works.

## Left for you

**The overlay in `../places` still has the broken `images:` block.** That's a separate repo on a feature branch, so I haven't touched it — the two-line fix is to key both entries on `ghcr.io/mlacayoemery/esgame` and `ghcr.io/mlacayoemery/esgame-calculation`. Say the word and I'll do it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE