### PR TITLE
fix(import-config): a bad file now says so, and start() stops navigating twice

### DIFF
--- a/v2/src/app/import-config/import-config.component.spec.ts
+++ b/v2/src/app/import-config/import-config.component.spec.ts
@@ -24,6 +24,13 @@ const changeEventWith = (text: string): Event => ({
 const flushFileReader = () => new Promise(resolve => setTimeout(resolve, 20));
 
 describe('ImportConfigComponent', () => {
+	// alert() is not implemented in jsdom.
+	let alertSpy: any;
+	beforeEach(() => {
+		alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => { });
+		vi.spyOn(console, 'error').mockImplementation(() => { });
+	});
+	afterEach(() => vi.restoreAllMocks());
 
 	describe('onImport', () => {
 		it('loads the parsed file into the game', async () => {
@@ -53,19 +60,34 @@ describe('ImportConfigComponent', () => {
 			expect(loaded).toEqual([]);
 		});
 
-		// JSON.parse is unguarded, inside FileReader.onload. A malformed file therefore throws
-		// asynchronously, where no caller can catch it: nothing loads, nothing navigates, and the
-		// user gets no indication beyond a console error. Recorded as current behaviour.
+		// JSON.parse used to be unguarded here, and because this runs inside FileReader.onload
+		// the throw was asynchronous — no caller could catch it, so a wrong file was silently
+		// indistinguishable from no file.
 		it('loads nothing when the file is not valid JSON', async () => {
 			const { component, loaded } = setup();
-			const onError = vi.fn();
-			window.addEventListener('error', onError);
 
 			component.onImport(changeEventWith('this is not json'));
 			await flushFileReader();
 
-			window.removeEventListener('error', onError);
 			expect(loaded).toEqual([]);
+		});
+
+		it('tells the user when the file cannot be parsed', async () => {
+			const { component } = setup();
+
+			component.onImport(changeEventWith('{ broken'));
+			await flushFileReader();
+
+			expect(alertSpy).toHaveBeenCalled();
+		});
+
+		it('says nothing when the file parses fine', async () => {
+			const { component } = setup();
+
+			component.onImport(changeEventWith('{"mode":"GRID"}'));
+			await flushFileReader();
+
+			expect(alertSpy).not.toHaveBeenCalled();
 		});
 	});
 
@@ -86,27 +108,26 @@ describe('ImportConfigComponent', () => {
 			expect(navigated).toEqual(['dynamic-game']);
 		});
 
-		// start() subscribes to settingsObs and never unsubscribes, so the subscription outlives
-		// the navigation. Every later loadSettings — and the level components call it on init —
-		// re-runs this and navigates again. Recorded rather than fixed here.
-		it('keeps navigating on later settings changes', () => {
+		// start() used to subscribe for the component's lifetime, so the subscription outlived the
+		// navigation and every later loadSettings navigated again — and the level components call
+		// loadSettings on init, immediately after arriving.
+		it('does not navigate again when the settings change later', () => {
 			const { component, settings, navigated } = setup({ mode: 'GRID' });
 
 			component.start();
 			settings.next({ mode: 'SVG' });
 
-			expect(navigated).toEqual(['static-game', 'dynamic-game']);
+			expect(navigated).toEqual(['static-game']);
 		});
 
-		it('adds another live subscription every time it is called', () => {
+		it('navigates once per call, with nothing left listening', () => {
 			const { component, settings, navigated } = setup({ mode: 'GRID' });
 
 			component.start();
 			component.start();
 			settings.next({ mode: 'GRID' });
 
-			// Two from the calls, then two more because both subscriptions are still listening.
-			expect(navigated).toHaveLength(4);
+			expect(navigated).toEqual(['static-game', 'static-game']);
 		});
 	});
 });

--- a/v2/src/app/import-config/import-config.component.ts
+++ b/v2/src/app/import-config/import-config.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { GameService } from '../services/game.service';
 import { Router } from '@angular/router';
+import { take } from 'rxjs';
 
 @Component({
     selector: 'tro-import-config',
@@ -22,7 +23,15 @@ export class ImportConfigComponent {
 			fileReader.onload = _ => {
 				let result = fileReader.result;
 				if (result) {
-					this.gameService.loadSettings(JSON.parse(result.toString()));
+					// JSON.parse was unguarded here. Because this runs in FileReader.onload the
+					// throw is asynchronous, so no caller could catch it: choosing the wrong file
+					// looked exactly like choosing no file at all — nothing loaded, nothing said.
+					try {
+						this.gameService.loadSettings(JSON.parse(result.toString()));
+					} catch (err) {
+						console.error(err);
+						alert("That file could not be read as a game configuration.");
+					}
 				}
 			}
 			fileReader.readAsText(files[0]);
@@ -30,7 +39,11 @@ export class ImportConfigComponent {
 	}
 
 	start() {
-		this.gameService.settingsObs.subscribe(settings => {
+		// take(1): this used to subscribe for the lifetime of the component, so the subscription
+		// outlived the navigation and every later loadSettings re-ran it and navigated again —
+		// and the level components call loadSettings on init, immediately after arriving here.
+		// Two clicks left two live subscriptions, and each settings change fired both.
+		this.gameService.settingsObs.pipe(take(1)).subscribe(settings => {
 			if (settings.mode == 'GRID') {
 				this.router.navigate(['static-game']);
 			} else {


### PR DESCRIPTION
Follow-up to #100, which deliberately recorded both of these rather than changing them.

## A malformed config failed silently

`JSON.parse` ran unguarded inside `FileReader.onload`, so the throw was **asynchronous** and no caller could catch it — choosing the wrong file was indistinguishable from choosing no file. It now catches, logs, and says *"That file could not be read as a game configuration."*

## `start()` leaked its subscription

It subscribed to `settingsObs` for the component's lifetime, so the subscription outlived the navigation and every later `loadSettings` ran it again — and the level components call `loadSettings` on init, immediately after arriving. Two clicks left two live subscriptions, and each settings change fired both.

`take(1)`: it navigates once per call and stops listening.

## Reverting either change fails its specs

| mutation | result |
|---|---|
| revert `take(1)` | 2 failed |
| revert the try/catch | 1 failed |

**224 tests pass** (was 222 — two new ones for the alert), bundle unchanged at 752.06 kB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE