### PR TITLE
test(help): cover the only thing that explains the game to a new player

### DIFF
--- a/v2/src/app/help/help.component.spec.ts
+++ b/v2/src/app/help/help.component.spec.ts
@@ -1,0 +1,128 @@
+import { BehaviorSubject, firstValueFrom } from 'rxjs';
+import { HelpComponent } from './help.component';
+
+// The instructions panel picks which text and which image to show from the level, and it is the
+// only thing that tells a new player what the game is. Untested until now.
+
+const cdRefStub: any = { markForCheck: () => { } };
+
+const setup = (settingsValue: any = {
+	basicInstructionsImageUrl: 'basic.png',
+	advancedInstructionsImageUrl: 'advanced.png'
+}) => {
+	const helpWindow = new BehaviorSubject<boolean>(false);
+	const level = new BehaviorSubject<any>(null);
+	const settings = new BehaviorSubject<any>(settingsValue);
+	const closed: boolean[] = [];
+	const gameStub: any = {
+		helpWindowObs: helpWindow,
+		currentLevelObs: level,
+		settingsObs: settings,
+		openHelp: (close = false) => closed.push(close)
+	};
+	return { helpWindow, level, settings, closed, component: new HelpComponent(gameStub, cdRefStub) };
+};
+
+describe('HelpComponent', () => {
+
+	describe('open state', () => {
+		it('starts closed', () => {
+			expect(setup().component.isOpen).toBe(false);
+		});
+
+		it('follows the service', () => {
+			const { component, helpWindow } = setup();
+
+			helpWindow.next(true);
+			expect(component.isOpen).toBe(true);
+
+			helpWindow.next(false);
+			expect(component.isOpen).toBe(false);
+		});
+
+		// openHelp(true) is "close" — the argument is inverted, so passing nothing would reopen
+		// the dialog the player just dismissed.
+		it('asks the service to close, not to open', () => {
+			const { component, closed } = setup();
+
+			component.onClose();
+
+			expect(closed).toEqual([true]);
+		});
+	});
+
+	describe('which instructions', () => {
+		it('shows the basic text before any level exists', () => {
+			expect(setup().component.helpText).toBe('basic_instructions');
+		});
+
+		it('shows the basic text on level 1', () => {
+			const { component, level } = setup();
+
+			level.next({ levelNumber: 1 });
+
+			expect(component.helpText).toBe('basic_instructions');
+		});
+
+		it('switches to the advanced text from level 2', () => {
+			const { component, level } = setup();
+
+			level.next({ levelNumber: 2 });
+
+			expect(component.helpText).toBe('advanced_instructions');
+		});
+
+		it('stays on the advanced text for later levels', () => {
+			const { component, level } = setup();
+
+			level.next({ levelNumber: 7 });
+
+			expect(component.helpText).toBe('advanced_instructions');
+		});
+
+		// Going back a level should put the basic text back, since prevLevel is reachable.
+		it('returns to the basic text if the level goes back to 1', () => {
+			const { component, level } = setup();
+			level.next({ levelNumber: 3 });
+
+			level.next({ levelNumber: 1 });
+
+			expect(component.helpText).toBe('basic_instructions');
+		});
+	});
+
+	describe('which image', () => {
+		it('uses the basic image on level 1', async () => {
+			const { component, level } = setup();
+
+			level.next({ levelNumber: 1 });
+
+			expect(await firstValueFrom(component.imageUrl)).toBe('basic.png');
+		});
+
+		it('uses the advanced image from level 2', async () => {
+			const { component, level } = setup();
+
+			level.next({ levelNumber: 2 });
+
+			expect(await firstValueFrom(component.imageUrl)).toBe('advanced.png');
+		});
+
+		it('follows a later settings change', async () => {
+			const { component, level, settings } = setup();
+			level.next({ levelNumber: 2 });
+
+			settings.next({ basicInstructionsImageUrl: 'b2.png', advancedInstructionsImageUrl: 'a2.png' });
+
+			expect(await firstValueFrom(component.imageUrl)).toBe('a2.png');
+		});
+
+		it('yields undefined when the deployment configures no image', async () => {
+			const { component, level } = setup({});
+
+			level.next({ levelNumber: 1 });
+
+			expect(await firstValueFrom(component.imageUrl)).toBeUndefined();
+		});
+	});
+});


### PR DESCRIPTION
The instructions panel picks which text and which image to show from the level. It had no coverage, and it's the one piece of UI whose whole job is being correct for someone who doesn't yet know what they're looking at.

12 specs.

## The one worth naming

`openHelp`'s argument is **inverted** — `openHelp(true)` means *close*. So `onClose()` passing nothing would **reopen** the dialog the player just dismissed. That's a plausible slip, and it now fails a test.

## Also covered

- `isOpen` following the service
- basic instructions before any level exists and on level 1
- advanced from level 2 onward
- returning to basic if the level goes back to 1 (`prevLevel` is reachable)
- the matching image for each
- the image following a later settings change
- `undefined` when a deployment configures no image at all

## Each confirmed able to fail

| mutation | result |
|---|---|
| `onClose` reopens instead of closing | 1 failed |
| basic text extended to level 2 | 3 failed |
| advanced image falls back to basic | 2 failed |
| `isOpen` ignores the service | 2 failed |

Tree restored green after each. **236 tests pass, was 224.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE