### PR TITLE
fix(k8s): the placeholder ingress hosts made `kubectl apply` fail outright

### DIFF
--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -70,3 +70,23 @@ jobs:
             exit 1
           fi
           echo "Dockerfile installs geosapi at build time"
+
+      - name: Ingress hosts must be valid RFC 1123 subdomains
+        run: |
+          # kubeconform does not check this: a host is just a string in the schema, so
+          # CHANGE-ME-esgame.example.com passed strict validation and was then rejected by
+          # the API server ("must be a lowercase RFC 1123 subdomain"), making
+          # `kubectl apply -k deploy/k8s/base` fail on all three ingresses. Uppercase in a
+          # placeholder is enough to break it, and the error talks about regexes rather
+          # than about setting your host.
+          hosts=$(grep -oP '^\s+- host:\s*\K\S+' rendered.yaml)
+          echo "$hosts"
+          bad=0
+          for h in $hosts; do
+            if ! printf '%s' "$h" | grep -qE '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'; then
+              echo "::error::ingress host '$h' is not a valid RFC 1123 subdomain; the API server will reject it"
+              bad=1
+            fi
+          done
+          [ "$bad" = 0 ] && echo "all ingress hosts are RFC 1123 valid"
+          exit $bad

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -26,7 +26,10 @@ deploy/k8s/base/          # this Kustomize base (angular + calculation + geoserv
 1. **Images** — in `base/kustomization.yaml` set the `images:` entries:
    - `esgame-angular` → your published frontend tag (defaults to `ghcr.io/mlacayoemery/esgame:master`).
    - `esgame-calculation` → build [`../../tools/R`](../../tools/R) and push it, then point here (or override in an overlay).
-2. **Hosts** — replace the `CHANGE-ME-*.example.com` hosts in the three `*-ingress.yaml` files.
+2. **Hosts** — replace the `change-me-*.example.com` hosts in the three `*-ingress.yaml` files,
+   and the matching `CALC_URL` in `base/configmap.yaml`. Keep them lowercase: an Ingress host
+   must be a valid RFC 1123 subdomain, so a single uppercase letter makes the API server
+   reject the whole apply — with a message about regexes rather than about the host.
    **Ingress class** — check `kubectl get ingressclass`. If none is marked default, uncomment
    `ingressClassName` in all three files and set your controller's class. An Ingress with neither
    applies without error and is then silently ignored: nothing routes, and nothing says why.

--- a/deploy/k8s/base/angular-ingress.yaml
+++ b/deploy/k8s/base/angular-ingress.yaml
@@ -14,7 +14,7 @@ spec:
   # class if `kubectl get ingressclass` shows no default.
   # ingressClassName: nginx
   rules:
-    - host: CHANGE-ME-esgame.example.com
+    - host: change-me-esgame.example.com
       http:
         paths:
           - path: /

--- a/deploy/k8s/base/calculation-ingress.yaml
+++ b/deploy/k8s/base/calculation-ingress.yaml
@@ -17,7 +17,7 @@ spec:
   # ingressClassName: nginx
   rules:
     # Must match CALC_URL in configmap.yaml (this is the public URL the browser posts to).
-    - host: CHANGE-ME-esgame-calculation.example.com
+    - host: change-me-esgame-calculation.example.com
       http:
         paths:
           - path: /

--- a/deploy/k8s/base/configmap.yaml
+++ b/deploy/k8s/base/configmap.yaml
@@ -7,7 +7,7 @@ data:
   # externally reachable calculation ingress host — NOT the in-cluster service name. Injected into
   # the frontend's assets/config.json at container start by the image entrypoint (no rebuild).
   # Set to "" to ship a client-side-only (grid) deployment with no backend.
-  CALC_URL: "https://CHANGE-ME-esgame-calculation.example.com"
+  CALC_URL: "https://change-me-esgame-calculation.example.com"
 
   # In-cluster GeoServer URL used by the calculation backend (server-to-server).
   GEOSERVER_URL: "http://esgame-geoserver-service:8080/geoserver"

--- a/deploy/k8s/base/geoserver-ingress.yaml
+++ b/deploy/k8s/base/geoserver-ingress.yaml
@@ -16,7 +16,7 @@ spec:
   # class if `kubectl get ingressclass` shows no default.
   # ingressClassName: nginx
   rules:
-    - host: CHANGE-ME-esgame-geoserver.example.com
+    - host: change-me-esgame-geoserver.example.com
       http:
         paths:
           - path: /geoserver

--- a/docs/guides/deployer.rst
+++ b/docs/guides/deployer.rst
@@ -546,7 +546,7 @@ ConfigMap, services and ingresses. The overlay does four things:
    with the real loader** that pulls from your object storage / data release.
 #. **Sets ingress hosts** via JSON-patch ``replace`` ops on the three base
    ingresses (``esgame-angular-ingress``, ``esgame-calculation-ingress``,
-   ``esgame-geoserver-ingress``), replacing the ``CHANGE-ME-*.example.com``
+   ``esgame-geoserver-ingress``), replacing the ``change-me-*.example.com``
    placeholders.
 
 Apply with Kustomize:
@@ -555,7 +555,7 @@ Apply with Kustomize:
 
    $ kubectl apply -k places/deploy/k8s
 
-Before applying, you must replace every ``CHANGE-ME-*`` placeholder: the two
+Before applying, you must replace every placeholder: the two
 image ``newName`` registries and the three ingress hosts, and swap the
 placeholder ``load-geodata`` init container for the real loader.
 


### PR DESCRIPTION
Stood up a throwaway **kind** cluster to do the `kubectl --dry-run` this loop's brief asks for. The base does not apply:

```
Error from server (Invalid): Ingress "esgame-angular-ingress" is invalid:
  spec.rules[0].host: Invalid value: "CHANGE-ME-esgame.example.com":
  a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.'
```

All three ingresses, every time. The **uppercase in the placeholder** is enough — an Ingress host must be a valid RFC 1123 subdomain.

## kubeconform could not catch this

A host is just a string in the OpenAPI schema, so `kubeconform -strict` passed all 10 resources while the API server rejected 3 of them. **#73's validation gave false confidence here** — that's the more useful half of this finding, and why the guard below is a regex check rather than more schema validation.

## Fix

Lowercased the placeholders (`change-me-*.example.com`) in the three ingresses and the matching `CALC_URL`. Still obviously placeholders, still greppable, now actually appliable.

## Verified against a real cluster, not a renderer

| | |
|---|---|
| `apply --dry-run=server` | **3 errors → 0**, all 10 resources ok |
| `kubectl apply -k` | all 10 created |
| `esgame-angular` | **1/1 ready** — the published image runs in k8s |
| `esgame-geoserver` | **1/1 ready** — 2.28.4 pulls and runs |
| `esgame-calculation` | 0/1 — image not published, documented as build-it-yourself, not a defect |
| endpointslices | populated for all three services, so the **selectors really match** |
| `CALC_URL` in the container | injected from the ConfigMap |
| frontend via port-forward | `GET /` 200, `robots.txt` 200 |
| `assets/config.json` calcUrl | **the injected value** — so the runtime-config substitution works in Kubernetes, not only under Docker |

That last row is the deployment's whole design premise ("one image serves any backend by env var alone"). It had never been demonstrated on a cluster.

Also confirmed live what #73 only warned about: all three ingresses show **`CLASS <none>`**. They apply and route nothing.

## Guarded

An RFC 1123 check over the rendered hosts, since schema validation structurally cannot see this. Verified both ways — passes now, and flags all three if the uppercase form returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE