### PR TITLE
feat(calculator): say how much of the allocation actually landed

### DIFF
--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -77,6 +77,27 @@ jobs:
           fi
           echo "Dockerfile installs geosapi at build time"
 
+      - name: The calculator reports how much of the allocation it actually used
+        run: |
+          # reclassify() ignores ids that are not in the base raster. Silently. The committed
+          # copy of LU_and_NEW_hexa.tif shares 4 of 465 ids with the board, so a round against
+          # it returns 200, publishes every coverage, and yields the SAME five scores for any
+          # allocation — a constant this repo's own docs once quoted as a working round.
+          # coverage.R turns that into a log line, so the check is that it is still wired in.
+          test -f tools/R/coverage.R || { echo "::error::tools/R/coverage.R is missing"; exit 1; }
+          if ! grep -q 'esgame_report_coverage(LU_hexa, map_AG)' tools/R/calculator.r; then
+            echo "::error file=tools/R/calculator.r::coverage check is not called before reclassify()"; exit 1
+          fi
+          # And it must be sourced, or the call above is an undefined-function error at run time.
+          if ! grep -q 'coverage.R' tools/R/calculator.r; then
+            echo "::error file=tools/R/calculator.r::coverage.R is never sourced"; exit 1
+          fi
+          # The Dockerfile ships /app by COPY . . — assert coverage.R is not excluded.
+          if [ -f tools/R/.dockerignore ] && grep -qE '^\s*coverage\.R\s*$' tools/R/.dockerignore; then
+            echo "::error::coverage.R is excluded from the image by .dockerignore"; exit 1
+          fi
+          echo "allocation coverage check is wired into the calculator"
+
       - name: GeoServer has a separate public URL for the browser
         run: |
           # The calculator publishes coverages over GeoServer's REST API from inside the cluster

--- a/tools/R/calculator.r
+++ b/tools/R/calculator.r
@@ -54,6 +54,11 @@ library(grid)
 library(geosapi)
 library(logger)
 library(devtools)
+# Allocation-vs-raster coverage check. The Dockerfile puts this next to calculator.r in /app;
+# the plain relative path covers running it from a checkout. stopifnot rather than a silent skip:
+# a guard that quietly fails to load is worse than no guard.
+for (.p in c("coverage.R", "/app/coverage.R")) if (file.exists(.p)) { source(.p); break }
+stopifnot("coverage.R must be alongside calculator.r" = exists("esgame_report_coverage"))
 
 
 calculate<-function(req, geoserver_url, game_id, round_id,score_PD,map_AG) {
@@ -64,6 +69,14 @@ calculate<-function(req, geoserver_url, game_id, round_id,score_PD,map_AG) {
   
   ##### 1) Create Land use map #####
   LU_hexa<- raster("LU_and_NEW_hexa.tif")
+  # How much of the allocation actually lands on this raster? reclassify() silently ignores any
+  # id that is not present, so a caller whose ids belong to a different id space gets a 200, a
+  # published set of coverages, and five finite scores that are the SAME whatever they allocate.
+  # That happened: the copy of LU_and_NEW_hexa.tif committed under v2/src/assets/images numbers
+  # its hexagons 10-474 while the board numbers its own 100-46500 in hundreds — 4 ids in common
+  # out of 465 — and the constant it returns was quoted in the docs as a working round.
+  # Cheap to check, and the only thing that distinguishes "scored" from "ignored".
+  esgame_report_coverage(LU_hexa, map_AG)
   LU_complete<-reclassify(LU_hexa, map_AG, right=F) # no value can be 1!!!!
 
   #### Set parameters ####

--- a/tools/R/coverage.R
+++ b/tools/R/coverage.R
@@ -1,0 +1,59 @@
+# Does the allocation actually land on the base raster?
+#
+# raster::reclassify() ignores any id that is not present in the raster. It does not warn, it
+# does not error, and the round that follows returns 200 with a full set of published coverages
+# and finite-looking scores. If the ids belong to a different id space, those scores are a
+# constant: the same numbers whatever the player does.
+#
+# This is not hypothetical. The copy of LU_and_NEW_hexa.tif committed under
+# v2/src/assets/images numbers its hexagons 10-474; the board (New_hexagons.tif) numbers its own
+# 100-46500 in hundreds. Four ids in common out of 465. Three different land-use patterns over
+# those 465 ids returned byte-identical scores — and that constant was quoted in the docs as
+# evidence of a working round for months.
+#
+# So: say how much of the allocation matched, every time, and warn loudly when it is a small
+# fraction. Sourced by calculator.r; places' calculation.r carries the same function.
+
+esgame_allocation_ids <- function(map_AG) {
+  # The allocation arrives as a data.frame (id, lulc) via jsonlite, but tolerate a matrix or a
+  # plain vector of ids rather than failing the round over a shape this only inspects.
+  if (is.null(map_AG)) return(numeric(0))
+  if (is.data.frame(map_AG) || is.matrix(map_AG)) {
+    if (ncol(map_AG) < 1) return(numeric(0))
+    return(suppressWarnings(as.numeric(map_AG[, 1])))
+  }
+  suppressWarnings(as.numeric(map_AG))
+}
+
+# Returns the stats invisibly so a caller can assert on them; logs as a side effect.
+esgame_report_coverage <- function(LU_hexa, map_AG, warn_below = 0.5) {
+  stats <- tryCatch({
+    alloc <- unique(stats::na.omit(esgame_allocation_ids(map_AG)))
+    present <- unique(stats::na.omit(raster::values(LU_hexa)))
+    matched <- length(intersect(alloc, present))
+    list(allocated = length(alloc),
+         matched   = matched,
+         fraction  = if (length(alloc)) matched / length(alloc) else 0)
+  }, error = function(e) NULL)
+
+  # Never let a diagnostic break a round.
+  if (is.null(stats)) {
+    logger::log_warn("Could not compute allocation coverage; continuing.")
+    return(invisible(NULL))
+  }
+
+  logger::log_info(
+    "Allocation coverage: {stats$matched} of {stats$allocated} ids exist in LU_and_NEW_hexa.tif ({round(100 * stats$fraction)}%).")
+
+  if (stats$allocated == 0) {
+    logger::log_warn("Allocation is empty; the round will score the base raster unchanged.")
+  } else if (stats$fraction < warn_below) {
+    logger::log_warn(paste(
+      "Only {round(100 * stats$fraction)}% of the allocation matches the base raster, so most of it",
+      "is being IGNORED. The scores below will barely depend on the allocation, and may be identical",
+      "for every round. This usually means the allocation and /app/data/LU_and_NEW_hexa.tif are in",
+      "different id spaces - check that /app/data holds the data-release raster and not the copy",
+      "shipped in the frontend assets."))
+  }
+  invisible(stats)
+}


### PR DESCRIPTION
`raster::reclassify()` ignores ids that are not present in the base raster. **Silently.** The round that follows returns `200`, publishes every coverage, and produces finite scores — so an allocation from the wrong id space is indistinguishable from a good one by looking at the response.

Not hypothetical: the copy of `LU_and_NEW_hexa.tif` committed under `v2/src/assets/images` shares **4 of 465** ids with the board, and the constant it returns (`42/45/48/50/44`) was quoted in this repo's own documentation as evidence of a working round until yesterday (#86).

## What it does

`coverage.R` computes the overlap and logs it on every round:

```
INFO  Allocation coverage: 465 of 465 ids exist in LU_and_NEW_hexa.tif (100%).

INFO  Allocation coverage: 4 of 465 ids exist in LU_and_NEW_hexa.tif (1%).
WARN  Only 1% of the allocation matches the base raster, so most of it is being IGNORED.
      The scores below will barely depend on the allocation, and may be identical for
      every round. This usually means the allocation and /app/data/LU_and_NEW_hexa.tif
      are in different id spaces — check that /app/data holds the data-release raster
      and not the copy shipped in the frontend assets.
```

## Verified

Each branch in isolation (separate runs, so no stdout/stderr interleaving to misread):

| allocation vs raster | result |
|---|---|
| 465 board ids vs committed raster | INFO 4/465 **+ WARN** |
| 465 board ids vs release raster | INFO 465/465, no warning |
| empty allocation | INFO 0/0 + "allocation is empty" |

**Purely diagnostic.** A real round against the release raster returns exactly the scores it did before the change — HH 14, NP 14, WA 20, HC 16, RV 14, identical — and any error computing the overlap is caught, so a diagnostic can never fail a round.

Sourced rather than inlined so places' `calculation.r` can carry the identical function. Loading is a `stopifnot`, because a guard that quietly fails to load is worse than no guard.

## CI

Asserts the file exists, is sourced, is called before `reclassify()`, and is not excluded from the image. All confirmed able to fail by mutating the tree and re-running, then restored to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE