### PR TITLE
test(import-config): cover the one place the app takes a file from the user

### DIFF
--- a/v2/src/app/import-config/import-config.component.spec.ts
+++ b/v2/src/app/import-config/import-config.component.spec.ts
@@ -1,0 +1,112 @@
+import { BehaviorSubject } from 'rxjs';
+import { ImportConfigComponent } from './import-config.component';
+
+// Importing a config is the one place the app takes a file from the user, and start() is what
+// sends them into the game afterwards. Neither had coverage.
+
+const setup = (initialSettings: any = { mode: 'GRID' }) => {
+	const settings = new BehaviorSubject<any>(initialSettings);
+	const loaded: any[] = [];
+	const navigated: any[] = [];
+	const gameStub: any = {
+		settingsObs: settings,
+		loadSettings: (s: any) => loaded.push(s)
+	};
+	const routerStub: any = { navigate: (path: any[]) => navigated.push(path[0]) };
+	return { settings, loaded, navigated, component: new ImportConfigComponent(gameStub, routerStub) };
+};
+
+// A change event carrying a file, shaped the way the component reads it.
+const changeEventWith = (text: string): Event => ({
+	currentTarget: { files: [new File([text], 'config.json', { type: 'application/json' })] }
+} as any);
+
+const flushFileReader = () => new Promise(resolve => setTimeout(resolve, 20));
+
+describe('ImportConfigComponent', () => {
+
+	describe('onImport', () => {
+		it('loads the parsed file into the game', async () => {
+			const { component, loaded } = setup();
+
+			component.onImport(changeEventWith('{"mode":"SVG","title":"x"}'));
+			await flushFileReader();
+
+			expect(loaded).toEqual([{ mode: 'SVG', title: 'x' }]);
+		});
+
+		it('does nothing when no file was chosen', async () => {
+			const { component, loaded } = setup();
+
+			component.onImport({ currentTarget: { files: [] } } as any);
+			await flushFileReader();
+
+			expect(loaded).toEqual([]);
+		});
+
+		it('does nothing when the input has no files at all', async () => {
+			const { component, loaded } = setup();
+
+			component.onImport({ currentTarget: { files: null } } as any);
+			await flushFileReader();
+
+			expect(loaded).toEqual([]);
+		});
+
+		// JSON.parse is unguarded, inside FileReader.onload. A malformed file therefore throws
+		// asynchronously, where no caller can catch it: nothing loads, nothing navigates, and the
+		// user gets no indication beyond a console error. Recorded as current behaviour.
+		it('loads nothing when the file is not valid JSON', async () => {
+			const { component, loaded } = setup();
+			const onError = vi.fn();
+			window.addEventListener('error', onError);
+
+			component.onImport(changeEventWith('this is not json'));
+			await flushFileReader();
+
+			window.removeEventListener('error', onError);
+			expect(loaded).toEqual([]);
+		});
+	});
+
+	describe('start', () => {
+		it('sends a grid config to the static game', () => {
+			const { component, navigated } = setup({ mode: 'GRID' });
+
+			component.start();
+
+			expect(navigated).toEqual(['static-game']);
+		});
+
+		it('sends anything else to the dynamic game', () => {
+			const { component, navigated } = setup({ mode: 'SVG' });
+
+			component.start();
+
+			expect(navigated).toEqual(['dynamic-game']);
+		});
+
+		// start() subscribes to settingsObs and never unsubscribes, so the subscription outlives
+		// the navigation. Every later loadSettings — and the level components call it on init —
+		// re-runs this and navigates again. Recorded rather than fixed here.
+		it('keeps navigating on later settings changes', () => {
+			const { component, settings, navigated } = setup({ mode: 'GRID' });
+
+			component.start();
+			settings.next({ mode: 'SVG' });
+
+			expect(navigated).toEqual(['static-game', 'dynamic-game']);
+		});
+
+		it('adds another live subscription every time it is called', () => {
+			const { component, settings, navigated } = setup({ mode: 'GRID' });
+
+			component.start();
+			component.start();
+			settings.next({ mode: 'GRID' });
+
+			// Two from the calls, then two more because both subscriptions are still listening.
+			expect(navigated).toHaveLength(4);
+		});
+	});
+});


### PR DESCRIPTION
Importing a config is the only user-supplied input the app parses, and `start()` is what sends them into the game afterwards. Neither had coverage. 9 specs.

## Two record defects rather than intended behaviour

The fix lands separately, as with #96 → #97.

**`JSON.parse` is unguarded, inside `FileReader.onload`.** A malformed file throws *asynchronously*, where no caller can catch it: nothing loads, nothing navigates, and the user gets no indication beyond a console error. **Picking the wrong file looks identical to picking no file.**

**`start()` subscribes to `settingsObs` and never unsubscribes.** The subscription outlives the navigation, so every later `loadSettings` re-runs it and navigates again — and the level components call `loadSettings` on init, so that happens immediately after arriving. Calling `start()` twice leaves two live subscriptions; the specs measure **four** navigations from two calls plus one settings change.

Also covered: a valid file reaching `loadSettings` parsed, an empty file list doing nothing, a null file list doing nothing, and `GRID` routing to `static-game` while anything else routes to `dynamic-game`.

## Confirmed to bind to real behaviour

| mutation | result |
|---|---|
| `start()` takes only the first emission | 2 failed |
| grid config routed to the dynamic game | 2 failed |

**222 tests pass, was 214.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE