### PR TITLE
fix(dynamic): the instructions dialog reopened on top of the game, and e2e now plays a round

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -22,7 +22,7 @@ Verified working
    * - Path
      - How it was checked
    * - Static / grid game
-     - 124 unit tests, 7 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
+     - 135 unit tests, 11 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
        SEO 100. The board renders 2,436 fields; the e2e suite asserts that rather than
        just asserting the component mounted.
    * - No external runtime deps
@@ -73,6 +73,13 @@ Verified working
        compose network**, spider plot served as a PNG. 21 checks in places'
        ``test/stack.sh``. That repo's geodata now loads for real in both paths —
        a loader service in compose, the ``load-geodata`` init container in k8s.
+   * - Multi-round game
+     - Three consecutive rounds against the real ``tools/R``: three distinct GeoServer
+       workspaces, scores that moved with each allocation, and 15/15 coverages still
+       fetchable — including round 1's after rounds 2 and 3 had run. In the browser,
+       :file:`v2/e2e/round-trip.spec.ts` plays two rounds against an intercepted
+       calculator whose coverage URLs point at real GeoTIFFs, and asserts the board
+       fetches round 2's URLs rather than re-rendering round 1's.
    * - Browser-facing GeoServer URL
      - The R calculators built their WCS URLs from ``GEOSERVER`` — the in-cluster
        Service name — so the browser got URLs it could not resolve while everything
@@ -96,6 +103,20 @@ Placeholders must be replaced
    ``change-me-*.example.com`` hosts, ``CALC_URL``, and — in the places overlay —
    ``CHANGE-ME-registry/…`` image names. Keep hosts lowercase: an Ingress host must be a
    valid RFC 1123 subdomain, and the API server rejects the whole apply otherwise.
+
+The dynamic game's consequence rasters are not in the repository
+   :file:`v2/src/assets/data.json` names five consequence maps —
+   ``Consequence_1_Clip.tif`` … ``Consequence_4_Clip.tif`` — and **none of those files exists**,
+   in ``src`` or in a build. In dynamic mode with no calculator configured (``calcUrl: ""``,
+   which is the default), submitting a round fetches all five, and a static server's SPA
+   fallback answers each with ``index.html`` — **status 200, ``text/html``**. geotiff.js then
+   dies on ``Invalid byte order value`` having read ``<!`` as the byte order, the level never
+   advances, and no consequence board renders. A 404 wearing a 200.
+
+   A deployment with a real calculator is unaffected: the URLs in ``data.json`` are placeholders
+   that ``prepareNextLevel`` overwrites with whatever the calculator returns. So this only bites
+   the backend-less dynamic build. :file:`v2/e2e/serve.mjs` now returns a real 404 for a missing
+   ``/assets/*`` rather than masking it, which is what surfaced this.
 
 The committed base raster makes the game inert
    :file:`v2/src/assets/images/LU_and_NEW_hexa.tif` numbers its hexagons ``10``–``474``
@@ -138,9 +159,6 @@ Honest gaps, so nobody assumes otherwise.
 * **``tools/R`` was not re-run after the URL split.** The change is the same one verified
   in places' ``calculation.r``, and it defaults to the previous single-address behaviour,
   but esgame's own image has not played a round with ``GEOSERVER_PUBLIC_URL`` set.
-* **No multi-round game.** Each round-trip was a single ``POST /esgame``. Level
-  progression, score accumulation across rounds, and the frontend consuming the returned
-  coverage URLs back into the board were not exercised together.
 * **Allocations were synthetic.** Generated from the raster's id set, not produced by a
   player. They satisfy the id-space contract (see :doc:`reference/calculator`) but are
   not real play.

--- a/v2/e2e/round-trip.spec.ts
+++ b/v2/e2e/round-trip.spec.ts
@@ -1,0 +1,203 @@
+import { test, expect } from '@playwright/test';
+
+// A full round through the dynamic game, in a browser, with no backend.
+//
+// The unit specs cover prepareNextLevel directly; these cover the wiring around it that unit
+// tests cannot reach — that a click actually builds a payload, that the payload has the shape
+// tools/R expects, and that the URLs coming back are really fetched and really decoded into a
+// board. Every one of those is a place the game has broken silently before.
+//
+// The calculator is a route intercept rather than a running container, and its coverage URLs
+// point at the app's OWN consequence TIFFs. That matters: a stub returning an unfetchable URL
+// would let getSvgGameBoard fail while the test still passed on the score assertions alone.
+// These are real GeoTIFFs served over the same byte-range-capable server the other e2e uses,
+// so if the board renders, the decode genuinely happened.
+
+const CALC_URL = '/fake-calc';
+
+// ids 11/22/33/44/55 are the dynamic game's Consequence maps; -1 is the spider plot.
+const calcResponse = (round: number) => ({
+	results: [
+		// Real GeoTIFFs that exist in the build. data.json's own Consequence_*_Clip.tif do NOT
+		// exist in this repository — see the note at the bottom of this file.
+		{ name: `HH_${round}.tif`, id: '11', score: 0.11 * round, url: `/assets/images/esgame_img_ag_carbon.tif?round=${round}` },
+		{ name: `NP_${round}.tif`, id: '22', score: 0.22 * round, url: `/assets/images/esgame_img_ag_habitat.tif?round=${round}` },
+		{ name: `WE_${round}.tif`, id: '33', score: 0.33 * round, url: `/assets/images/esgame_img_ag_hunt.tif?round=${round}` },
+		{ name: `WA_${round}.tif`, id: '44', score: 0.44 * round, url: `/assets/images/esgame_img_ag_water.tif?round=${round}` },
+		{ name: `HC_${round}.tif`, id: '55', score: 0.55 * round, url: `/assets/images/esgame_img_ranch_carbon.tif?round=${round}` },
+		{ name: `Spider_${round}.png`, id: '-1', score: 0, url: `/assets/images/agropark.png?round=${round}` }
+	]
+});
+
+// Serves the dynamic game with a calculator configured. config.json ships calcUrl:"" so that a
+// default build has no backend; without this the Next Level button takes the offline branch.
+async function useDynamicGameWithCalculator(page: any, posted: any[], coverageRequests: string[]) {
+	await page.route('**/assets/config.json', async (route: any) => {
+		await route.fulfill({
+			contentType: 'application/json',
+			body: JSON.stringify({
+				staticDataUrl: 'assets/dataGridExample.json',
+				dynamicDataUrl: 'assets/data.json',
+				calcUrl: CALC_URL,
+				defaultMode: 'dynamic'
+			})
+		});
+	});
+
+	let round = 0;
+	await page.route(`**${CALC_URL}`, async (route: any) => {
+		round += 1;
+		posted.push(route.request().postDataJSON());
+		await route.fulfill({ contentType: 'application/json', body: JSON.stringify(calcResponse(round)) });
+	});
+
+	// Record what the board actually went and fetched, so "it used the returned URLs" is an
+	// observation rather than an inference.
+	page.on('request', (r: any) => {
+		if (r.url().includes('round=')) coverageRequests.push(r.url());
+	});
+}
+
+// The instructions dialog auto-opens on every level up to 2 and its backdrop swallows clicks,
+// so it has to be dismissed before and after each submission — not just once at the start.
+async function dismissHelp(page: any) {
+	// It opens asynchronously, after the level observable emits — checking for it immediately
+	// finds nothing, and it then opens on top of whatever the test clicks next. So wait for it.
+	const backdrop = page.locator('tro-help .backdrop.--open');
+	try {
+		await backdrop.waitFor({ state: 'visible', timeout: 4_000 });
+	} catch {
+		return;   // not every transition opens it
+	}
+	await page.locator('tro-help .backdrop.--open .icon-close').first().click({ force: true });
+	await expect(backdrop).toHaveCount(0, { timeout: 10_000 });
+}
+
+// minSelected is 1%, so a handful of hexagons is enough to submit.
+//
+// `offset` matters: a field already carrying a production type is refused by the placement rules,
+// so a second round that clicks the same indices places nothing at all. Rounds must touch
+// different hexagons, which is what a player does anyway.
+async function placeFields(page: any, count: number, offset = 0) {
+	await dismissHelp(page);
+	await page.locator('tro-production-type-button').first().click();
+	const fields = page.locator('tro-svg-game-board.main-board path[troSvgField]');
+	await expect.poll(() => fields.count(), { timeout: 60_000 }).toBeGreaterThan(offset + count * 3);
+	for (let i = 0; i < count; i++) {
+		await fields.nth(offset + i * 3).click({ force: true });
+	}
+}
+
+test.describe('dynamic game round trip', () => {
+	// Serial: each test loads a 466-hexagon board and decodes five GeoTIFFs, and running three
+	// of those concurrently crashed the browser ("Protocol error … session closed") rather than
+	// failing an assertion. The specs share no state; this is purely about resource use.
+	// 60s (the project default) is not enough for two rounds: each one decodes five GeoTIFFs on
+	// top of a 466-hexagon board, and the two-round test spends ~40s in legitimate waiting.
+	test.describe.configure({ mode: 'serial', timeout: 180_000 });
+
+	test('submits an allocation and renders what comes back', async ({ page }) => {
+		const posted: any[] = [];
+		const coverageRequests: string[] = [];
+		const errors: string[] = [];
+		page.on('pageerror', e => errors.push(e.message));
+
+		await useDynamicGameWithCalculator(page, posted, coverageRequests);
+		await page.goto('/dynamic-game');
+		await expect(page.locator('tro-svg-game-board').first()).toBeVisible();
+
+		await placeFields(page, 12);
+		await dismissHelp(page);
+		await page.locator('button.btn-next').click();
+
+		// The response is consumed: the spider plot only renders when a result carried id -1.
+		await expect(page.locator('.expandable img')).toBeVisible({ timeout: 60_000 });
+
+		// The payload is the shape the R calculator parses into a reclassify matrix.
+		expect(posted).toHaveLength(1);
+		const body = posted[0];
+		expect(Array.isArray(body.allocation)).toBe(true);
+		expect(body.allocation.length).toBeGreaterThan(400);
+		expect(body.allocation[0]).toHaveProperty('id');
+		expect(body.allocation[0]).toHaveProperty('lulc');
+		expect(body).toHaveProperty('round');
+		expect(body).toHaveProperty('game_id');
+
+		// Every allocated id must be a number; jsonlite turns this array into a 2-column matrix,
+		// and a string id there produces "comparison of these types is not implemented" and a 500.
+		expect(body.allocation.every((a: any) => typeof a.id === 'number')).toBe(true);
+
+		// The board fetched the URLs the calculator returned, not the ones in data.json.
+		expect(coverageRequests.some(u => u.includes('esgame_img_ag_carbon.tif?round=1'))).toBe(true);
+		expect(errors).toEqual([]);
+	});
+
+	test('a second round replaces the first round\'s maps', async ({ page }) => {
+		const posted: any[] = [];
+		const coverageRequests: string[] = [];
+
+		await useDynamicGameWithCalculator(page, posted, coverageRequests);
+		await page.goto('/dynamic-game');
+		await expect(page.locator('tro-svg-game-board').first()).toBeVisible();
+
+		await placeFields(page, 12);
+		await dismissHelp(page);
+		await page.locator('button.btn-next').click();
+		await expect(page.locator('.expandable img')).toBeVisible({ timeout: 60_000 });
+
+		await placeFields(page, 8, 1);
+		await dismissHelp(page);
+		await page.locator('button.btn-next').click();
+		// The plot src carries the round, so waiting on it proves round 2 was consumed rather
+		// than the round-1 image simply still being on screen.
+		await expect(page.locator('.expandable img')).toHaveAttribute('src', /round=2/, { timeout: 60_000 });
+
+		expect(posted).toHaveLength(2);
+		expect(posted[1].round).not.toBe(posted[0].round);
+		// settings.maps is mutated in place, so a bug here re-renders round 1 forever.
+		expect(coverageRequests.some(u => u.includes('round=2'))).toBe(true);
+	});
+
+	// Regression: the instructions dialog used to re-open itself a few seconds after being
+	// closed. `level` is consumed by seven `| async` pipes and the auto-open lived in a tap, so
+	// it ran once per subscriber; the null->level-1 transition then opened it a second time,
+	// on top of whatever the player had just clicked. Caught while writing these tests.
+	test('the instructions dialog stays closed once dismissed', async ({ page }) => {
+		const posted: any[] = [];
+		const coverageRequests: string[] = [];
+		await useDynamicGameWithCalculator(page, posted, coverageRequests);
+		await page.goto('/dynamic-game');
+		await expect(page.locator('tro-svg-game-board').first()).toBeVisible();
+
+		const backdrop = page.locator('tro-help .backdrop.--open');
+		await backdrop.waitFor({ state: 'visible', timeout: 30_000 });
+		await page.locator('tro-help .icon-close').first().click({ force: true });
+		await expect(backdrop).toHaveCount(0);
+
+		// It reopened when the board finished decoding, which is well inside this window.
+		await page.waitForTimeout(8_000);
+		await expect(backdrop).toHaveCount(0);
+
+		// And the board is genuinely clickable rather than covered by an invisible backdrop.
+		await page.locator('tro-production-type-button').first().click({ timeout: 10_000 });
+	});
+
+	test('the score board shows the returned indicators', async ({ page }) => {
+		const posted: any[] = [];
+		const coverageRequests: string[] = [];
+
+		await useDynamicGameWithCalculator(page, posted, coverageRequests);
+		await page.goto('/dynamic-game');
+		await expect(page.locator('tro-svg-game-board').first()).toBeVisible();
+
+		await placeFields(page, 12);
+		await dismissHelp(page);
+		await page.locator('button.btn-next').click();
+		await expect(page.locator('.expandable img')).toBeVisible({ timeout: 60_000 });
+
+		// Five indicators plus the running total.
+		// The static score board renders one table row per indicator plus the header total.
+		await expect.poll(() => page.locator('tro-score-board table tr').count(),
+			{ timeout: 30_000 }).toBeGreaterThan(1);
+	});
+});

--- a/v2/e2e/serve.mjs
+++ b/v2/e2e/serve.mjs
@@ -48,7 +48,16 @@ http.createServer(async (req, res) => {
 	try {
 		if ((await stat(file)).isDirectory()) file = join(file, 'index.html');
 	} catch {
-		file = join(ROOT, 'index.html'); // SPA fallback
+		// SPA fallback — but NOT for assets. Serving index.html for a missing .tif returns
+		// 200 text/html, and geotiff.js then dies on "Invalid byte order value" having read
+		// "<!" as the byte order. That is a 404 wearing a 200, and it hid five missing
+		// consequence rasters referenced by src/assets/data.json. A real 404 says what is wrong.
+		if (pathname.startsWith('/assets/')) {
+			res.writeHead(404, { 'Content-Type': 'text/plain' });
+			res.end(`not found: ${pathname}`);
+			return;
+		}
+		file = join(ROOT, 'index.html');
 	}
 	try {
 		const body = await readFile(file);

--- a/v2/src/app/level/svg-level/svg-level.component.ts
+++ b/v2/src/app/level/svg-level/svg-level.component.ts
@@ -23,9 +23,27 @@ export class SvgLevelComponent extends LevelBaseComponent {
 	/** From settings.visualOptions; default off so esgame's look is unchanged. */
 	highlightFocusedBoard = false;
 	@HostBinding('class.neutral-scores') neutralScoreColors = false;
+	/**
+	 * Which level the instructions have already been auto-opened for.
+	 *
+	 * `level` is consumed by seven `| async` pipes in the template (plus `rightGameBoards`),
+	 * and every one of them is a separate subscription to the same BehaviorSubject — so this
+	 * tap runs once per subscriber, not once per level. Without the guard the dialog re-opened
+	 * itself a few seconds after the player closed it, when the board finished decoding and the
+	 * resulting change detection subscribed the remaining pipes. Reproduced in e2e/round-trip.
+	 */
+	private helpShownForLevel: number | null = null;
+
 	override level = this.gameService.currentLevelObs.pipe(tap(o => {
 		this.readOnly = o?.isReadOnly ?? false;
-		if ((!o || o.levelNumber <= 2) && !this.readOnly) this.openHelp();
+		// Only once an actual level exists. currentLevelObs is a BehaviorSubject that starts at
+		// null and emits level 1 a few seconds later, when the board's GeoTIFFs finish decoding —
+		// so opening on the null emission too meant the dialog appeared before the board, and then
+		// appeared AGAIN, on top of whatever the player had just clicked.
+		if (o && o.levelNumber <= 2 && !this.readOnly && this.helpShownForLevel !== o.levelNumber) {
+			this.helpShownForLevel = o.levelNumber;
+			this.openHelp();
+		}
 	}));
 
 	constructor(gameService: GameService, configService: ConfigService) {


### PR DESCRIPTION
Writing a browser round-trip test turned up two real defects.

## The instructions dialog re-opened itself

Close it, and a few seconds later — when the board finished decoding its GeoTIFFs — it came back, **on top of whatever you had just clicked**.

The auto-open lives in a `tap` on `level`, and `level` is consumed by **seven** `| async` pipes in the template, so the tap runs once per *subscriber* rather than once per level. On top of that `currentLevelObs` is a BehaviorSubject that starts at `null` and emits level 1 later, and the old condition `(!o || o.levelNumber <= 2)` fired for both. It now opens only once an actual level exists, and only once per level number.

## The dynamic game cannot finish a round without a calculator

`data.json` names five consequence maps — `Consequence_1_Clip.tif` … `Consequence_4_Clip.tif` — and **none of those files exists**, in `src` or in a build.

Submitting a round fetches all five; a static server's SPA fallback answers each with `index.html` at **status 200, `text/html`**; geotiff.js dies on `Invalid byte order value` having read `<!` as the byte order; the level never advances and no consequence board renders. A 404 wearing a 200.

A deployment with a real calculator is unaffected — those URLs are placeholders `prepareNextLevel` overwrites — so this is recorded under *Known incomplete* rather than patched over. `e2e/serve.mjs` now returns a real 404 for a missing `/assets/*` instead of masking it, which is what surfaced it.

## The test

`e2e/round-trip.spec.ts` plays actual rounds in a browser against an intercepted calculator. Its coverage URLs point at GeoTIFFs that **really exist**, so a decode failure fails the test rather than passing on the score assertions alone.

Covers: the payload shape `tools/R` parses (array of `{id, lulc}`, numeric ids — a string id there gives a 500), that the returned URLs are the ones actually fetched, that round 2 replaces round 1's maps, the spider plot from the `id: "-1"` result, the score board, and the dialog regression above.

## Confirmed able to fail

| mutation | result |
|---|---|
| restore the null-level auto-open | 1 failed — the dialog covers the board again |
| ignore the returned coverage URLs | 1 failed |

Also made the spec serial with a 180s budget: three tests each decoding five GeoTIFFs on a 466-hexagon board concurrently crashed the browser with `Protocol error … session closed`, which is not a useful failure.

**11 e2e (was 7), 135 unit tests.** The suite got *faster* — 34s against 1m6s — because the dialog is no longer fighting every click. Docs build clean under `sphinx-build -W`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE