### PR TITLE
test(legend-board): cover the setter, and record that a short gradient throws

### DIFF
--- a/v2/src/app/legend-board/legend-board.component.spec.ts
+++ b/v2/src/app/legend-board/legend-board.component.spec.ts
@@ -1,0 +1,119 @@
+import { LegendBoardComponent } from './legend-board.component';
+import { Legend, LegendElement } from '../shared/models/legend';
+
+// The legend is what tells a player which colour means what, and its whole behaviour lives in
+// one setter: sort, then either build a CSS gradient from the first two entries or drop the
+// zero entry. Untested until now.
+
+const element = (forValue: number, color: string): LegendElement => ({ forValue, color });
+
+const legend = (elements: LegendElement[], opts: Partial<Legend> = {}): Legend =>
+	Object.assign(new Legend(), { elements, isNegative: false, isGradient: false }, opts);
+
+describe('LegendBoardComponent', () => {
+
+	describe('discrete legends', () => {
+		it('orders entries by value', () => {
+			const c = new LegendBoardComponent();
+
+			c.legendData = legend([element(3, 'c'), element(1, 'a'), element(2, 'b')]);
+
+			expect(c.legendElements.map(e => e.forValue)).toEqual([1, 2, 3]);
+		});
+
+		// forValue 0 is the "no data" entry and is not shown.
+		it('drops the zero entry', () => {
+			const c = new LegendBoardComponent();
+
+			c.legendData = legend([element(0, 'none'), element(1, 'a')]);
+
+			expect(c.legendElements.map(e => e.forValue)).toEqual([1]);
+		});
+
+		it('carries isNegative through', () => {
+			const c = new LegendBoardComponent();
+
+			c.legendData = legend([element(1, 'a')], { isNegative: true });
+
+			expect(c.isNegative).toBe(true);
+		});
+
+		it('builds no gradient', () => {
+			const c = new LegendBoardComponent();
+
+			c.legendData = legend([element(1, 'a'), element(2, 'b')]);
+
+			expect(c.gradient).toBe('');
+			expect(c.isGradient).toBe(false);
+		});
+	});
+
+	describe('gradient legends', () => {
+		it('builds a CSS gradient from the two lowest values', () => {
+			const c = new LegendBoardComponent();
+
+			c.legendData = legend([element(2, 'ff0000'), element(1, '00ff00')], { isGradient: true });
+
+			expect(c.gradient).toBe('linear-gradient(90deg, #00ff00, #ff0000)');
+		});
+
+		it('keeps the zero entry rather than filtering it', () => {
+			const c = new LegendBoardComponent();
+
+			c.legendData = legend([element(0, 'aaaaaa'), element(1, 'bbbbbb')], { isGradient: true });
+
+			expect(c.legendElements.map(e => e.forValue)).toEqual([0, 1]);
+		});
+
+		// isGradient is both an @Input and set here, so the data wins over whatever the template
+		// bound — which is what makes the host class track the legend rather than the caller.
+		it('overrides the isGradient input from the data', () => {
+			const c = new LegendBoardComponent();
+			c.isGradient = false;
+
+			c.legendData = legend([element(1, 'a'), element(2, 'b')], { isGradient: true });
+
+			expect(c.isGradient).toBe(true);
+		});
+	});
+
+	describe('edge cases', () => {
+		it('ignores an absent legend', () => {
+			const c = new LegendBoardComponent();
+			c.legendData = legend([element(1, 'a')]);
+			const before = c.legendElements;
+
+			c.legendData = undefined as any;
+
+			expect(c.legendElements).toBe(before);
+		});
+
+		// sort() sorts in place, so the Legend handed in comes back reordered. Worth recording:
+		// a Legend shared between two boards is mutated by whichever renders first.
+		it('reorders the caller\'s own array', () => {
+			const c = new LegendBoardComponent();
+			const data = legend([element(2, 'b'), element(1, 'a')]);
+
+			c.legendData = data;
+
+			expect(data.elements.map(e => e.forValue)).toEqual([1, 2]);
+		});
+
+		// A gradient legend with fewer than two entries indexes elements[1] unguarded and THROWS.
+		// Recorded, not fixed, because it is a behaviour change rather than a test: the setter
+		// runs during change detection, so this does not merely render a wrong legend — it takes
+		// out the view binding it. Worth guarding in its own change.
+		it('throws on a gradient legend with only one entry', () => {
+			const c = new LegendBoardComponent();
+
+			expect(() => { c.legendData = legend([element(1, 'abcdef')], { isGradient: true }); })
+				.toThrow(/color/);
+		});
+
+		it('throws on a gradient legend with no entries', () => {
+			const c = new LegendBoardComponent();
+
+			expect(() => { c.legendData = legend([], { isGradient: true }); }).toThrow();
+		});
+	});
+});


### PR DESCRIPTION
The legend tells a player which colour means what, and its whole behaviour lives in one `@Input` setter: sort by value, then either build a CSS gradient from the first two entries or drop the zero entry. No coverage until now.

11 specs. Two record behaviour that's surprising rather than merely untested:

**`sort()` sorts in place**, so the `Legend` handed in comes back reordered. A Legend shared between two boards is mutated by whichever renders first.

**A gradient legend with fewer than two entries throws.** It indexes `elements[1]` unguarded — `Cannot read properties of undefined (reading 'color')`. I'd assumed it would quietly produce `#undefined`; it doesn't, it raises. That matters more than a wrong-looking legend, because the setter runs during change detection, so it takes out the view binding it rather than just rendering badly.

Recorded, **not** fixed: guarding it is a behaviour change and belongs in its own commit rather than smuggled into a test PR.

Also covered: ordering, dropping the zero entry outside gradient mode and keeping it inside, `isNegative` passthrough, `isGradient` from the data overriding the input, and the absent-data guard.

## Confirmed able to fail

| mutation | result |
|---|---|
| no sorting | 3 failed |
| zero entry not filtered | 1 failed |
| `isGradient` not taken from data | 1 failed |
| gradient endpoints swapped | 1 failed |
| no guard on absent data | 1 failed |

Tree restored green after each. **182 tests pass, was 171.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE