### PR TITLE
docs: verify the published image, and correct the bundle figure

### DIFF
--- a/docs/dependency-review.rst
+++ b/docs/dependency-review.rst
@@ -150,8 +150,14 @@ All of it is vendored now:
   :file:`src/assets/images`.
 
 :file:`v2/lighthouserc.json` asserts ``resource-summary:third-party:size <= 0``, so any
-new external asset fails CI. Verified by loading the container with every non-localhost
-origin blocked: no request is even attempted, and icons, fonts and images all render.
+new external asset fails CI.
+
+Verified against the **published** image, not just a local build: pulling
+``ghcr.io/mlacayoemery/esgame:master`` and loading it with every non-localhost origin
+blocked renders the full 2,436-field board, with Roboto 400/500 and the icon font loaded,
+both production-type images present, ``mat-icon`` measuring 18x18, no console errors, and
+**no external request even attempted**. The published bundle is byte-identical to a local
+production build (same filenames, same md5 sums).
 
 **Vendored font licensing:** Roboto and Material Icons are both Apache-2.0.
 :file:`src/assets/fonts/Roboto/LICENSE.txt` is retained.

--- a/perf/README.md
+++ b/perf/README.md
@@ -28,7 +28,7 @@ The production build is **within** its `initial` budget. Measured on Angular 22.
 | `main-*.js` | 610,307 B |
 | `styles-*.css` | 105,750 B |
 | `polyfills-*.js` | 35,784 B |
-| **initial total** | **751,841 B** |
+| **initial total** | **751,842 B** |
 
 The budgets in `v2/angular.json` are `maximumWarning: 1mb` / `maximumError: 2mb`, and
 Angular reports them in decimal units (1 mb = 1,000,000 bytes). The build emitted the
@@ -39,9 +39,9 @@ warning on every run until the two non-game routes were made lazy:
 | (before) | 1,106,956 B |
 | `/configurator` lazy | 976,723 B |
 | `/config` lazy | 817,134 B |
-| `@angular/animations` dropped | **751,841 B** |
+| `@angular/animations` dropped | **751,842 B** |
 
-a 355,115 B reduction (−32%). There is now ~248 kB of headroom under the warning.
+a 355,114 B reduction (−32%). There is now ~248 kB of headroom under the warning.
 
 The heavy client op is GeoTIFF decode → SVG.
 


### PR DESCRIPTION
`image.yml` has been green all session, but nothing had ever run **the artifact it publishes** — only local builds. Pulled `ghcr.io/mlacayoemery/esgame:master` and exercised it.

## It is byte-identical to a local production build

Same filenames, same md5 sums for `main-*.js`, `styles-*.css` and `polyfills-*.js`. So the shipped image really is what the source produces — worth knowing rather than assuming.

## It carries every v2 change from this session

| | |
|---|---|
| `robots.txt` (#55) | present |
| Roboto woff2 / ttf (#52, #56) | **3 / 0** |
| MaterialIcons woff2 (#56) | present |
| `corn.png`, `cow.png` local (#56) | 2/2 |
| Google font links in `index.html` | **0** |
| meta description (#55) | present |
| brand blue `#0b5ed7` (#62) | present |
| lazy chunks (#53, #54) | 13 |

## And it works on a filtered network

Loaded with **every** non-localhost origin blocked: **2,436 fields render**, Roboto 400/500 and the icon font load, both production-type images resolve, `mat-icon` measures 18×18, no console errors, and **no external request is even attempted**.

That claim previously rested on a local build; `docs/dependency-review.rst` now records it against the published image.

## The `:master` tag is one commit behind — correctly

Published `:master` is at `c5ee2ca`. #73–#76 touched `deploy/`, `docs/`, `tools/R` and workflows — none in `image.yml`'s `v2/**` path filter, so no rebuild fired. Verified, not drift.

## One correction

`perf/README.md` said the initial bundle is **751,841 B**. It's **751,842 B** — a fresh local build and the published image both agree (610,308 main + 105,750 styles + 35,784 polyfills). One byte, but that file exists to be accurate about measurements, and **I've quoted 751,841 in several PR descriptions this session**; 751,842 is the correct figure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE