### PR TITLE
fix(tools/R): plot.margin had five values for a four-sided box

### DIFF
--- a/tools/R/calculator.r
+++ b/tools/R/calculator.r
@@ -272,7 +272,11 @@ calculate<-function(req, geoserver_url, game_id, round_id,score_PD,map_AG) {
       axis.text = element_blank(),
       axis.title = element_blank(),
       panel.grid = element_blank(),
-      plot.margin = unit(rep(1,5), "cm") 
+      # A margin has four sides. rep(1,5) supplies five; ggplot2 tolerated the extra
+      # silently until 4.x, which now errors with "The `plot.margin` theme element must
+      # be a <unit> vector of length 4" — losing the whole round at plot(p) below, after
+      # the model has already done all its work.
+      plot.margin = unit(rep(1,4), "cm") 
     ) +
     coord_polar()
   


### PR DESCRIPTION
`calculator.r:275` set:

```r
plot.margin = unit(rep(1,5), "cm")
```

A margin has four sides, and ggplot2 documents `plot.margin` as a unit vector of **length 4**. The fifth value was always wrong.

## Not hypothetical

The sibling copy of this script — places' `calculation/calculation.r` — carried the same mistake, and it is **fatal** there:

```
Error in `plot_theme()`:
! The `plot.margin` theme element must be a <unit> vector of length 4
```

with the model dying at `plot(p)` *after* completing ~100s of raster work — the whole round lost at the final step.

## But preventive here, and worth being precise about

The image this Dockerfile currently produces resolves **ggplot2 4.0.3**, which tolerates the extra value. I restored `rep(1,5)`, rebuilt, and the round still returned 200 — so I am **not** claiming this fixes a live break in esgame.

The places image resolves **4.6.1**, which rejects it. Neither Dockerfile pins ggplot2, so which behaviour you get isn't determined by anything in the repo. That's the actual risk this closes.

## Verified by running a round, which nothing had done before

GeoServer with a non-default password, `/app/data` mounted with the repo's `LU_and_NEW_hexa.tif`, and a 472-hexagon allocation POSTed to `/esgame`:

| | |
|---|---|
| response | **HTTP 200** in 29s, 1340 bytes |
| results | 6 — five indicators plus the spider plot |
| workspace | `esgame_gameesg-rt-1_round1` created in GeoServer |
| coverages published | HC, HH, NP, RV, WA |
| WCS `GetCoverage` | **5/5** return a GeoTIFF at the URLs handed to the browser |
| spider plot | served from `/images/`, PNG 393×393 |

## Unresolved — claimed as neither working nor broken

**Every score came back `NaN`**, with `min`/`max` warnings over all-NA vectors in the log. This calculator reads exactly **one** input (`LU_and_NEW_hexa.tif`) where the places model reads **thirteen**, so it may simply lack the data to score with — or my synthetic allocation may be invalid, since I round-robined land uses across all 472 hexagon values including the low fixed ones (2–8).

**The pipeline is verified; the numbers are not.** Someone who knows which hexagons are allocatable should check this against a real board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE