### PR TITLE
docs: correct what a missing asset actually does — the container 404s, the test server did not

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,8 @@ jobs:
           retention-days: 7
 
       # Bundle-size + Core Web Vitals gate. The Angular `initial` budget only warns,
-      # so this is what actually fails a regression. Reuses e2e/serve.mjs (same SPA
-      # fallback as the container's nginx) and the build produced above.
+      # so this is what actually fails a regression. Reuses e2e/serve.mjs, which matches
+      # the container's nginx: SPA fallback for routes, a real 404 for a missing asset.
       - name: Lighthouse CI
         env:
           CHROME_PATH: /usr/bin/google-chrome

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -108,15 +108,20 @@ The dynamic game's consequence rasters are not in the repository
    :file:`v2/src/assets/data.json` names five consequence maps —
    ``Consequence_1_Clip.tif`` … ``Consequence_4_Clip.tif`` — and **none of those files exists**,
    in ``src`` or in a build. In dynamic mode with no calculator configured (``calcUrl: ""``,
-   which is the default), submitting a round fetches all five, and a static server's SPA
-   fallback answers each with ``index.html`` — **status 200, ``text/html``**. geotiff.js then
-   dies on ``Invalid byte order value`` having read ``<!`` as the byte order, the level never
-   advances, and no consequence board renders. A 404 wearing a 200.
+   which is the default), submitting a round fetches all five, they all fail, the level never
+   advances, and no consequence board renders.
+
+   The container is honest about it: :file:`v2/nginx.conf` matches ``.tif`` with
+   ``try_files $uri =404``, so a missing raster returns a real **404** — verified against the
+   published image. The *test* server was not. :file:`v2/e2e/serve.mjs` fell back to
+   ``index.html`` for everything, so the same request came back **200 ``text/html``** and
+   geotiff.js died on ``Invalid byte order value`` having read ``<!`` as the byte order. That
+   divergence is why the missing files went unnoticed; serve.mjs now 404s ``/assets/*`` like
+   nginx does.
 
    A deployment with a real calculator is unaffected: the URLs in ``data.json`` are placeholders
    that ``prepareNextLevel`` overwrites with whatever the calculator returns. So this only bites
-   the backend-less dynamic build. :file:`v2/e2e/serve.mjs` now returns a real 404 for a missing
-   ``/assets/*`` rather than masking it, which is what surfaced this.
+   the backend-less dynamic build.
 
 The committed base raster makes the game inert
    :file:`v2/src/assets/images/LU_and_NEW_hexa.tif` numbers its hexagons ``10``–``474``

--- a/v2/e2e/serve.mjs
+++ b/v2/e2e/serve.mjs
@@ -48,10 +48,13 @@ http.createServer(async (req, res) => {
 	try {
 		if ((await stat(file)).isDirectory()) file = join(file, 'index.html');
 	} catch {
-		// SPA fallback — but NOT for assets. Serving index.html for a missing .tif returns
-		// 200 text/html, and geotiff.js then dies on "Invalid byte order value" having read
-		// "<!" as the byte order. That is a 404 wearing a 200, and it hid five missing
-		// consequence rasters referenced by src/assets/data.json. A real 404 says what is wrong.
+		// SPA fallback — but NOT for assets, because the container does not fall back either.
+		// nginx.conf matches .tif/.js/.css/fonts/config.json with `try_files $uri =404`, so a
+		// missing raster returns a real 404 there (verified against the published image). This
+		// server used to answer the same request with index.html at 200 text/html, and geotiff.js
+		// died on "Invalid byte order value" having read "<!" as the byte order — a 404 wearing a
+		// 200, and less faithful than production, which is how five missing consequence rasters
+		// referenced by src/assets/data.json went unnoticed.
 		if (pathname.startsWith('/assets/')) {
 			res.writeHead(404, { 'Content-Type': 'text/plain' });
 			res.end(`not found: ${pathname}`);


### PR DESCRIPTION
Yesterday's entry (#90) said a missing consequence raster comes back as `200 text/html` from a static server's SPA fallback. **That is what the test server did. It is not what ships.**

Checked against the published image rather than assumed:

| request | result |
|---|---|
| existing `.tif` | `200 image/tiff` |
| **missing `.tif`** | **`404`** ← `nginx.conf: try_files $uri =404` |
| unknown route | `200 index.html` ← the SPA fallback, correctly scoped |

`v2/nginx.conf` has always matched `.tif`/`.js`/`.css`/fonts/`config.json` with `try_files $uri =404`; only the catch-all `location /` falls back. So the container was honest and `e2e/serve.mjs` was not — it fell back for *everything*, turning a 404 into a 200 with an HTML body. That's why geotiff.js reported `Invalid byte order value` rather than a fetch failure, and why five missing rasters referenced by `src/assets/data.json` went unnoticed for so long.

**So the `serve.mjs` change in #90 did not introduce a divergence from production — it removed one.** I had it backwards in the docs.

The finding itself stands: those five files really are absent, and the backend-less dynamic game really cannot finish a round. Only the *symptom* differs between the two servers.

Also fixes the `ci.yml` comment claiming `serve.mjs` had "the same SPA fallback as the container's nginx" — it does now, but it didn't when that was written.

11 e2e pass; docs build clean under `sphinx-build -W`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE