### PR TITLE
fix(k8s): stop shipping GeoServer's default admin credentials

### DIFF
--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -117,6 +117,12 @@ jobs:
 
       - name: Apply for real, and check what should actually come up
         run: |
+          # The base intentionally has no default GeoServer password: the deployments
+          # reference a Secret that does not exist in-repo, so a missing one fails the
+          # rollout instead of quietly shipping admin/geoserver. Create a throwaway here.
+          kubectl create secret generic esgame-geoserver-admin \
+            --from-literal=username=admin \
+            --from-literal=password="ci-only-$(head -c 16 /dev/urandom | base64 | tr -dc 'A-Za-z0-9')"
           kubectl apply -k deploy/k8s/base
           # esgame-angular and esgame-geoserver use published images and must become ready.
           # esgame-calculation is deliberately excluded: its image is documented as

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -33,10 +33,23 @@ deploy/k8s/base/          # this Kustomize base (angular + calculation + geoserv
    **Ingress class** — check `kubectl get ingressclass`. If none is marked default, uncomment
    `ingressClassName` in all three files and set your controller's class. An Ingress with neither
    applies without error and is then silently ignored: nothing routes, and nothing says why.
-3. **Backend URL** — in `base/configmap.yaml` set `CALC_URL` to the **public** calculation ingress
+3. **GeoServer admin Secret** — required; there is no default, so the rollout fails without it.
+   The image would otherwise keep its built-in `admin` / `geoserver` login, on a GeoServer whose
+   REST API is published through `geoserver-ingress` and which the calculation backend uses to
+   create workspaces and upload coverages:
+
+   ```sh
+   kubectl create secret generic esgame-geoserver-admin \
+     --from-literal=username=admin \
+     --from-literal=password='<a real password>'
+   ```
+
+   Both `esgame-geoserver` and `esgame-calculation` read it, so they always agree.
+
+4. **Backend URL** — in `base/configmap.yaml` set `CALC_URL` to the **public** calculation ingress
    host from step 2 (the browser posts there client-side, so it must be externally reachable, not the
    in-cluster service name). Set `CALC_URL: ""` for a client-side-only (grid) deployment.
-4. Apply:
+5. Apply:
    ```sh
    kubectl apply -k deploy/k8s/base
    ```

--- a/deploy/k8s/base/calculation-deployment.yaml
+++ b/deploy/k8s/base/calculation-deployment.yaml
@@ -31,6 +31,18 @@ spec:
                 configMapKeyRef:
                   name: esgame-config
                   key: GEOSERVER_URL
+            # calculator.r creates a workspace and uploads coverages per game/round through
+            # GeoServer's REST API, so it needs the same admin credentials.
+            - name: GEOSERVER_USER
+              valueFrom:
+                secretKeyRef:
+                  name: esgame-geoserver-admin
+                  key: username
+            - name: GEOSERVER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: esgame-geoserver-admin
+                  key: password
           ports:
             - containerPort: 8000
               protocol: TCP

--- a/deploy/k8s/base/geoserver-deployment.yaml
+++ b/deploy/k8s/base/geoserver-deployment.yaml
@@ -16,7 +16,6 @@ spec:
     spec:
       containers:
         - name: esgame-geoserver
-          # Pin to a specific patch (e.g. 2.24.4) for reproducible deploys instead of rolling 2.24.x.
           # Pinned to a specific patch, matching v2/docker-compose.dynamic.yml and
           # examples/esgame-dynamic/docker-compose.yml. 2.24.x was a rolling tag.
           image: docker.osgeo.org/geoserver:2.28.4
@@ -24,6 +23,21 @@ spec:
           env:
             - name: CORS_ENABLED
               value: "true"
+            # Without these the image keeps its default admin/geoserver login — on a
+            # deployment whose REST API is published through geoserver-ingress, and which
+            # the calculation backend uses to create workspaces and upload coverages.
+            # Deliberately required, with no default: a missing Secret must stop the
+            # rollout, not silently ship well-known credentials.
+            - name: GEOSERVER_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: esgame-geoserver-admin
+                  key: username
+            - name: GEOSERVER_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: esgame-geoserver-admin
+                  key: password
           ports:
             - containerPort: 8080
               protocol: TCP

--- a/tools/R/calculator.r
+++ b/tools/R/calculator.r
@@ -300,9 +300,18 @@ calculate<-function(req, geoserver_url, game_id, round_id,score_PD,map_AG) {
   #connect to GeoServer
   ## Geoserver
   gs_url <- geoserver_url
+  # Credentials come from the environment. They used to be hardcoded as admin/geoserver —
+  # the image's defaults — on a GeoServer whose REST API is published through an ingress.
+  # The fallbacks keep an already-running deployment working, and warn loudly, rather than
+  # breaking it on upgrade; deploy/k8s injects real values from a Secret.
+  gs_user <- Sys.getenv("GEOSERVER_USER", "admin")
+  gs_pwd  <- Sys.getenv("GEOSERVER_PASSWORD", "geoserver")
+  if (gs_pwd == "geoserver") {
+    log_warn("GEOSERVER_PASSWORD is unset, so the GeoServer default password is in use. Set GEOSERVER_USER/GEOSERVER_PASSWORD.")
+  }
   gsman <-GSManager$new(
     url = gs_url, #baseUrl of the Geoserver
-    user = "admin", pwd = "geoserver", #credentials
+    user = gs_user, pwd = gs_pwd,
     logger = NULL #logger, for info or debugging purpose
   )
   


### PR DESCRIPTION
`calculator.r` authenticated to GeoServer with hardcoded credentials:

```r
gsman <- GSManager$new(url = gs_url, user = "admin", pwd = "geoserver", ...)
```

Those are the image's **defaults**, and nothing in `deploy/`, the compose files, or the docs ever set a different password — the base's geoserver Deployment passed only `CORS_ENABLED`.

So a deployment of this base ran GeoServer with `admin`/`geoserver`, with its **REST API published through `geoserver-ingress`**, and with the calculation backend using that API to create workspaces and upload coverages per game round.

## Fix

Both deployments now read a **required** Secret, `esgame-geoserver-admin`:

| Deployment | Vars |
|---|---|
| `esgame-geoserver` | `GEOSERVER_ADMIN_USER` / `GEOSERVER_ADMIN_PASSWORD` |
| `esgame-calculation` | `GEOSERVER_USER` / `GEOSERVER_PASSWORD` |

No default, no committed placeholder. A missing Secret must **stop the rollout** rather than quietly ship well-known credentials — so it's a required deploy step (README step 3) and CI creates a throwaway one.

`calculator.r` now reads `GEOSERVER_USER`/`GEOSERVER_PASSWORD`, falling back to the old values with a `log_warn`. **The fallback is deliberate:** places is already running against a GeoServer provisioned with those credentials, and breaking a live deployment on upgrade would be worse than warning. The k8s manifests inject real values, so the fallback isn't reached there.

## Verified on a kind cluster, all three directions

| | |
|---|---|
| no Secret | geoserver pod `CreateContainerConfigError`, event `secret "esgame-geoserver-admin" not found` |
| Secret created | rollout completes, 1/1 ready |
| `admin:geoserver` | **401 — the default login is gone** |
| `admin:<secret pw>` | **200 — the injected credentials work** |

I confirmed the image supports this before relying on it: `/opt/handle_geoserver_admin_credentials.sh` reads `GEOSERVER_ADMIN_USER`/`GEOSERVER_ADMIN_PASSWORD` (and `_FILE` variants).

Also dropped a stale duplicate comment I left in `geoserver-deployment.yaml` in #73, which still referenced the old 2.24.4 pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE