### PR TITLE
fix(calculator): the coverage URLs handed to the browser were in-cluster names

### DIFF
--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -77,6 +77,37 @@ jobs:
           fi
           echo "Dockerfile installs geosapi at build time"
 
+      - name: GeoServer has a separate public URL for the browser
+        run: |
+          # The calculator publishes coverages over GeoServer's REST API from inside the cluster
+          # (GEOSERVER = the Service name) but returns WCS GetCoverage URLs that the BROWSER
+          # fetches. Building those from the Service name renders, applies, and returns 200 with
+          # URLs no client can resolve — which is why the geoserver Ingress exists. Verified in
+          # the places stack: with the split, 6/6 coverages fetch from outside the network.
+          # kustomize strips the quotes it finds in the source, so tolerate both forms.
+          internal=$(grep -oP '^\s+GEOSERVER_URL:\s*"?\K[^"[:space:]]+' rendered.yaml)
+          public=$(grep -oP '^\s+GEOSERVER_PUBLIC_URL:\s*"?\K[^"[:space:]]+' rendered.yaml)
+          echo "internal=$internal"
+          echo "public=$public"
+          if [ -z "$public" ]; then
+            echo "::error::GEOSERVER_PUBLIC_URL is missing from the ConfigMap"; exit 1
+          fi
+          if [ "$internal" = "$public" ]; then
+            echo "::error::GEOSERVER_PUBLIC_URL equals the in-cluster GEOSERVER_URL; the browser cannot resolve a Service name"; exit 1
+          fi
+          if grep -q 'esgame-geoserver-service' <<<"$public"; then
+            echo "::error::GEOSERVER_PUBLIC_URL points at the Service; use the geoserver ingress host"; exit 1
+          fi
+          # And the calculator container must actually receive it, or the ConfigMap value is inert.
+          if ! grep -q 'GEOSERVER_PUBLIC_URL' deploy/k8s/base/calculation-deployment.yaml; then
+            echo "::error file=deploy/k8s/base/calculation-deployment.yaml::GEOSERVER_PUBLIC_URL is not wired into the calculation container"; exit 1
+          fi
+          # The R calculator must build its URLs from it rather than from GEOSERVER.
+          if ! grep -qE '^\s*raster_url\s*<-\s*paste0\(\s*gs_public' tools/R/calculator.r; then
+            echo "::error file=tools/R/calculator.r::raster_url must be built from gs_public (GEOSERVER_PUBLIC_URL), not gs_url"; exit 1
+          fi
+          echo "GeoServer public URL is separate, wired through, and used for coverage URLs"
+
       - name: Ingress hosts must be valid RFC 1123 subdomains
         run: |
           # kubeconform does not check this: a host is just a string in the schema, so

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -17,7 +17,7 @@ A generalized Kustomize base for deploying the **full esgame stack** (dynamic mo
 ```
 deploy/k8s/base/          # this Kustomize base (angular + calculation + geoserver)
   kustomization.yaml      # resources + image name→registry mapping
-  configmap.yaml          # CALC_URL (public backend URL) + GEOSERVER_URL
+  configmap.yaml          # CALC_URL + GEOSERVER_PUBLIC_URL (public) + GEOSERVER_URL (in-cluster)
   *-deployment.yaml *-service.yaml *-ingress.yaml
 ```
 
@@ -46,9 +46,14 @@ deploy/k8s/base/          # this Kustomize base (angular + calculation + geoserv
 
    Both `esgame-geoserver` and `esgame-calculation` read it, so they always agree.
 
-4. **Backend URL** — in `base/configmap.yaml` set `CALC_URL` to the **public** calculation ingress
-   host from step 2 (the browser posts there client-side, so it must be externally reachable, not the
-   in-cluster service name). Set `CALC_URL: ""` for a client-side-only (grid) deployment.
+4. **Public URLs** — in `base/configmap.yaml`, two values must be externally reachable hosts from
+   step 2, because the **browser** fetches both:
+   - `CALC_URL` — the calculation ingress host; the browser posts game state there client-side.
+     Set `CALC_URL: ""` for a client-side-only (grid) deployment.
+   - `GEOSERVER_PUBLIC_URL` — the geoserver ingress host. The calculation returns WCS
+     `GetCoverage` URLs built from this. `GEOSERVER_URL` (the in-cluster Service) stays as it is —
+     that one is only used server-to-server, to publish the coverages. Setting the public value to
+     the Service name applies cleanly and returns `200` with URLs no browser can resolve.
 5. Apply:
    ```sh
    kubectl apply -k deploy/k8s/base

--- a/deploy/k8s/base/calculation-deployment.yaml
+++ b/deploy/k8s/base/calculation-deployment.yaml
@@ -31,6 +31,13 @@ spec:
                 configMapKeyRef:
                   name: esgame-config
                   key: GEOSERVER_URL
+            # The WCS URLs the calculator returns are fetched by the browser, not by the cluster,
+            # so they are built from the public host rather than the Service name above.
+            - name: GEOSERVER_PUBLIC_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: esgame-config
+                  key: GEOSERVER_PUBLIC_URL
             # calculator.r creates a workspace and uploads coverages per game/round through
             # GeoServer's REST API, so it needs the same admin credentials.
             - name: GEOSERVER_USER

--- a/deploy/k8s/base/configmap.yaml
+++ b/deploy/k8s/base/configmap.yaml
@@ -9,5 +9,12 @@ data:
   # Set to "" to ship a client-side-only (grid) deployment with no backend.
   CALC_URL: "https://change-me-esgame-calculation.example.com"
 
-  # In-cluster GeoServer URL used by the calculation backend (server-to-server).
+  # In-cluster GeoServer URL used by the calculation backend (server-to-server) to publish
+  # coverages over the REST API.
   GEOSERVER_URL: "http://esgame-geoserver-service:8080/geoserver"
+
+  # Public GeoServer URL. The calculation returns WCS GetCoverage URLs built from THIS, and the
+  # browser fetches them — so like CALC_URL it must be the externally reachable ingress host, not
+  # the Service name above. Leave it equal to GEOSERVER_URL and every round still returns 200 with
+  # coverage URLs no client can resolve. See geoserver-ingress.yaml for the matching host.
+  GEOSERVER_PUBLIC_URL: "https://change-me-esgame-geoserver.example.com/geoserver"

--- a/docs/reference/calculator.rst
+++ b/docs/reference/calculator.rst
@@ -242,12 +242,24 @@ GitHub (``remotes::install_github('eblondel/geosapi')``) and defines:
   * ``score_PD`` ← ``score``
   * ``map_AG``   ← ``allocation``
 
-* **GeoServer URL source:**
+* **GeoServer URL source:** two addresses, and they are not interchangeable.
 
-  * ``calculator.r``:
+  * ``GEOSERVER`` — server-to-server. Coverages are published over GeoServer's REST
+    API from inside the cluster, so this is the in-cluster Service name.
+    ``calculator.r`` reads
     ``Sys.getenv("GEOSERVER", "https://esgame-geoserver.azurewebsites.net/geoserver")``
-    (env with a hard default).
-  * ``calculation.r``: ``Sys.getenv("GEOSERVER")`` (no default).
+    (env with a hard default); ``calculation.r`` reads ``Sys.getenv("GEOSERVER")``
+    (no default).
+  * ``GEOSERVER_PUBLIC_URL`` — browser-facing. The WCS ``GetCoverage`` URLs in the
+    response are built from this and fetched by the **client**, which cannot resolve
+    a Service name. Both R engines default it to ``GEOSERVER`` and log a warning, so
+    an existing single-address deployment is unchanged; set it to the geoserver
+    ingress host. Leave it equal and every round still returns ``200`` — with
+    coverage URLs nothing outside the cluster can load.
+
+  Enforced by :file:`.github/workflows/manifests.yml`, which fails a PR if the two
+  ConfigMap values are equal, if the public one names the Service, if the calculation
+  container does not receive it, or if ``raster_url`` is built from ``gs_url`` again.
 
 * **Output:** delegates to and returns
   ``calculate(req, geoserver_url, game_id, round_id, score_PD, map_AG)``.

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -55,8 +55,21 @@ Verified working
        5/5 GeoTIFFs, spider plot served. Also starts with ``--network none``.
    * - places overlay
      - Renders 11 resources, all valid under ``kubeconform -strict``; ingress-host
-       patches apply; the GeoServer pin flows through from this base. Its calculation
-       completes a round: 200, six indicators, six coverages, WCS 6/6.
+       patches apply; the GeoServer pin flows through from this base. 19 checks in
+       places' ``test/k8s.sh``, three of them confirmed able to fail by mutation.
+   * - places local stack
+     - The full compose stack up from a clean slate and a real round played through
+       it: ``POST /esgame`` → 200 in 71s, six finite scores (HH 64, NP 34, WE 25,
+       WA 25, HC 46, RV 47), six coverages fetched as GeoTIFFs **from outside the
+       compose network**, spider plot served as a PNG. 21 checks in places'
+       ``test/stack.sh``. That repo's geodata now loads for real in both paths —
+       a loader service in compose, the ``load-geodata`` init container in k8s.
+   * - Browser-facing GeoServer URL
+     - The R calculators built their WCS URLs from ``GEOSERVER`` — the in-cluster
+       Service name — so the browser got URLs it could not resolve while everything
+       returned 200. Split into ``GEOSERVER_PUBLIC_URL``; measured 6/6 coverages
+       fetchable from outside the network in the places stack. Gated in CI, with all
+       four failure modes checked by mutation.
 
 
 Known incomplete
@@ -82,10 +95,12 @@ No default IngressClass is assumed
 
 The places geodata is not in its working tree
    places' ``calculation.r`` reads 13 files from ``/app/data``; its repository contains
-   one. The other twelve were deleted from ``kubernetes_deployment/assets`` by commit
-   ``310fd46`` and exist only in git history, while ``deploy/k8s``'s ``load-geodata``
-   init container is still an ``echo 'TODO: fetch places geodata'``. Nothing in the tree
-   provides them at deploy time.
+   one, deliberately — the rest are a data release. That is now *handled* rather than
+   merely true: ``scripts/fetch-geodata.sh`` caches them (from a tarball URL, or from
+   places' own git history when no URL is set), the compose stack copies that cache into
+   the calculation's writable volume, and ``deploy/k8s``'s ``load-geodata`` init
+   container fetches the tarball from a ``places-geodata-source`` Secret. Both verify
+   all 13 arrived and fail loudly otherwise. A deployment still has to supply the URL.
 
 
 Not verified
@@ -94,7 +109,13 @@ Not verified
 Honest gaps, so nobody assumes otherwise.
 
 * **No cluster ingress traffic.** Everything k8s was reached by ``port-forward``. No
-  request has gone through an actual ingress controller with a real host and TLS.
+  request has gone through an actual ingress controller with a real host and TLS. So
+  ``GEOSERVER_PUBLIC_URL`` was proved end to end in *compose* (6/6 coverages fetched from
+  outside the network) and only statically in k8s — rendered, wired, and gated in CI, but
+  no browser has followed one of those URLs through a real geoserver ingress.
+* **``tools/R`` was not re-run after the URL split.** The change is the same one verified
+  in places' ``calculation.r``, and it defaults to the previous single-address behaviour,
+  but esgame's own image has not played a round with ``GEOSERVER_PUBLIC_URL`` set.
 * **No multi-round game.** Each round-trip was a single ``POST /esgame``. Level
   progression, score accumulation across rounds, and the frontend consuming the returned
   coverage URLs back into the board were not exercised together.

--- a/tools/R/calculator.r
+++ b/tools/R/calculator.r
@@ -304,6 +304,17 @@ calculate<-function(req, geoserver_url, game_id, round_id,score_PD,map_AG) {
   #connect to GeoServer
   ## Geoserver
   gs_url <- geoserver_url
+  # Two addresses, because this one variable was doing two incompatible jobs. gs_url is
+  # server-to-server: coverages are published over the REST API from inside the cluster, so it
+  # must be the in-cluster name — deploy/k8s sets GEOSERVER to esgame-geoserver-service. But the
+  # WCS URLs built from it further down are fetched by the BROWSER, which cannot resolve a
+  # Service name. That is what the geoserver Ingress is for. The FastAPI example calculator
+  # already made this split; this brings the R calculator in line with it.
+  # Defaults to gs_url, so an existing single-address deployment behaves exactly as before.
+  gs_public <- Sys.getenv("GEOSERVER_PUBLIC_URL", geoserver_url)
+  if (gs_public == gs_url) {
+    log_warn("GEOSERVER_PUBLIC_URL is unset, so coverage URLs will use the internal GeoServer address ({gs_url}). A browser probably cannot resolve it.")
+  }
   # Credentials come from the environment. They used to be hardcoded as admin/geoserver —
   # the image's defaults — on a GeoServer whose REST API is published through an ingress.
   # The fallbacks keep an already-running deployment working, and warn loudly, rather than
@@ -386,7 +397,7 @@ calculate<-function(req, geoserver_url, game_id, round_id,score_PD,map_AG) {
   
   created <- gsman$createCoverage(ws = ws_name, cs = short_name, coverage = cov)
   
-  raster_url <- paste0(gs_url , "/wcs?service=WCS&version=2.0.0&request=GetCoverage" ,
+  raster_url <- paste0(gs_public , "/wcs?service=WCS&version=2.0.0&request=GetCoverage" ,
                            "&coverageId=" , ws_name , ":" , short_name ,
                            "&format=image%2Fgeotiff" )
   


### PR DESCRIPTION
## The bug

`GEOSERVER` was doing two incompatible jobs in the R calculator.

Publishing coverages goes over GeoServer's REST API **from inside the cluster**, so that variable has to be the Service name — `deploy/k8s` sets it to `esgame-geoserver-service`. But the WCS `GetCoverage` URLs built from the *same* variable are returned to the client and fetched by the **browser**, which cannot resolve a Service name.

So a round returned `200`, created the workspace, published every coverage, and handed back URLs nothing outside the cluster could load. `geoserver-ingress.yaml` existed for exactly this and nothing referenced it.

## The fix

Split into two values:

| Variable | Consumer | Value |
|---|---|---|
| `GEOSERVER` | the calculator, server-to-server | in-cluster Service (unchanged) |
| `GEOSERVER_PUBLIC_URL` | the **browser**, via the returned URLs | the geoserver ingress host |

This is what the FastAPI example calculator already did — the R calculator was the outlier. `GEOSERVER_PUBLIC_URL` defaults to `GEOSERVER` and logs a warning, so an already-running single-address deployment behaves exactly as before rather than breaking on upgrade.

## Evidence

Verified end to end in the sibling `places` stack, which took the same change: with the split, **all six published coverages fetch as GeoTIFFs from outside the compose network**. Before it, they were `places-geoserver:8080` URLs.

New CI check in `manifests.yml`, because every failure mode here is silent — it renders, it applies, it returns `200`. It fails a PR if:

- the two ConfigMap values are equal,
- the public one names the Service,
- the calculation container never receives it,
- `raster_url` goes back to being built from `gs_url`.

All four confirmed able to fail by mutating the tree and re-running, then restored to green. Docs build clean under `sphinx-build -W`.

## Honest limits

`docs/verification-status.rst` records these rather than implying otherwise: the split is proved end to end in **compose** and only **statically** in k8s — no browser has followed one of these URLs through a real ingress controller, and `tools/R` itself was not re-run (the change is the one verified in places' `calculation.r`, and it defaults to the old behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE