### PR TITLE
chore(tools/R): 3.35 GB → 2.58 GB, and check what the cuts could have broken

### DIFF
--- a/tools/R/Dockerfile
+++ b/tools/R/Dockerfile
@@ -1,6 +1,36 @@
 FROM rstudio/plumber
 
-RUN apt-get update -qq && apt-get install -y libssl-dev libcurl4-gnutls-dev unixodbc-dev libmysqlclient-dev
+# System libraries FIRST, then R packages. The previous order installed R packages and only
+# then the apt layers, which meant a package could install cleanly and still fail to LOAD:
+# geosapi pulls in keyring, whose shared object needs libsecret, so `requireNamespace('geosapi')`
+# was FALSE at that point in the build even though install.packages had just succeeded.
+#
+# --no-install-recommends matters here: without it this layer was 632 MB and pulled in
+# python3-numpy, libpoppler-dev and libhdf5-dev, none of which anything here uses. gdal-bin
+# (the command-line tools), protobuf-compiler, libjq-dev, unixodbc-dev and libmysqlclient-dev
+# went with it — calculator.r shells out to nothing and talks to no database.
+#
+# These are RUNTIME libraries, not -dev packages. Every R package here installs as a p3m binary
+# for noble, so it links against the shared objects and never needs headers — swapping the six
+# -dev packages for their runtime equivalents took the image from 3.10 GB to 2.58 GB.
+#
+# The trade-off: these names are tied to the Ubuntu release and the library soname
+# (libgdal34t64 is noble/GDAL 3.8). If the base image moves to a newer Ubuntu they will not
+# resolve. That fails the build immediately with "Unable to locate package", which is the good
+# kind of failure — and the load check at the end covers the subtler one. If you ever add an R
+# package that has no binary and compiles from source, add its -dev package back.
+#
+# libssl-dev and libcurl4-openssl-dev are gone too; the base already ships the runtime libssl3
+# and libcurl4 that plumber itself needs. Verified below rather than assumed.
+RUN apt-get update -qq \
+ && apt-get install -y --no-install-recommends \
+      libgdal34t64 \
+      libgeos-c1t64 \
+      libproj25 \
+      libudunits2-0 \
+      libsecret-1-0 \
+      libsodium23 \
+ && rm -rf /var/lib/apt/lists/*
 
 RUN R -e "install.packages('Rcpp')"
 RUN R -e "install.packages('sf')"
@@ -20,13 +50,30 @@ RUN R -e "install.packages('jsonlite')"
 # reachable at run time, and pulled whatever @HEAD happened to be.
 RUN R -e "install.packages('geosapi')"
 RUN R -e "install.packages('logger')"
-RUN R -e "install.packages('devtools')"
+# devtools and remotes were here. Nothing in calculator.r calls anything from either —
+# they were left over from the run-time install_github, which is long gone. devtools alone
+# was 39 MB of package-development toolchain (usethis, roxygen2, pkgdown) in a runtime image.
 
-RUN R -e "install.packages('remotes')"
+# Fail the build if anything calculator.r library()-s is not loadable. install.packages only
+# WARNS on an unavailable package — that is how install.packages('rgdal') exited 0 and installed
+# nothing for years — and a package can install fine yet fail to load when a system library is
+# missing. Loading is the real test; presence in installed.packages() is not.
+RUN R -q -e "\
+  pkgs <- c('sf','sp','raster','ggplot2','ggpubr','tidyverse','tidyr','grid','jsonlite','geosapi','logger'); \
+  bad <- pkgs[!vapply(pkgs, requireNamespace, logical(1), quietly = TRUE)]; \
+  if (length(bad)) stop('not loadable: ', paste(bad, collapse = ', ')); \
+  cat('all', length(pkgs), 'R packages load\n')"
 
-RUN apt-get install -y libcurl4-openssl-dev libssl-dev libjq-dev libprotobuf-dev protobuf-compiler make libgeos-dev libudunits2-dev libgdal-dev gdal-bin libproj-dev libv8-dev
-
-RUN apt-get install -y libsecret-1-dev libsodium-dev
+# And the two things dropping the -dev packages could plausibly have broken, checked rather than
+# assumed. sf loading proves it found libgdal/libproj; asking for the versions proves they work.
+# TLS is the other one: geosapi talks to GeoServer over https in any real deployment, and losing
+# libssl would not show up until a request failed at run time.
+RUN R -q -e "\
+  v <- sf::sf_extSoftVersion(); \
+  cat('GDAL', v[['GDAL']], '/ PROJ', v[['PROJ']], '/ GEOS', v[['GEOS']], '\n'); \
+  s <- curl::curl_fetch_memory('https://cran.r-project.org/')\$status_code; \
+  if (s != 200) stop('TLS request failed with status ', s); \
+  cat('https ok\n')"
 
 WORKDIR /app
 

--- a/tools/R/calculator.r
+++ b/tools/R/calculator.r
@@ -53,7 +53,7 @@ library(grid)
 #library(jsonlite)
 library(geosapi)
 library(logger)
-library(devtools)
+# library(devtools) was here — nothing in this file calls anything from it. See the Dockerfile.
 # Allocation-vs-raster coverage check. The Dockerfile puts this next to calculator.r in /app;
 # the plain relative path covers running it from a checkout. stopifnot rather than a silent skip:
 # a guard that quietly fails to load is worse than no guard.


### PR DESCRIPTION
The calculation image is the most expensive thing a node pulls, and the main argument against publishing it (#86). Three cuts, each verified rather than assumed.

| | on disk | compressed (what a node pulls) |
|---|---|---|
| before | 3.35 GB | 838 MB |
| after | **2.58 GB** (−23%) | **702 MB** (−16%) |

## The cuts

**System libraries, not headers (−520 MB).** Every R package here installs as a p3m binary for noble, so it links against shared objects and never needs `-dev` headers. `libssl-dev` and `libcurl4-openssl-dev` went entirely — the base already ships the runtime `libssl3`/`libcurl4` that plumber needs.

**`--no-install-recommends` + clean apt lists (−145 MB).** That layer was 632 MB and pulled in `python3-numpy`, `libpoppler-dev`, `libhdf5-dev`. `gdal-bin`, `protobuf-compiler`, `libjq-dev`, `unixodbc-dev` and `libmysqlclient-dev` went with the recommends — `calculator.r` shells out to nothing and talks to no database.

**`devtools` and `remotes` (−40 MB).** Left over from the run-time `install_github` removed months ago. Nothing calls anything from either, so `library(devtools)` is gone too — 39 MB of package-development toolchain (usethis, roxygen2, pkgdown) sitting in a runtime image.

## Also fixed: layer order

apt now runs **before** the R packages. The old order installed R packages first, which meant a package could install cleanly and still fail to *load* — `geosapi` pulls in `keyring`, whose shared object needs libsecret, so `requireNamespace('geosapi')` was `FALSE` at that point in the build even though `install.packages` had just succeeded.

## Verified

A real round against the release raster returns **exactly** the scores it did before — HH 14, NP 14, WA 20, HC 16, RV 14, identical — with WCS 5/5 GeoTIFFs.

Two new build-time assertions, because these cuts had two plausible silent failures and the build should catch them, not a deployment:

```
GDAL 3.8.4 / PROJ 9.4.0 / GEOS 3.12.1     sf found its geospatial libraries
https ok                                   TLS still works without libssl-dev
```

## Trade-off worth knowing

Runtime library names are tied to the Ubuntu release and soname (`libgdal34t64` is noble/GDAL 3.8). A newer base fails the build immediately with "Unable to locate package" — the good kind of failure. Documented in the file, along with what to do if a future package needs to compile from source.

The base image is **2.01 GB of the remaining 2.58 GB**, so anything further means changing the base — a bigger and riskier change than this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE