### PR TITLE
feat(deploy): a local registry, a cluster that can pull from it — and what that turned up

### DIFF
--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -72,6 +72,34 @@ The frontend image reads `CALC_URL` at container start and substitutes it into
 over `/usr/share/nginx/html/assets/` (nginx serves those files `no-store`, so changes apply on
 reload). See [../../docs/ARCHITECTURE.md](../../docs/ARCHITECTURE.md).
 
+## Running it locally, for real
+
+`esgame-calculation` is published nowhere, so the base cannot come up as-is (step 1). To exercise
+the whole stack — including an actual ingress controller rather than `port-forward`:
+
+```sh
+deploy/registry/registry.sh up && deploy/registry/registry.sh push   # build + serve the images
+deploy/k8s/kind.sh up          # cluster wired to that registry + ingress-nginx
+deploy/k8s/kind.sh deploy      # apply overlays/local-registry, wait for rollout
+deploy/k8s/ingress-test.sh     # a real round through the ingress, by Host header
+```
+
+`overlays/local-registry` is where everything local lives — the images, `.local` hosts,
+`ingressClassName: nginx`, and the two public URLs. The base's ghcr defaults and `change-me` hosts
+are what a real deployment wants and are left alone.
+
+Two things `kind.sh` does that a bare `kind create cluster` does not, both of which fail silently
+otherwise:
+
+- **Registry access.** `localhost:5001` inside a node means *the node*, so a plain kind cluster
+  cannot pull these images at all. It writes a containerd `hosts.toml` and joins the registry to
+  kind's docker network.
+- **inotify preflight.** On a busy host `fs.inotify.max_user_instances` (default 128, kind wants
+  512) runs out, and the way that surfaces is four unrelated-looking symptoms about eight minutes
+  in — `kube-proxy` crash-looping on "too many open files", no Service routing, the ingress
+  admission Job unable to reach the API server, and the controller stuck on a missing cert Secret.
+  `kind.sh up` checks first and prints the `sysctl` to run.
+
 ## Overlays (how a downstream like `places` reuses this)
 
 Create an overlay `kustomization.yaml` with `resources: [../esgame/deploy/k8s/base]` (or a vendored

--- a/deploy/k8s/ingress-test.sh
+++ b/deploy/k8s/ingress-test.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Drive a real round through a real ingress controller.
+#
+# This closes the largest gap in docs/verification-status.rst. Everything k8s in this repo had
+# only ever been reached by `kubectl port-forward`, which proves a Pod is listening and proves
+# nothing at all about the Ingress: an Ingress with no class, or no controller, applies cleanly
+# and routes nothing, silently. So every request here goes over the host port that kind maps to
+# ingress-nginx, addressed by Host header — the same path a browser takes.
+#
+#   deploy/k8s/kind.sh up && deploy/k8s/kind.sh deploy
+#   deploy/k8s/ingress-test.sh
+set -euo pipefail
+cd "$(dirname "$0")"
+
+CLUSTER="${KIND_CLUSTER:-esgame}"
+PORT="${KIND_HTTP_PORT:-8880}"
+K=(kubectl --context "kind-${CLUSTER}")
+BASE="http://localhost:${PORT}"
+
+# Every request carries a Host header and none of them use port-forward.
+ing()  { curl -s -H "Host: $1" "${BASE}${2:-/}" "${@:3}"; }
+code() { curl -s -o /dev/null -w '%{http_code}' -H "Host: $1" "${BASE}${2:-/}" "${@:3}"; }
+ctype(){ curl -s -o /dev/null -w '%{content_type}' -H "Host: $1" "${BASE}${2:-/}" "${@:3}"; }
+
+fail=0
+check() { if eval "$2" >/dev/null 2>&1; then echo "  ok   $1"; else echo "  FAIL $1"; fail=1; fi; }
+
+echo "==> the controller is actually wired to our Ingresses"
+# An Ingress only gets a status.loadBalancer address once a controller has adopted it. Empty here
+# means the class did not match and nothing is routing, however healthy everything looks.
+for i in esgame-angular-ingress esgame-calculation-ingress esgame-geoserver-ingress; do
+  addr=$("${K[@]}" get ingress "$i" -o jsonpath='{.status.loadBalancer.ingress[*].ip}{.status.loadBalancer.ingress[*].hostname}' 2>/dev/null)
+  cls=$("${K[@]}" get ingress "$i" -o jsonpath='{.spec.ingressClassName}' 2>/dev/null)
+  check "${i} adopted by a controller (class=${cls:-none})" "[ -n '${addr}' ]"
+done
+
+echo "==> frontend through the ingress"
+check "esgame.local serves the app"        "[ \"\$(code esgame.local /)\" = 200 ]"
+check "index.html is really the app"       "ing esgame.local / | grep -qi '<app-root\|<title'"
+check "assets/config.json served"          "[ \"\$(code esgame.local /assets/config.json)\" = 200 ]"
+# The premise of the whole deployment: one image, retargeted by env var at container start.
+want=$("${K[@]}" get cm esgame-config -o jsonpath='{.data.CALC_URL}')
+got=$(ing esgame.local /assets/config.json | sed -n 's/.*"calcUrl"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+echo "     ConfigMap CALC_URL=${want}"
+echo "     served    calcUrl =${got}"
+check "CALC_URL reached the served config" "[ -n '${want}' ] && [ '${want}' = '${got}' ]"
+
+echo "==> a wrong Host must NOT be served by our app"
+# If this returns the app, the Ingress is matching everything and host routing is not working.
+check "unknown host is not the esgame app"  "[ \"\$(code no-such-host.local /)\" != 200 ] || ! ing no-such-host.local / | grep -qi '<app-root'"
+
+echo "==> geoserver through the ingress"
+gs_user=$("${K[@]}" get secret esgame-geoserver-admin -o jsonpath='{.data.username}' | base64 -d)
+gs_pass=$("${K[@]}" get secret esgame-geoserver-admin -o jsonpath='{.data.password}' | base64 -d)
+check "geoserver REST answers with the Secret creds" \
+  "[ \"\$(code esgame-geoserver.local /geoserver/rest/about/version.json -u '${gs_user}:${gs_pass}')\" = 200 ]"
+check "the image default password does NOT work" \
+  "[ \"\$(code esgame-geoserver.local /geoserver/rest/about/version.json -u admin:geoserver)\" != 200 ]"
+
+echo "==> a real round through the calculation ingress"
+# Ids come from the raster the deployed calculator actually reads, not from an assumption.
+pod=$("${K[@]}" get pod -l app=esgame-calculation -o jsonpath='{.items[0].metadata.name}')
+"${K[@]}" exec "${pod}" -- R -q -e '
+  suppressMessages(library(raster))
+  v <- sort(unique(na.omit(values(raster("/app/data/LU_and_NEW_hexa.tif")))))
+  cat("IDS:", paste(v[v >= 9], collapse=","), "\n")' 2>/dev/null \
+  | tr -d '\r' | sed -n 's/^IDS: //p' | tr -d ' ' > /tmp/esgame-ingress-ids.txt
+n=$(tr ',' '\n' < /tmp/esgame-ingress-ids.txt | grep -c . || echo 0)
+echo "     ${n} allocatable ids read from the deployed raster"
+check "read the id space from the pod"     "[ '${n}' -gt 100 ]"
+
+python3 - /tmp/esgame-ingress-ids.txt > /tmp/esgame-ingress-payload.json <<'PY'
+import json, sys
+ids = [int(x) for x in open(sys.argv[1]).read().strip().split(',') if x]
+types = [10, 20, 30, 40, 50, 60]
+json.dump({"game_id": "ingress", "round": 1, "score": 42,
+           "allocation": [{"id": i, "lulc": types[n % len(types)]} for n, i in enumerate(ids)]}, sys.stdout)
+PY
+
+start=$(date +%s)
+http=$(curl -s -o /tmp/esgame-ingress-round.json -w '%{http_code}' -m 900 \
+  -H 'Host: esgame-calculation.local' -H 'Content-Type: application/json' \
+  --data @/tmp/esgame-ingress-payload.json "${BASE}/esgame")
+echo "     POST /esgame via ingress -> ${http} in $(( $(date +%s) - start ))s"
+check "round returns 200 through the ingress" "[ '${http}' = 200 ]"
+
+python3 - /tmp/esgame-ingress-round.json > /tmp/esgame-ingress-summary.txt <<'PY' || true
+import json, sys, math
+rows = json.load(open(sys.argv[1]))["results"]
+scored, urls = 0, []
+for it in rows:
+    if it.get("url"): urls.append(str(it["url"]))
+    if it.get("id") == -1:
+        print(f"     {it.get('name',''):<40} (plot)"); continue
+    s = it.get("score")
+    ok = isinstance(s, (int, float)) and not isinstance(s, bool) and math.isfinite(float(s))
+    if ok: scored += 1
+    print(f"     {it.get('name',''):<40} score={s}{'' if ok else '  <-- NOT FINITE'}")
+print(f"SCORED={scored}")
+print("URLS=" + " ".join(urls))
+PY
+grep -v '^SCORED=\|^URLS=' /tmp/esgame-ingress-summary.txt
+scored=$(sed -n 's/^SCORED=//p' /tmp/esgame-ingress-summary.txt)
+urls=$(sed -n 's/^URLS=//p' /tmp/esgame-ingress-summary.txt)
+check "indicators scored (not NaN)"        "[ -n '${scored}' ] && [ '${scored}' -ge 5 ]"
+
+echo "==> the returned coverage URLs are fetchable as a browser would fetch them"
+# The GEOSERVER_PUBLIC_URL split, end to end: these URLs must name the geoserver INGRESS host,
+# and must actually return GeoTIFFs over it. Built from the Service name they would 200 from
+# inside the cluster and be unreachable from anywhere a browser runs.
+tot=0; ok=0
+for u in ${urls}; do
+  case "${u}" in *"/wcs?"*) ;; *) continue ;; esac
+  tot=$((tot + 1))
+  host=$(sed -E 's|https?://([^/:]+).*|\1|' <<<"${u}")
+  path=$(sed -E 's|https?://[^/]+||' <<<"${u}")
+  ct=$(curl -s -o /dev/null -w '%{content_type}' -m 180 -H "Host: ${host}" "${BASE}${path}")
+  case "${ct}" in *tiff*) ok=$((ok + 1));; *) echo "     unfetchable via ingress: ${host} (${ct:-none})";; esac
+done
+echo "     WCS GetCoverage through the ingress: ${ok}/${tot}"
+check "coverage URLs use an ingress host"  "! grep -q 'esgame-geoserver-service' <<<'${urls}'"
+check "coverage URLs return GeoTIFFs"      "[ ${tot} -gt 0 ] && [ ${ok} = ${tot} ]"
+
+echo
+if [ "${fail}" = 0 ]; then
+  echo "ingress round-trip: PASS   (${n} ids, ${scored} scores, ${ok}/${tot} coverages, all via http://localhost:${PORT})"
+else
+  echo "ingress round-trip: FAIL"; exit 1
+fi

--- a/deploy/k8s/kind.sh
+++ b/deploy/k8s/kind.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# A local cluster that can actually pull the esgame images and route real ingress traffic.
+#
+#   deploy/registry/registry.sh up && deploy/registry/registry.sh push   # images first
+#   deploy/k8s/kind.sh up            # cluster + registry wiring + ingress-nginx
+#   deploy/k8s/kind.sh deploy        # apply the local-registry overlay, wait for rollout
+#   deploy/k8s/kind.sh test          # a real round THROUGH the ingress
+#   deploy/k8s/kind.sh down
+#
+# Two things this sets up that a bare `kind create cluster` does not:
+#
+# 1. Registry access. `localhost:5001` inside a node means the NODE, not your host — so a plain
+#    kind cluster cannot pull these images at all. The fix is containerd's registry config dir
+#    plus joining the registry container to kind's docker network, so `localhost:5001` resolves
+#    to the registry from inside the nodes. This is the upstream kind local-registry recipe.
+#
+# 2. An ingress controller. The base's Ingresses set no ingressClassName, and with no controller
+#    (or no default IngressClass) they apply cleanly and route nothing, silently. Everything k8s
+#    in this repo had only ever been reached by port-forward, which proves the Service but not
+#    the Ingress. This installs ingress-nginx and maps it to a host port so traffic is real.
+set -euo pipefail
+cd "$(dirname "$0")"
+REPO=$(cd ../.. && pwd)
+
+CLUSTER="${KIND_CLUSTER:-esgame}"
+REG_NAME="${ESGAME_REGISTRY_NAME:-esgame-registry}"
+REG_PORT="${ESGAME_REGISTRY_PORT:-5001}"
+# High ports on purpose: this host already runs other stacks, and a bind conflict on 80 would
+# surface as an opaque cluster-create failure.
+HTTP_PORT="${KIND_HTTP_PORT:-8880}"
+HTTPS_PORT="${KIND_HTTPS_PORT:-8843}"
+HOSTS=(esgame.local esgame-calculation.local esgame-geoserver.local)
+
+need() { command -v "$1" >/dev/null || { echo "!! $1 not on PATH" >&2; exit 2; }; }
+
+case "${1:-}" in
+  up)
+    need kind; need kubectl
+    # Preflight: inotify. A busy host runs out of instances, and the way that surfaces is awful —
+    # `kube-proxy` CrashLoopBackOffs with "failed complete: too many open files", so Services get
+    # no routing, the ingress-nginx admission job cannot reach the API server, its cert Secret is
+    # never created, and the controller sits in ContainerCreating on a missing volume. Four
+    # unrelated-looking symptoms, ~8 minutes in, none of which name the actual cause.
+    inst=$(cat /proc/sys/fs/inotify/max_user_instances 2>/dev/null || echo 0)
+    watch=$(cat /proc/sys/fs/inotify/max_user_watches 2>/dev/null || echo 0)
+    if [ "${inst}" -lt 512 ] || [ "${watch}" -lt 524288 ]; then
+      cat >&2 <<EOF
+!! inotify limits are too low for kind on this host:
+     fs.inotify.max_user_instances = ${inst}   (kind wants >= 512)
+     fs.inotify.max_user_watches   = ${watch}   (kind wants >= 524288)
+
+   Raise them (needs root; not persistent across reboot):
+     sudo sysctl fs.inotify.max_user_instances=512
+     sudo sysctl fs.inotify.max_user_watches=524288
+
+   To persist, add both to /etc/sysctl.d/99-kind-inotify.conf.
+EOF
+      [ "${KIND_SKIP_SYSCTL_CHECK:-}" = "1" ] || exit 1
+      echo "   (KIND_SKIP_SYSCTL_CHECK=1 set — continuing anyway)" >&2
+    fi
+    if kind get clusters 2>/dev/null | grep -qx "${CLUSTER}"; then
+      echo ">> cluster ${CLUSTER} already exists"
+    else
+      # config_path makes containerd read /etc/containerd/certs.d/<registry>/hosts.toml, which is
+      # what lets us redirect localhost:5001 to the registry container by name.
+      kind create cluster --name "${CLUSTER}" --wait 180s --config=- <<EOF
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = "/etc/containerd/certs.d"
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      - containerPort: 80
+        hostPort: ${HTTP_PORT}
+        protocol: TCP
+      - containerPort: 443
+        hostPort: ${HTTPS_PORT}
+        protocol: TCP
+EOF
+    fi
+
+    echo ">> pointing containerd at the local registry"
+    for node in $(kind get nodes --name "${CLUSTER}"); do
+      docker exec "${node}" mkdir -p "/etc/containerd/certs.d/localhost:${REG_PORT}"
+      docker exec -i "${node}" cp /dev/stdin "/etc/containerd/certs.d/localhost:${REG_PORT}/hosts.toml" <<EOF
+[host."http://${REG_NAME}:5000"]
+  capabilities = ["pull", "resolve"]
+  skip_verify = true
+EOF
+    done
+
+    # Without this the nodes cannot resolve the registry's name at all.
+    if ! docker network inspect kind --format '{{range .Containers}}{{.Name}} {{end}}' | grep -qw "${REG_NAME}"; then
+      docker network connect kind "${REG_NAME}"
+      echo ">> joined ${REG_NAME} to the kind network"
+    else
+      echo ">> ${REG_NAME} already on the kind network"
+    fi
+
+    echo ">> installing ingress-nginx"
+    kubectl --context "kind-${CLUSTER}" apply -f \
+      https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.15.1/deploy/static/provider/kind/deploy.yaml
+    K=(kubectl --context "kind-${CLUSTER}")
+    "${K[@]}" -n ingress-nginx wait --for=condition=available \
+      deploy/ingress-nginx-controller --timeout=300s
+
+    # `condition=available` on the Deployment is NOT enough. ingress-nginx registers a validating
+    # webhook, and until its admission Service has endpoints every Ingress apply fails with
+    # "failed calling webhook … context deadline exceeded" — while the Deployments in the same
+    # apply succeed. That leaves a half-deployed stack and an exit code you have to notice.
+    # So wait for the thing the API server actually calls.
+    "${K[@]}" -n ingress-nginx wait --for=condition=complete job/ingress-nginx-admission-patch --timeout=180s 2>/dev/null || true
+    echo ">> waiting for the admission webhook to have endpoints"
+    for _ in $(seq 1 60); do
+      n=$("${K[@]}" -n ingress-nginx get endpointslice \
+            -l kubernetes.io/service-name=ingress-nginx-controller-admission \
+            -o jsonpath='{.items[*].endpoints[*].addresses[*]}' 2>/dev/null | wc -w)
+      [ "${n}" -ge 1 ] && break
+      sleep 3
+    done
+    [ "${n:-0}" -ge 1 ] || { echo "!! admission webhook never got endpoints; Ingress applies will fail"; exit 1; }
+    echo ">> ingress reachable on http://localhost:${HTTP_PORT} (send a Host header)"
+    ;;
+
+  deploy)
+    need kubectl
+    K=(kubectl --context "kind-${CLUSTER}")
+    # The base deliberately ships no GeoServer password — it references a Secret that does not
+    # exist in-repo, so a missing one fails the rollout instead of quietly shipping admin/geoserver.
+    if ! "${K[@]}" get secret esgame-geoserver-admin >/dev/null 2>&1; then
+      "${K[@]}" create secret generic esgame-geoserver-admin \
+        --from-literal=username=admin \
+        --from-literal=password="local-$(head -c 12 /dev/urandom | base64 | tr -dc 'A-Za-z0-9')"
+    fi
+    "${K[@]}" apply -k overlays/local-registry
+    for d in esgame-angular esgame-geoserver esgame-calculation; do
+      "${K[@]}" rollout status "deploy/${d}" --timeout=300s
+    done
+    # A Service whose selector matches nothing still applies without error, so assert endpoints.
+    for s in esgame-angular-service esgame-geoserver-service esgame-calculation-service; do
+      n=$("${K[@]}" get endpointslice -l "kubernetes.io/service-name=${s}" \
+            -o jsonpath='{.items[*].endpoints[*].addresses[*]}' | wc -w)
+      [ "${n}" -ge 1 ] || { echo "!! ${s} has no endpoints"; exit 1; }
+      echo "  ${s} -> ${n} endpoint(s)"
+    done
+    ;;
+
+  test)   exec "${REPO}/deploy/k8s/ingress-test.sh" ;;
+  down)   kind delete cluster --name "${CLUSTER}" ;;
+
+  *) sed -n '2,10p' "$0" | sed 's/^# \{0,1\}//'; exit 2 ;;
+esac

--- a/deploy/k8s/overlays/local-registry/kustomization.yaml
+++ b/deploy/k8s/overlays/local-registry/kustomization.yaml
@@ -1,0 +1,70 @@
+# Dev overlay: run the whole stack on a local cluster, pulling from the local registry.
+#
+#   deploy/registry/registry.sh up && deploy/registry/registry.sh push
+#   deploy/k8s/kind.sh up                       # cluster + ingress-nginx + registry wiring
+#   kubectl apply -k deploy/k8s/overlays/local-registry
+#
+# The base's ghcr defaults and change-me hosts are what a real deployment wants, so they are NOT
+# edited. Everything local lives here.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+# IMPORTANT: these key on the names the base rewrites images TO, not the logical names.
+# Kustomize applies the base's own images transformer first, so by the time this overlay runs
+# `esgame-angular` no longer appears anywhere — an entry keyed on it matches nothing, does not
+# warn, and leaves the ghcr image deployed. That exact mistake shipped once; see ../../README.md.
+images:
+  - name: ghcr.io/mlacayoemery/esgame
+    newName: localhost:5001/esgame
+    newTag: local
+  - name: ghcr.io/mlacayoemery/esgame-calculation
+    newName: localhost:5001/esgame-calculation
+    newTag: local
+
+patches:
+  # Real hosts, and a real IngressClass. The base leaves ingressClassName commented out because it
+  # cannot know the cluster's controller; without either a class or a cluster default, an Ingress
+  # applies cleanly and routes nothing at all, silently. kind.sh installs ingress-nginx, so:
+  - target: { kind: Ingress, name: esgame-angular-ingress }
+    patch: |
+      - op: add
+        path: /spec/ingressClassName
+        value: nginx
+      - op: replace
+        path: /spec/rules/0/host
+        value: esgame.local
+  - target: { kind: Ingress, name: esgame-calculation-ingress }
+    patch: |
+      - op: add
+        path: /spec/ingressClassName
+        value: nginx
+      - op: replace
+        path: /spec/rules/0/host
+        value: esgame-calculation.local
+  - target: { kind: Ingress, name: esgame-geoserver-ingress }
+    patch: |
+      - op: add
+        path: /spec/ingressClassName
+        value: nginx
+      - op: replace
+        path: /spec/rules/0/host
+        value: esgame-geoserver.local
+
+  # tls-acme would have cert-manager try to issue a real certificate for a .local host. Nothing
+  # is listening for the ACME challenge here, so drop the annotation rather than leave it failing.
+  - target: { kind: Ingress, annotationSelector: "kubernetes.io/tls-acme" }
+    patch: |
+      - op: remove
+        path: /metadata/annotations/kubernetes.io~1tls-acme
+
+configMapGenerator:
+  - name: esgame-config
+    behavior: merge
+    literals:
+      # Both of these are fetched by the BROWSER, so they must be the ingress hosts above — not
+      # Service names. Plain http: no TLS on a .local cluster.
+      - CALC_URL=http://esgame-calculation.local/esgame
+      - GEOSERVER_PUBLIC_URL=http://esgame-geoserver.local/geoserver

--- a/deploy/registry/README.md
+++ b/deploy/registry/README.md
@@ -1,0 +1,67 @@
+# Local image registry
+
+A throwaway registry that serves the esgame images to a local cluster.
+
+## Why this exists
+
+`esgame-calculation` is published nowhere. Kubernetes has no build step — a Deployment only pulls
+an `image:`, and Kustomize cannot build either — so *"just build it from the Dockerfile"* works for
+compose and **cannot** work for k8s. Something has to serve the image.
+
+Until it lives on a public registry, this is that something. With it, `kubectl apply -k` is
+testable end to end against a real cluster with no external dependency at all.
+
+It also removes the reason not to: the R calculation image is **~3.35 GB** and takes ~15 minutes to
+build cold. Asking every deployer to rebuild that — for the component least likely to differ
+between deployments — is the expensive option.
+
+## Use
+
+```sh
+deploy/registry/registry.sh up        # start; waits until /v2/ answers
+deploy/registry/registry.sh push      # build + push everything the manifests reference
+deploy/registry/registry.sh ls        # catalog, tags, sizes
+deploy/registry/registry.sh verify    # pull each tag back, compare digests
+deploy/registry/registry.sh down      # stop (images survive)
+deploy/registry/registry.sh purge     # stop AND drop the volume
+```
+
+| | |
+|---|---|
+| registry | <http://localhost:5001> |
+| UI | <http://localhost:8184> |
+
+`push` builds four images — `esgame` and `esgame-calculation` from this repo, plus
+`places-frontend` and `places-calculation` from `../places` when it is checked out next door
+(set `PLACES_REPO` to point elsewhere; skipped with a notice if absent). Between them that is every
+image `deploy/k8s/base` and places' overlay reference.
+
+## Notes
+
+Modeled on ord-x's `deploy/build/build-docker-registry.yml`, with two deliberate differences:
+
+- **Port 5001, not 5000.** ord-x's own registry already holds `0.0.0.0:5000` on this host, and the
+  two are separate stores — esgame images have no business in ord-x's volume.
+- **distribution v3, not `registry:2`.** v3 reads `/etc/distribution/config.yml`. Mounting a config
+  at v2's `/etc/docker/registry/config.yml` against a v3 image is **silently ignored**: the registry
+  starts happily on its built-in defaults, `delete.enabled` quietly goes away, and nothing says so.
+
+Plain HTTP, no auth. Docker treats `localhost` as insecure-by-default, so pushing from this host
+needs no `daemon.json` change. Anything *not* on this host would — and that is the point at which
+you want a real registry instead of this one.
+
+`verify` exists because a push that half-fails still leaves a tag that `ls` will happily list. It
+pulls each tag back and compares repo digests, so what the registry serves is confirmed to be what
+was built.
+
+## Pointing a cluster at it
+
+Do **not** repoint `deploy/k8s/base` — its ghcr defaults are what a real deployment wants. Use the
+dev overlay, which layers the local registry on top of the base:
+
+```sh
+kubectl apply -k deploy/k8s/overlays/local-registry
+```
+
+A kind cluster additionally needs the registry reachable from inside its nodes; see
+[`../k8s/README.md`](../k8s/README.md).

--- a/deploy/registry/docker-compose.yml
+++ b/deploy/registry/docker-compose.yml
@@ -1,0 +1,73 @@
+# A local Docker registry for the esgame images, so a cluster can PULL them.
+#
+# This exists because `esgame-calculation` is published nowhere. Kubernetes has no build step —
+# a Deployment only pulls an `image:`, and Kustomize cannot build either — so "just build from
+# the Dockerfile" works for compose and cannot work for k8s. Something has to serve the image.
+# Until it is on a public registry, this is that something, and it makes `kubectl apply -k`
+# testable end to end with no external dependency at all.
+#
+#   deploy/registry/registry.sh up          # start, wait for /v2/, print the endpoint
+#   deploy/registry/registry.sh push        # build + push everything the manifests reference
+#   deploy/registry/registry.sh ls          # what is in it
+#   deploy/registry/registry.sh down        # stop (images survive)
+#   deploy/registry/registry.sh purge       # stop AND drop the volume
+#
+#   registry  http://localhost:5001        UI  http://localhost:8184
+#
+# Modeled on ord-x's deploy/build/build-docker-registry.yml. Two deliberate differences:
+#
+#   * Port 5001, not 5000. ord-x's own registry already holds 0.0.0.0:5000 on this host, and
+#     the two are separate stores — esgame images have no business in ord-x's volume.
+#   * distribution v3, not registry:2. v3 reads /etc/distribution/config.yml; mounting a config
+#     at v2's /etc/docker/registry/config.yml is silently ignored (see registry-config.yml).
+#
+# Plain HTTP, no auth. Docker treats localhost as insecure-by-default, so pushing from this host
+# needs no daemon.json change. Anything NOT on this host would — which is the point at which you
+# should be using a real registry instead of this.
+name: esgame-registry
+
+volumes:
+  esgame_registry_data:   # survives `down`; only `purge` drops it
+
+services:
+  registry:
+    image: registry:3.1.1
+    container_name: esgame-registry
+    restart: unless-stopped
+    ports:
+      - "${ESGAME_REGISTRY_PORT:-5001}:5000"
+    volumes:
+      # v3 path. See the warning in registry-config.yml.
+      - ./registry-config.yml:/etc/distribution/config.yml:ro
+      - esgame_registry_data:/var/lib/registry
+    healthcheck:
+      # /v2/ is the API root and returns 200 once the registry is actually serving. Waiting on
+      # this rather than a sleep is what makes `registry.sh push` safe to run straight after up.
+      test: ["CMD", "wget", "-qO-", "http://localhost:5000/v2/"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+
+  # Browsable view of what was pushed — handy for confirming a 3.35 GB push actually landed,
+  # and for deleting tags to reclaim the space.
+  ui:
+    image: joxit/docker-registry-ui:2.6.0
+    container_name: esgame-registry-ui
+    restart: unless-stopped
+    ports:
+      - "${ESGAME_REGISTRY_UI_PORT:-8184}:80"
+    environment:
+      SINGLE_REGISTRY: "true"
+      REGISTRY_TITLE: esgame local registry
+      # The UI is an nginx reverse proxy in front of the registry, so the browser talks to the
+      # UI's own origin and the registry needs no CORS config. Both containers are on this
+      # compose network, so it can address the registry by service name.
+      NGINX_PROXY_PASS_URL: http://registry:5000
+      PULL_URL: localhost:${ESGAME_REGISTRY_PORT:-5001}
+      DELETE_IMAGES: "true"
+      SHOW_CONTENT_DIGEST: "true"
+      SHOW_CATALOG_NB_TAGS: "true"
+      SHOW_TAG_HISTORY: "true"
+    depends_on:
+      registry:
+        condition: service_healthy

--- a/deploy/registry/registry-config.yml
+++ b/deploy/registry/registry-config.yml
@@ -1,0 +1,29 @@
+# Registry config for distribution v3.
+#
+# NOTE THE MOUNT PATH. v2 read /etc/docker/registry/config.yml; v3 reads
+# /etc/distribution/config.yml, and its entrypoint passes that path explicitly. Mount a config
+# at the v2 path against a v3 image and it is silently ignored — the registry starts happily on
+# its built-in defaults, so `delete.enabled` quietly goes away and nothing says so.
+version: 0.1
+
+log:
+  level: info
+
+storage:
+  filesystem:
+    rootdirectory: /var/lib/registry
+  delete:
+    # Needed by the UI's delete button, and to reclaim space from an image this size:
+    # esgame-calculation is ~3.35 GB per tag.
+    enabled: true
+
+http:
+  addr: :5000
+  headers:
+    X-Content-Type-Options: [nosniff]
+
+health:
+  storagedriver:
+    enabled: true
+    interval: 10s
+    threshold: 3

--- a/deploy/registry/registry.sh
+++ b/deploy/registry/registry.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Drive the local registry: start it, fill it, inspect it, tear it down.
+#
+#   deploy/registry/registry.sh up      # start + wait until /v2/ answers
+#   deploy/registry/registry.sh push    # build + push everything the manifests reference
+#   deploy/registry/registry.sh ls      # catalog + tags + sizes
+#   deploy/registry/registry.sh verify  # pull each tag back and compare digests
+#   deploy/registry/registry.sh down    # stop (images survive)
+#   deploy/registry/registry.sh purge   # stop AND drop the volume
+#
+# `push` builds four images — the two esgame ones from this repo, and the two places ones from
+# ../places if it is checked out next door (skipped with a notice if not). Between them they are
+# every image deploy/k8s/base and places' overlay reference, which is what makes a cluster deploy
+# testable with nothing external.
+#
+# The R calculation image is ~3.35 GB and takes ~15 min to build cold. That is the whole reason
+# to have a registry rather than asking every deployer to rebuild it.
+set -euo pipefail
+cd "$(dirname "$0")"
+REPO=$(cd ../.. && pwd)
+PLACES="${PLACES_REPO:-$(cd ../../../places 2>/dev/null && pwd || true)}"
+
+PORT="${ESGAME_REGISTRY_PORT:-5001}"
+REG="localhost:${PORT}"
+DC=(docker compose -f docker-compose.yml)
+
+# Logical name -> build context. The names match what deploy/k8s/base rewrites images TO, so an
+# overlay can repoint them by name; see ../k8s/README.md on why keying on the logical name fails.
+esgame_ctx()      { echo "${REPO}/v2"; }
+calculation_ctx() { echo "${REPO}/tools/R"; }
+
+images() {
+  # name:context, one per line. places entries only if the repo is there.
+  echo "esgame:$(esgame_ctx)"
+  echo "esgame-calculation:$(calculation_ctx)"
+  if [ -n "${PLACES}" ] && [ -d "${PLACES}/calculation" ]; then
+    echo "places-frontend:${PLACES}/frontend"
+    echo "places-calculation:${PLACES}/calculation"
+  fi
+}
+
+wait_ready() {
+  for _ in $(seq 1 60); do
+    curl -fs "http://${REG}/v2/" >/dev/null 2>&1 && return 0
+    sleep 2
+  done
+  echo "!! registry did not come up on ${REG}" >&2
+  return 1
+}
+
+case "${1:-}" in
+  up)
+    # Fail early and clearly if the port is taken — ord-x's registry sits on 5000 on this host,
+    # and a bind conflict otherwise surfaces as an opaque compose error.
+    if curl -fs "http://${REG}/v2/" >/dev/null 2>&1; then
+      echo ">> a registry is already serving on ${REG}"
+    else
+      "${DC[@]}" up -d
+      wait_ready
+    fi
+    echo ">> registry  http://${REG}        UI  http://localhost:${ESGAME_REGISTRY_UI_PORT:-8184}"
+    ;;
+
+  push)
+    wait_ready
+    while IFS=: read -r name ctx; do
+      echo "==> ${name}  (context ${ctx})"
+      docker build -q -t "${REG}/${name}:local" "${ctx}" >/dev/null
+      docker push -q "${REG}/${name}:local"
+      echo "    pushed ${REG}/${name}:local  ($(docker images --format '{{.Size}}' "${REG}/${name}:local" | head -1))"
+    done < <(images)
+    if [ -z "${PLACES}" ]; then
+      echo ">> note: ../places not found, so places-frontend/places-calculation were NOT pushed"
+      echo "   set PLACES_REPO=/path/to/places to include them"
+    fi
+    ;;
+
+  ls)
+    wait_ready
+    # buildx pushes an OCI image INDEX, not a plain manifest, so the size has to be found by
+    # following the index to the linux/amd64 manifest and summing that one's layers. Grepping
+    # "size" out of the top level yields the sub-manifest sizes — a few kB — which looks like a
+    # working size column while being off by six orders of magnitude.
+    python3 - "${REG}" <<'PY'
+import json, sys, urllib.request
+reg = sys.argv[1]
+ACCEPT = ", ".join([
+    "application/vnd.oci.image.index.v1+json",
+    "application/vnd.oci.image.manifest.v1+json",
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+    "application/vnd.docker.distribution.manifest.v2+json",
+])
+def get(path):
+    r = urllib.request.Request(f"http://{reg}{path}", headers={"Accept": ACCEPT})
+    with urllib.request.urlopen(r, timeout=30) as f:
+        return json.load(f), f.headers.get("Docker-Content-Digest", "")
+def human(n):
+    for u in ("B", "kB", "MB", "GB"):
+        if n < 1024 or u == "GB":
+            return f"{n:.0f}{u}" if u == "B" else f"{n/1:.1f}{u}"
+        n /= 1024
+for repo in sorted(get("/v2/_catalog")[0].get("repositories") or []):
+    for tag in sorted(get(f"/v2/{repo}/tags/list")[0].get("tags") or []):
+        man, digest = get(f"/v2/{repo}/manifests/{tag}")
+        if "manifests" in man:                      # an index: pick the real platform image
+            sub = next((m for m in man["manifests"]
+                        if m.get("platform", {}).get("architecture") not in (None, "unknown")), None)
+            if sub:
+                man, _ = get(f"/v2/{repo}/manifests/{sub['digest']}")
+        total = man.get("config", {}).get("size", 0) + sum(l.get("size", 0) for l in man.get("layers", []))
+        print(f"  {repo + ':' + tag:<34} {human(total):>9}  {digest[:19]}…")
+print("  (compressed transfer size — `docker images` reports the larger uncompressed size)")
+PY
+    ;;
+
+  verify)
+    # The point: prove the thing IN the registry is the thing that was built, by pulling it back
+    # under a different name and comparing repo digests. A push that half-failed still leaves a
+    # tag behind that `ls` will happily list.
+    wait_ready
+    fail=0
+    while IFS=: read -r name _ctx; do
+      ref="${REG}/${name}:local"
+      local_digest=$(docker image inspect "${ref}" --format '{{index .RepoDigests 0}}' 2>/dev/null | sed 's/.*@//')
+      docker rmi "${ref}" >/dev/null 2>&1 || true
+      docker pull -q "${ref}" >/dev/null 2>&1 || { echo "  FAIL ${name}: could not pull back"; fail=1; continue; }
+      pulled_digest=$(docker image inspect "${ref}" --format '{{index .RepoDigests 0}}' 2>/dev/null | sed 's/.*@//')
+      if [ -n "${local_digest}" ] && [ "${local_digest}" = "${pulled_digest}" ]; then
+        echo "  ok   ${name}  ${pulled_digest:0:19}…"
+      else
+        echo "  FAIL ${name}: pushed ${local_digest:0:19}… != pulled ${pulled_digest:0:19}…"; fail=1
+      fi
+    done < <(images)
+    [ "${fail}" = 0 ] && echo "registry verify: PASS" || { echo "registry verify: FAIL"; exit 1; }
+    ;;
+
+  down)  "${DC[@]}" down ;;
+  purge) "${DC[@]}" down -v ;;
+
+  *)
+    sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'
+    exit 2
+    ;;
+esac

--- a/docs/reference/calculator.rst
+++ b/docs/reference/calculator.rst
@@ -549,33 +549,82 @@ the difference matters.
      - Role
    * - ``New_hexagons.tif`` (the ``Drawing`` map)
      - 465
-     - The playable board. These are the ids the frontend sends.
-   * - ``LU_and_NEW_hexa.tif`` (calculator input)
+     - The playable board: ``100``, ``200`` … ``46500``, in hundreds. These are the
+       ids the frontend sends.
+   * - ``LU_and_NEW_hexa.tif`` — **data release**
      - 472
      - The same 465, **plus 7** low values (``2``–``8``).
+   * - ``LU_and_NEW_hexa.tif`` — **committed in the repos**
+     - 462
+     - ``10``–``474`` consecutive, plus the same 7. A **different id space** — see below.
 
 Those seven extra values are fixed landscape features, not playable hexagons. The
 frontend never allocates them, and neither should anything else calling this endpoint:
 reclassifying them to a production-type code overwrites the features the model scores
 against.
 
+.. warning::
+
+   **There are two different rasters called** ``LU_and_NEW_hexa.tif``, and only one of them
+   shares an id space with the board.
+
+   The copy committed at :file:`v2/src/assets/images/LU_and_NEW_hexa.tif` (and identically at
+   places' ``frontend/assets/images/``) numbers its hexagons ``10``–``474`` consecutively.
+   The board numbers its own ``100``–``46500`` in hundreds. **Exactly 4 ids overlap**
+   (``100``, ``200``, ``300``, ``400``) out of 465 — the two rasters share an extent and a
+   100 m resolution, and nothing else.
+
+   Only the copy in the **data release** (the one ``places/scripts/fetch-geodata.sh``
+   fetches) uses the board's numbering, and it is the one a deployment must supply.
+
+   Feeding the committed copy a real frontend allocation therefore does not fail — the
+   request returns ``200``, the rasters are produced and published, the scores are finite —
+   it just reclassifies 4 hexagons out of 465 and silently leaves the rest untouched. Measured
+   on 2026-07-30 against ``tools/R``. The committed copy is fine for exercising the plumbing
+   and useless for a real game; do not read a green round against it as the model working.
+
 Doing so does not fail — the request still returns ``200``, the rasters are still
-produced, published and served. **Every score comes back ``NaN``.** Verified both ways
-against ``tools/R``:
+produced, published and served. **Every score comes back ``NaN``.**
+
+Measured against ``tools/R`` on 2026-07-30, the same 465 board ids under three different
+land-use patterns, against each raster in turn:
 
 .. list-table::
    :header-rows: 1
-   :widths: 46 16 38
+   :widths: 22 22 56
 
-   * - Allocation
-     - Scores
-     - Runtime
-   * - all 472 ids, including ``2``–``8``
-     - 5 of 5 ``NaN``
-     - 29 s
-   * - the 465 board ids only
-     - HH 42, NP 45, WA 48, HC 50, RV 44
-     - 15 s
+   * - ``LU_and_NEW_hexa.tif``
+     - Allocation
+     - HH / NP / WA / HC / RV
+   * - committed (462)
+     - mixed 6 types
+     - 42 / 45 / 48 / 50 / 44
+   * - committed (462)
+     - all ``10`` (arable)
+     - 42 / 45 / 48 / 50 / 44
+   * - committed (462)
+     - all ``60`` (nature)
+     - 42 / 45 / 48 / 50 / 44
+   * - release (472)
+     - mixed 6 types
+     - 14 / 14 / 20 / 16 / 14
+   * - release (472)
+     - all ``10`` (arable)
+     - 49 / 53 / 73 / 50 / 48
+   * - release (472)
+     - all ``60`` (nature)
+     - ``NaN`` × 5
 
-So a silently unscored round looks exactly like a successful one from the outside. If
-scores arrive as ``NaN``, suspect the allocation's id set before the model.
+Read the top three rows carefully. Against the committed raster the scores are **identical
+under every allocation** — the player's choices change nothing, because only 4 of their 465
+ids exist in that raster. ``42 / 45 / 48 / 50 / 44`` is not a result; it is that raster's
+constant. Earlier revisions of this page quoted it as evidence of a working round.
+
+Against the release raster the same three allocations give three different answers, which is
+what a responsive model looks like. Note also that an all-``60`` (Extra Nature everywhere)
+allocation — a legal move — returns ``NaN`` there; the agricultural indicators have no
+agriculture left to score.
+
+So a round that ignores its input looks exactly like one that worked, and so does a silently
+unscored one. **Two checks are worth more than reading the scores:** vary the allocation and
+confirm the numbers move, and confirm they are numbers at all.

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -50,9 +50,18 @@ Verified working
        the calculator emits only pygeoapi coverage URLs with no WCS anywhere — which is
        the evidence for the "true drop-in" claim.
    * - ``tools/R`` calculator
-     - A real round: 465-hexagon allocation POSTed to ``/esgame`` → HTTP 200 in 15s,
-       five real scores, workspace created in GeoServer, five coverages published, WCS
-       5/5 GeoTIFFs, spider plot served. Also starts with ``--network none``.
+     - The **plumbing**: 465-hexagon allocation POSTed to ``/esgame`` → HTTP 200,
+       workspace created in GeoServer, five coverages published, WCS 5/5 GeoTIFFs,
+       spider plot served. Also starts with ``--network none``. The *scores* are a
+       different matter — see "the committed base raster" under Known incomplete. This
+       row previously claimed "five real scores"; they were real numbers that did not
+       depend on the allocation.
+   * - Local registry + published images
+     - ``deploy/registry`` serves all four images the manifests reference; each was
+       pulled back and its digest compared against what was pushed. A round was then
+       driven through the ``esgame-calculation`` image **pulled from the registry**
+       (image ID confirmed identical): 200 in 58s, five finite scores, WCS 5/5, spider
+       plot PNG, and no run-time package installation.
    * - places overlay
      - Renders 11 resources, all valid under ``kubeconform -strict``; ingress-host
        patches apply; the GeoServer pin flows through from this base. 19 checks in
@@ -88,6 +97,19 @@ Placeholders must be replaced
    ``CHANGE-ME-registry/…`` image names. Keep hosts lowercase: an Ingress host must be a
    valid RFC 1123 subdomain, and the API server rejects the whole apply otherwise.
 
+The committed base raster makes the game inert
+   :file:`v2/src/assets/images/LU_and_NEW_hexa.tif` numbers its hexagons ``10``–``474``
+   while the board (``New_hexagons.tif``) numbers its own ``100``–``46500`` in hundreds.
+   **4 ids overlap out of 465.** So ``reclassify`` is very nearly a no-op and the round
+   returns the same five scores — ``42 / 45 / 48 / 50 / 44`` — for *any* allocation.
+   Verified by POSTing three different land-use patterns and getting identical output;
+   the release copy of the raster gives three different answers to the same three.
+
+   Nothing is broken in the code: a deployment is supposed to supply the real geodata,
+   and the release copy shares the board's id space. But the committed asset is only good
+   for exercising the plumbing, and a green round against it says nothing about the model.
+   See :ref:`allocation-id-space`.
+
 No default IngressClass is assumed
    The three Ingresses set no ``ingressClassName``. If the cluster has no default
    ``IngressClass`` they apply cleanly and route nothing, with no error. Check
@@ -122,6 +144,13 @@ Honest gaps, so nobody assumes otherwise.
 * **Allocations were synthetic.** Generated from the raster's id set, not produced by a
   player. They satisfy the id-space contract (see :doc:`reference/calculator`) but are
   not real play.
+* **No cluster ingress traffic yet, and now for a concrete reason.** The tooling is in
+  place — :file:`deploy/k8s/kind.sh` builds a cluster wired to the local registry and
+  installs ingress-nginx, and :file:`deploy/k8s/ingress-test.sh` drives a round through
+  it by ``Host`` header. It has not been *run* green: this host's
+  ``fs.inotify.max_user_instances`` is 128 where kind needs 512, which crash-loops
+  ``kube-proxy`` and cascades into an ingress controller that never gets its certificate.
+  Raising it needs root. ``kind.sh up`` now checks and says so up front.
 * **Timing numbers move.** Lighthouse timings swing with machine load — 57 to 90 for
   identical code on one host. Only the byte budgets are stable; compare timings A/B in
   one sitting or not at all.


### PR DESCRIPTION
## Why a registry

`esgame-calculation` is published nowhere, and **Kubernetes has no build step** — a Deployment only pulls an `image:`, and Kustomize cannot build either. So *"just build it from the Dockerfile"* works for compose and cannot work for k8s. Something has to serve the image.

`deploy/registry/` is that something: distribution **v3** on `:5001` with a browsable UI, modeled on ord-x's `deploy/build/build-docker-registry.yml`. Two deliberate differences from that model, both noted in-file — port 5001 because ord-x's own registry holds 5000 on this host, and v3 reads `/etc/distribution/config.yml` (mounting a config at v2's path is **silently ignored**, and `delete.enabled` quietly vanishes).

`registry.sh push` builds all four images the manifests reference. `registry.sh verify` pulls each back and compares digests, because a push that half-fails still leaves a tag a catalog listing happily shows.

## And a cluster that can use it

`kind.sh` sets up two things a bare `kind create cluster` does not, both of which fail silently:

- **Registry access** — `localhost:5001` inside a node means *the node*. It writes a containerd `hosts.toml` and joins the registry to kind's network.
- **An ingress controller** — the base's Ingresses set no class; with no controller they apply cleanly and route nothing.

`ingress-test.sh` then drives a full round by `Host` header, never `port-forward`, and checks the returned coverage URLs are fetchable *through the geoserver ingress*.

## Verified

- All four images pushed, digest-verified against what was built.
- A real round through the `esgame-calculation` image **pulled from the registry** (image ID confirmed identical): 200 in 58s, five finite scores, WCS 5/5 GeoTIFFs, spider plot PNG, no run-time package install.
- Overlay renders: both images repointed, three Ingresses on `class=nginx` with `.local` hosts, 10/10 `kubeconform -strict`. Docs build clean under `-W`.

## What this turned up — the calculator was ignoring the game

There are **two different rasters** named `LU_and_NEW_hexa.tif`. The one committed at `v2/src/assets/images/` numbers its hexagons `10`–`474`; the board (`New_hexagons.tif`) numbers its own `100`–`46500` in hundreds. **4 ids overlap, out of 465.**

So `reclassify()` is very nearly a no-op. Measured — same 465 board ids, three different land-use patterns:

| raster | allocation | HH | NP | WA | HC | RV |
|---|---|---|---|---|---|---|
| committed | mixed 6 types | 42 | 45 | 48 | 50 | 44 |
| committed | all `10` arable | 42 | 45 | 48 | 50 | 44 |
| committed | all `60` nature | 42 | 45 | 48 | 50 | 44 |
| release | mixed 6 types | 14 | 14 | 20 | 16 | 14 |
| release | all `10` arable | 49 | 53 | 73 | 50 | 48 |
| release | all `60` nature | NaN | NaN | NaN | NaN | NaN |

`42 / 45 / 48 / 50 / 44` is not a result — it is that raster's **constant**. And it is exactly the figure `docs/reference/calculator.rst` quoted as evidence of a working round, which `docs/verification-status.rst` recorded as *"five real scores"*, and which places' README repeats. All corrected here: they were real numbers, and they did not depend on the input.

Nothing in the code is broken — a deployment supplies the real geodata, and the release copy does share the board's id space. But the committed asset only exercises the plumbing, and a green round against it says nothing about the model. The control run also surfaced that an all-Extra-Nature allocation — a legal move — returns `NaN` on the release raster.

## Not verified, and why

The ingress round-trip has **not been run green**. This host has `fs.inotify.max_user_instances=128` where kind needs 512, which crash-loops `kube-proxy` and cascades into an ingress controller that never gets its cert — four unrelated-looking symptoms ~8 minutes in, none naming the cause. Raising it needs root. `kind.sh up` now preflights it and prints the `sysctl`. Recorded under "Not verified" rather than claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE