### PR TITLE
ci(k8s): validate the manifests against a real API server, not just a schema

### DIFF
--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -4,6 +4,12 @@ name: Validate deploy artifacts
 # (GeoServer stayed on a rolling 2.24.x tag while both compose stacks moved to 2.28.4).
 # This renders the Kustomize base and schema-checks the result, so drift and typos fail
 # a PR instead of waiting for someone to apply them to a real cluster.
+#
+# Schema validation is not sufficient on its own. `kubeconform -strict` passed all ten
+# resources while the API server rejected three of them: an Ingress host is just a string
+# in the OpenAPI schema, so an uppercase placeholder validated cleanly and then failed
+# `kubectl apply` with an RFC 1123 error. The dry-run job below exists for that whole class
+# — anything the API server enforces but the schema does not.
 on:
   pull_request:
     paths: ['deploy/**', 'tools/R/**', '.github/workflows/manifests.yml']
@@ -90,3 +96,55 @@ jobs:
           done
           [ "$bad" = 0 ] && echo "all ingress hosts are RFC 1123 valid"
           exit $bad
+
+  # Separate job so the fast checks above are not held up by cluster startup (~40s).
+  server-dryrun:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Start a throwaway cluster
+        run: |
+          curl -sSfL -o kind https://kind.sigs.k8s.io/dl/v0.30.0/kind-linux-amd64
+          chmod +x kind
+          ./kind create cluster --name validate --wait 120s
+
+      - name: kubectl apply --dry-run=server
+        run: |
+          # The real API server, so admission and field validation both apply. This is what
+          # catches what the schema cannot — see the note at the top of this file.
+          kubectl apply --dry-run=server -k deploy/k8s/base
+
+      - name: Apply for real, and check what should actually come up
+        run: |
+          kubectl apply -k deploy/k8s/base
+          # esgame-angular and esgame-geoserver use published images and must become ready.
+          # esgame-calculation is deliberately excluded: its image is documented as
+          # build-it-yourself, so it will never pull here.
+          for d in esgame-angular esgame-geoserver; do
+            kubectl rollout status "deploy/$d" --timeout=180s
+          done
+          # A Service with a selector that matches nothing still creates cleanly, so assert
+          # the endpoints actually populated.
+          for s in esgame-angular-service esgame-geoserver-service; do
+            n=$(kubectl get endpointslice -l "kubernetes.io/service-name=$s" \
+                  -o jsonpath='{.items[*].endpoints[*].addresses[*]}' | wc -w)
+            [ "$n" -ge 1 ] || { echo "::error::$s has no endpoints; its selector matches no pod"; exit 1; }
+            echo "$s -> $n endpoint(s)"
+          done
+
+      - name: The runtime config substitution reaches the container
+        run: |
+          # The deployment's premise is that one image serves any backend by env var alone:
+          # the entrypoint injects CALC_URL into assets/config.json at start. Assert it,
+          # rather than trusting the ConfigMap was merely mounted.
+          want=$(kubectl get cm esgame-config -o jsonpath='{.data.CALC_URL}')
+          got=$(kubectl exec deploy/esgame-angular -- sh -c 'cat /usr/share/nginx/html/assets/config.json' \
+                  | sed -n 's/.*"calcUrl"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+          echo "ConfigMap CALC_URL: $want"
+          echo "config.json calcUrl: $got"
+          [ "$want" = "$got" ] || { echo "::error::CALC_URL was not substituted into assets/config.json"; exit 1; }
+
+      - name: Tear down
+        if: always()
+        run: ./kind delete cluster --name validate || true

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -41,6 +41,12 @@ deploy/k8s/base/          # this Kustomize base (angular + calculation + geoserv
    kubectl apply -k deploy/k8s/base
    ```
 
+   CI does this too, on a throwaway kind cluster: `kubectl apply --dry-run=server`, then a real
+   apply that waits for `esgame-angular` and `esgame-geoserver` to become ready, checks their
+   Services actually have endpoints, and asserts `CALC_URL` was substituted into
+   `assets/config.json` inside the running container. Schema validation alone missed a bug that
+   made this very command fail — see `.github/workflows/manifests.yml`.
+
 ### Runtime configuration (no rebuild)
 The frontend image reads `CALC_URL` at container start and substitutes it into
 `assets/config.json` — so the same image targets any backend by env var alone. To override the game


### PR DESCRIPTION
#78 found that `kubectl apply -k deploy/k8s/base` failed on **all three** ingresses while `kubeconform -strict` reported **10/10 valid**. An Ingress host is just a string in the OpenAPI schema, so schema validation structurally cannot see an invalid RFC 1123 subdomain.

The regex guard added there covers that one case. This covers **the class** — anything the API server enforces that the schema doesn't.

## New `server-dryrun` job

Its own job, so the fast checks aren't held up by ~40s of cluster startup.

- **kind cluster** (v0.30.0), thrown away in an `always()` step.
- **`kubectl apply --dry-run=server`** — admission and field validation both run.
- **A real apply**, then `rollout status` on `esgame-angular` and `esgame-geoserver`. `esgame-calculation` is deliberately excluded: its image is documented as build-it-yourself and will never pull in CI.
- **An endpointslice assertion** — a Service whose selector matches nothing still creates cleanly and reports no error, so "applied successfully" proves less than it looks.
- **Assert `CALC_URL` was substituted into `assets/config.json` inside the running container.** The deployment's whole premise is *one image serves any backend by env var alone*, and nothing checked it.

## Every step ran locally first, and both assertions were negative-tested

| | |
|---|---|
| selector patched to match nothing | endpoints 1 → 0, **assertion fails** |
| `CALC_URL` overridden on the pod | want/got differ, **assertion fails** |
| both restored | pass again |

So neither is a decoration — which matters, because a green check that can't fail is exactly what let the original bug through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE