### PR TITLE
test(production-type-button): cover how a player picks what to place

### DIFF
--- a/v2/src/app/product-type-button/production-type-button.component.spec.ts
+++ b/v2/src/app/product-type-button/production-type-button.component.spec.ts
@@ -1,0 +1,120 @@
+import { BehaviorSubject } from 'rxjs';
+import { ProductionTypeButtonComponent } from './production-type-button.component';
+import { ProductionType } from '../shared/models/production-type';
+
+// The production-type buttons are how a player chooses what to place, so a regression here
+// breaks the game outright — nothing can be placed and nothing says why. Constructed directly
+// with a stub service rather than through TestBed; the component uses three members of it.
+
+const productionType = (id: number, colour = '#123456') =>
+	new ProductionType(id, colour, null as any, '', 0);
+
+const setup = (opts: { imageMode?: boolean } = {}) => {
+	const settings = new BehaviorSubject<any>({ imageMode: opts.imageMode ?? false });
+	const selected = new BehaviorSubject<ProductionType | null>(null);
+	const chosen: ProductionType[] = [];
+	const gameStub: any = {
+		settingsObs: settings,
+		selectedProductionTypeObs: selected,
+		setSelectedProductionType: (pt: ProductionType) => chosen.push(pt)
+	};
+	return { settings, selected, chosen, make: () => new ProductionTypeButtonComponent(gameStub) };
+};
+
+describe('ProductionTypeButtonComponent', () => {
+
+	it('is inactive until its own type is selected', () => {
+		const { make } = setup();
+		const pt = productionType(1);
+		const c = make();
+		c.productionType = pt;
+
+		c.ngOnInit();
+
+		expect(c.isActive).toBe(false);
+	});
+
+	it('becomes active when its own type is selected', () => {
+		const { selected, make } = setup();
+		const pt = productionType(1);
+		const c = make();
+		c.productionType = pt;
+		c.ngOnInit();
+
+		selected.next(pt);
+
+		expect(c.isActive).toBe(true);
+	});
+
+	it('does not activate for a different type', () => {
+		const { selected, make } = setup();
+		const c = make();
+		c.productionType = productionType(1);
+		c.ngOnInit();
+
+		selected.next(productionType(2));
+
+		expect(c.isActive).toBe(false);
+	});
+
+	// The comparison is `o == this.productionType`, by identity. Two ProductionTypes sharing an
+	// id are still different objects and will not match — worth pinning, because a refactor that
+	// rebuilds the list on every emission would silently leave every button inactive.
+	it('compares by identity, not by id', () => {
+		const { selected, make } = setup();
+		const c = make();
+		c.productionType = productionType(7);
+		c.ngOnInit();
+
+		selected.next(productionType(7));   // same id, different object
+
+		expect(c.isActive).toBe(false);
+	});
+
+	it('deactivates when the selection is cleared', () => {
+		const { selected, make } = setup();
+		const pt = productionType(1);
+		const c = make();
+		c.productionType = pt;
+		c.ngOnInit();
+		selected.next(pt);
+
+		selected.next(null);
+
+		expect(c.isActive).toBe(false);
+	});
+
+	it('selects its own type when clicked', () => {
+		const { chosen, make } = setup();
+		const pt = productionType(3);
+		const c = make();
+		c.productionType = pt;
+		c.ngOnInit();
+
+		c.onClick();
+
+		expect(chosen).toEqual([pt]);
+	});
+
+	it('takes its colour from the production type', () => {
+		const { make } = setup();
+		const c = make();
+		c.productionType = productionType(1, '#abcdef');
+
+		c.ngOnInit();
+
+		expect(c.backgroundColor).toBe('#abcdef');
+	});
+
+	it('follows imageMode from settings', () => {
+		const { settings, make } = setup({ imageMode: true });
+		const c = make();
+		c.productionType = productionType(1);
+
+		c.ngOnInit();
+		expect(c.isImageMode).toBe(true);
+
+		settings.next({ imageMode: false });
+		expect(c.isImageMode).toBe(false);
+	});
+});


### PR DESCRIPTION
The production-type buttons are how anything gets placed on the board, so a regression here breaks the game outright — nothing can be selected, and nothing says why. They had no coverage.

8 specs, constructed directly with a stub service rather than through TestBed.

## The one worth calling out

`isActive` compares by **identity** (`o == this.productionType`), not by id. Two `ProductionType`s sharing an id are different objects and won't match — so a refactor that rebuilds the list on each emission would leave every button permanently inactive while looking entirely correct. Now pinned.

Also covered: activation only for its own type, deactivation when the selection is cleared, the click selecting its own type, colour from the production type, and `imageMode` following settings.

## Confirmed able to fail

| mutation | result |
|---|---|
| `isActive` compares by id instead of identity | 1 failed |
| click does nothing | 1 failed |
| colour not taken from the production type | 1 failed |
| `imageMode` ignored | 1 failed |

Tree restored green after each. **171 tests pass, was 163.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE