### PR TITLE
fix(game): a level that fails to build now says so, instead of nothing

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -136,6 +136,19 @@ The committed base raster makes the game inert
    for exercising the plumbing, and a green round against it says nothing about the model.
    See :ref:`allocation-id-space`.
 
+The loading spinner does not clear when a level fails to build
+   ``prepareNextLevel`` now handles the error, clears the loading counter and tells the player
+   (:file:`v2/src/app/services/game.service.ts`, ``failLevel``) — before, a failed raster fetch
+   left the counter pushed, the level unchanged and nothing said at all. The **spinner itself
+   still does not disappear.** ``LoadingIndicatorComponent``'s subscriber does receive the
+   cleared value — verified in a browser, it runs with ``length 0`` — but its
+   ``@HostBinding('class.show')`` never reaches the DOM: the error arrives from outside Angular's
+   zone, and a host binding is evaluated by the *parent* view, not the component's own. Both
+   ``cdRef.detectChanges()`` in the component and ``NgZone.run()`` in its subscriber were tried
+   and neither updated it. Reachable today only in offline dynamic mode, which cannot finish a
+   round anyway (see above); a deployment with a working calculator does not hit it unless a
+   returned coverage URL fails.
+
 No default IngressClass is assumed
    The three Ingresses set no ``ingressClassName``. If the cluster has no default
    ``IngressClass`` they apply cleanly and route nothing, with no error. Check

--- a/v2/src/app/services/game.service.loading.spec.ts
+++ b/v2/src/app/services/game.service.loading.spec.ts
@@ -1,0 +1,135 @@
+import { firstValueFrom, of, throwError } from 'rxjs';
+import { GameService } from './game.service';
+import { GameBoardType } from '../shared/models/game-board-type';
+import { CalculationResult } from '../shared/models/calculation-result';
+
+// The loading indicator is a push/pop counter: loading() pushes, loading(false) pops, and the
+// spinner shows while the array is non-empty. prepareNextLevel pushes on entry and pops in the
+// subscribe body — so anything that makes the observable error instead of emit left the counter
+// pushed and the spinner up forever, over a board still showing the previous level.
+//
+// That is not hypothetical: the dynamic game's five consequence rasters are not in the build, so
+// in offline dynamic mode every round hit exactly this. Observed in a browser before the fix —
+// spinner visible, level still 1, no error shown, nothing dismissable.
+
+const translateStub: any = { getLangs: () => [], setTranslation: () => { } };
+const scoreStub: any = { createEmptyScoreEntry: () => [], calculateScore: () => { } };
+
+const settingsData = {
+	title: { en: 'T' },
+	mapMode: 'svg',
+	elementSize: 1,
+	gameBoardColumns: 4,
+	gameBoardRows: 4,
+	productionTypes: [],
+	customColors: [{ id: 'cc', colors: [{ number: 0, color: '#000000' }, { number: 1, color: '#ffffff' }] }],
+	maps: [
+		{ id: '-3', gameBoardType: 'Drawing', urlToData: 'drawing.tif', productionTypes: [] },
+		{ id: '-2', gameBoardType: 'Background', urlToData: 'bg.tif', customColorId: 'cc', productionTypes: [] },
+		{ id: '11', gameBoardType: 'Consequence', urlToData: 'c11.tif', productionTypes: [] }
+	]
+};
+
+const result: CalculationResult = {
+	results: [
+		{ name: 'HH.tif', id: '11', score: 0.1, url: 'http://gs/wcs?coverageId=ws:HH' },
+		{ name: 'S.png', id: '-1', score: 0, url: 'http://calc/images/S.png' }
+	]
+};
+
+// getSvgGameBoard is what fetches and decodes a consequence raster — the call that 404s.
+const makeService = (opts: { failBoard?: boolean, failBackground?: boolean, failInit?: boolean } = {}) => {
+	// initialiseSVGMode fetches the background too, so failing it outright would break startup
+	// rather than the round. Succeed once (init), fail afterwards — unless failInit is set, which
+	// is how the startup path itself gets tested.
+	let backgroundCalls = 0;
+	const tiffStub: any = {
+		getOverlayGameBoard: (id: any, url: string, t: any) => of({ id, gameBoardType: t, urlToData: url }),
+		getSvgBackground: () => {
+			backgroundCalls += 1;
+			const fail = opts.failInit || (opts.failBackground && backgroundCalls > 1);
+			return fail ? throwError(() => new Error('404 background')) : of({ id: 'bg' });
+		},
+		getSvgGameBoard: (id: any, url: string, t: any) => opts.failBoard
+			? throwError(() => new Error('404 consequence raster'))
+			: of({ id, gameBoardType: t, urlToData: url })
+	};
+	const service = new GameService(tiffStub, scoreStub, translateStub, {} as any);
+	service.loadSettings(JSON.parse(JSON.stringify(settingsData)));
+	service.initialiseSVGMode();
+	return service;
+};
+
+const isLoading = (service: GameService) =>
+	firstValueFrom(service.loadingIndicatorObs).then(a => a.length > 0);
+
+describe('GameService loading indicator', () => {
+	// alert() is not implemented in jsdom and would log an error per call.
+	let alertSpy: any;
+	beforeEach(() => {
+		alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => { });
+		vi.spyOn(console, 'error').mockImplementation(() => { });
+	});
+	afterEach(() => vi.restoreAllMocks());
+
+	it('stops loading once a level is built', async () => {
+		const service = makeService();
+
+		service.prepareNextLevel(result, 40);
+
+		expect(await isLoading(service)).toBe(false);
+	});
+
+	it('stops loading when a consequence raster fails to load', async () => {
+		const service = makeService({ failBoard: true });
+
+		service.prepareNextLevel(result, 40);
+
+		expect(await isLoading(service)).toBe(false);
+	});
+
+	it('stops loading when the background fails to load', async () => {
+		const service = makeService({ failBackground: true });
+
+		service.prepareNextLevel(result, 40);
+
+		expect(await isLoading(service)).toBe(false);
+	});
+
+	it('tells the player something went wrong rather than failing silently', async () => {
+		const service = makeService({ failBoard: true });
+
+		service.prepareNextLevel(result, 40);
+
+		expect(alertSpy).toHaveBeenCalled();
+	});
+
+	it('does not advance the level when building it failed', async () => {
+		const service = makeService({ failBoard: true });
+		const before = (await firstValueFrom(service.currentLevelObs))!.levelNumber;
+
+		service.prepareNextLevel(result, 40);
+
+		expect((await firstValueFrom(service.currentLevelObs))!.levelNumber).toBe(before);
+	});
+
+	// Same defect, earlier: initialiseSVGMode/initialiseGridMode also push the counter and pop it
+	// only in the subscribe body, so a raster missing at STARTUP left the spinner up over an empty
+	// board — before the player had done anything at all.
+	it('stops loading when the game fails to initialise', async () => {
+		const service = makeService({ failInit: true });
+
+		expect(await isLoading(service)).toBe(false);
+		expect(alertSpy).toHaveBeenCalled();
+	});
+
+	it('leaves no residual loading after several failed rounds', async () => {
+		const service = makeService({ failBoard: true });
+
+		service.prepareNextLevel(result, 40);
+		service.prepareNextLevel(result, 50);
+		service.prepareNextLevel(result, 60);
+
+		expect(await isLoading(service)).toBe(false);
+	});
+});

--- a/v2/src/app/services/game.service.ts
+++ b/v2/src/app/services/game.service.ts
@@ -212,7 +212,7 @@ export class GameService {
 				this.currentLevel.next(level);
 				this.selectedFields.next(this.selectedFields.value);
 				this.loading(false);
-			});
+			}, (err) => this.failLevel(err));
 		} else if (this.settings.value.mode == 'SVG') {
 			const overlay = this.currentLevel.value!.gameBoards.find(o => o.gameBoardType == GameBoardType.DrawingMap)!;
 			const backgroundMap = settings.maps.find(o => o.gameBoardType == GameBoardType.BackgroundMap)!;
@@ -253,7 +253,7 @@ export class GameService {
 					this.currentLevel.next(level);
 					this.selectedFields.next(this.selectedFields.value);
 					this.loading(false);
-				});
+				}, (err) => this.failLevel(err));
 		}
 	}
 
@@ -308,7 +308,7 @@ export class GameService {
 			this.currentLevel.next(level);
 			this.focusedGameBoard.next(gameBoards.find(o => o.gameBoardType == GameBoardType.DrawingMap)!);
 			this.loading(false);
-		});
+		}, (err) => this.failLevel(err));
 
 	}
 
@@ -342,7 +342,7 @@ export class GameService {
 			this.currentLevel.next(level);
 			this.focusedGameBoard.next(gameBoards[0]);
 			this.loading(false);
-		});
+		}, (err) => this.failLevel(err));
 
 	}
 
@@ -354,6 +354,31 @@ export class GameService {
 	}
 
 	openHelp(close = false) { this.helpWindow.next(!close); }
+
+	/**
+	 * A level failed to build. Without this the loading spinner ran forever: prepareNextLevel
+	 * fetches every consequence map, and if one of them fails — a 404 for a raster that is not
+	 * in the build, say — the combineLatest errors, the subscribe body never runs, and nothing
+	 * ever calls loading(false). The board stayed on the old level behind a spinner that could
+	 * not be dismissed, with no indication that anything had gone wrong.
+	 *
+	 * Same shape as the POST failure path above, which already did this.
+	 */
+	private failLevel(err: unknown) {
+		console.error(err);
+		// Clear the counter rather than popping one entry: loading() is a push/pop stack and a
+		// failed build is terminal, so nothing is loading any more whatever else had been pushed.
+		//
+		// NOTE: this makes the state correct, and the alert below means the player is told. It
+		// does NOT currently make the spinner disappear — the LoadingIndicatorComponent receives
+		// the cleared value (its subscriber runs with length 0) but its @HostBinding('class.show')
+		// never reaches the DOM, because the error arrives from outside Angular's zone and a host
+		// binding is evaluated by the PARENT view. detectChanges() on the component's own view
+		// and NgZone.run() in the subscriber were both tried and neither updated it. Left for a
+		// separate change rather than shipping a guess; see docs/verification-status.rst.
+		this.loadingIndicator.next([]);
+		alert("Something went wrong, please try again later");
+	}
 
 	loading(show = true) {
 		if (show) {


### PR DESCRIPTION
`prepareNextLevel` and both `initialise*` paths subscribed **without an error handler**. If any raster failed to load — a 404 for a file that isn't in the build, say — the `combineLatest` errored, the subscribe body never ran, and nothing called `loading(false)`. The board stayed on the previous level behind a spinner, with no message and nothing to dismiss.

Observed in a browser: click Next Level in offline dynamic mode, wait, and that's all that happens.

All four subscribe sites now route errors to `failLevel`, which clears the loading counter, logs, and tells the player — the same shape the POST failure path already used. It *clears* rather than popping one entry: `loading()` is a push/pop stack and a failed build is terminal. Popping one was measurably not enough.

## What this does not fix

I'd rather say so than let the title imply otherwise. **The spinner still doesn't disappear.**

`LoadingIndicatorComponent`'s subscriber *does* receive the cleared value — verified in a browser, it runs with `length 0` — but its `@HostBinding('class.show')` never reaches the DOM. The error arrives from outside Angular's zone, and a host binding is evaluated by the **parent** view rather than the component's own. `cdRef.detectChanges()` in the component and `NgZone.run()` in its subscriber were both tried; neither updated it. That's a rendering problem in a different component and it isn't going in as a guess — recorded under *Known incomplete*.

So what lands is: the failure is handled, the state is correct, and the player is told something went wrong. Strictly better than silence.

## Confirmed able to fail

| mutation | result |
|---|---|
| all four error handlers removed | 5 failed |
| handler no longer clears the counter | 4 failed |

The specs also caught the same defect one step earlier — `initialiseSVGMode`/`initialiseGridMode` had it too, so a raster missing at **startup** hung the game before the player did anything.

**163 unit tests** (was 156), **11 e2e**. Docs build clean under `-W`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE