### PR TITLE
fix(legend-board): a gradient legend with fewer than two stops no longer throws

### DIFF
--- a/v2/src/app/legend-board/legend-board.component.spec.ts
+++ b/v2/src/app/legend-board/legend-board.component.spec.ts
@@ -99,21 +99,30 @@ describe('LegendBoardComponent', () => {
 			expect(data.elements.map(e => e.forValue)).toEqual([1, 2]);
 		});
 
-		// A gradient legend with fewer than two entries indexes elements[1] unguarded and THROWS.
-		// Recorded, not fixed, because it is a behaviour change rather than a test: the setter
-		// runs during change detection, so this does not merely render a wrong legend — it takes
-		// out the view binding it. Worth guarding in its own change.
-		it('throws on a gradient legend with only one entry', () => {
+		// This used to throw: elements[1] was indexed unguarded, giving "Cannot read properties
+		// of undefined (reading 'color')". Since the setter runs during change detection, that
+		// took out the view binding the legend rather than merely rendering it wrong.
+		it('renders a one-entry gradient as a solid bar', () => {
 			const c = new LegendBoardComponent();
 
-			expect(() => { c.legendData = legend([element(1, 'abcdef')], { isGradient: true }); })
-				.toThrow(/color/);
+			c.legendData = legend([element(1, 'abcdef')], { isGradient: true });
+
+			expect(c.gradient).toBe('linear-gradient(90deg, #abcdef, #abcdef)');
 		});
 
-		it('throws on a gradient legend with no entries', () => {
+		it('renders nothing for an empty gradient legend', () => {
 			const c = new LegendBoardComponent();
 
-			expect(() => { c.legendData = legend([], { isGradient: true }); }).toThrow();
+			c.legendData = legend([], { isGradient: true });
+
+			expect(c.gradient).toBe('');
+		});
+
+		it('does not throw for a short gradient legend', () => {
+			const c = new LegendBoardComponent();
+
+			expect(() => { c.legendData = legend([element(1, 'a')], { isGradient: true }); }).not.toThrow();
+			expect(() => { c.legendData = legend([], { isGradient: true }); }).not.toThrow();
 		});
 	});
 });

--- a/v2/src/app/legend-board/legend-board.component.ts
+++ b/v2/src/app/legend-board/legend-board.component.ts
@@ -23,9 +23,17 @@ export class LegendBoardComponent {
 			this.legendElements = data.elements.sort((a, b) => a.forValue - b.forValue);
 			this.isNegative = data.isNegative;
 			this.isGradient = data.isGradient;
-			if (data.isGradient)
-				this.gradient = `linear-gradient(90deg, #${this.legendElements[0].color}, #${this.legendElements[1].color})`
-			else
+			if (data.isGradient) {
+				// A gradient needs two stops. With fewer, this used to index elements[1] and throw
+				// "Cannot read properties of undefined (reading 'color')" — and because this setter
+				// runs during change detection, that took out the view binding the legend rather
+				// than merely rendering it wrong. One entry now renders as a solid bar of its own
+				// colour, which is what a one-value gradient means; none renders nothing.
+				const [first, second] = this.legendElements;
+				this.gradient = first
+					? `linear-gradient(90deg, #${first.color}, #${(second ?? first).color})`
+					: '';
+			} else
 				this.legendElements = this.legendElements.filter(o => o.forValue != 0)
 		}
 	}


### PR DESCRIPTION
Follow-up to #96, which deliberately recorded this rather than changing it.

The setter built its CSS gradient from `elements[0]` and `elements[1]` with no guard, so a gradient legend carrying fewer than two entries raised `Cannot read properties of undefined (reading 'color')`. Because the setter runs during change detection, that didn't merely render a wrong legend — it took out the view binding it.

- **One entry** now renders as a solid bar of its own colour, which is what a one-value gradient means.
- **Zero entries** render nothing.
- **Two or more** are unchanged — the spec asserting the exact two-stop output still passes, so the normal case is untouched.

Reverting the guard fails 3 specs. **183 tests** (was 182), **11 e2e**, bundle unchanged at 752.06 kB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE