### PR TITLE
docs: re-verify the published image after this session's frontend changes

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -31,7 +31,11 @@ Verified working
    * - Published container image
      - ``ghcr.io/mlacayoemery/esgame:master`` pulled and run. Byte-identical to a local
        production build (same filenames, same md5 sums), and renders with the network
-       blocked.
+       blocked. **Re-checked after this session's frontend changes** (2026-07-30, image
+       for ``379545a``): pulled fresh, ``CALC_URL`` injected at start, grid board decodes
+       2,436 fields and the SVG board 466 hexagons from real GeoTIFFs, no page errors.
+       Also confirms nginx's asset handling first-hand — a missing ``.tif`` returns 404,
+       a real one 200 ``image/tiff``, and an unknown route falls back to the app.
    * - ``deploy/k8s`` base
      - Applied to a throwaway kind cluster. ``--dry-run=server`` clean;
        ``esgame-angular`` and ``esgame-geoserver`` reach ready; Services have endpoints


### PR DESCRIPTION
Twelve PRs touched `v2/` today, each republishing `ghcr.io/mlacayoemery/esgame:master`. The *"verified working"* row for that image described a check run **yesterday, against different code** — exactly the sort of stale claim this file exists to prevent.

Re-run against the image built for `379545a`, **pulled fresh** rather than built locally:

| check | result |
|---|---|
| index serves | 200 |
| `CALC_URL` injected at start | yes, into `assets/config.json` |
| grid board | **2,436 fields** decoded from real GeoTIFFs |
| svg board | **466 hexagons** decoded |
| page errors | none |

HTTP codes alone wouldn't have shown this — a board that renders nothing still answers 200, which is the failure this repo has shipped before. **The field counts are the assertion.**

The same run also confirms nginx's asset handling first-hand rather than by reading the config: a missing `.tif` returns 404, a real one 200 `image/tiff`, and an unknown route falls back to the app. That's the evidence behind the correction in #93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE