### PR TITLE
test(start): cover the page where one game ends and the next begins

### DIFF
--- a/v2/src/app/start/start.component.spec.ts
+++ b/v2/src/app/start/start.component.spec.ts
@@ -1,0 +1,85 @@
+import { StartComponent } from './start.component';
+
+// The start page is where a game begins, so it is also where the previous one has to end:
+// resetGame runs on construction. Getting that wrong would carry a finished board into the
+// next session, which looks like a game that will not start rather than one that did not stop.
+
+const setup = (opts: { langs?: string[], current?: string | null } = {}) => {
+	const used: string[] = [];
+	const navigated: string[] = [];
+	const calls: string[] = [];
+	const langs = opts.langs ?? ['en', 'nl', 'de'];
+	const translateStub: any = {
+		getLangs: () => langs,
+		currentLang: () => ('current' in opts ? opts.current : 'nl'),
+		use: (l: string) => used.push(l)
+	};
+	const gameStub: any = { resetGame: () => calls.push('reset') };
+	const routerStub: any = { navigate: (p: any[]) => navigated.push(p[0]) };
+	return { used, navigated, calls, langs, make: () => new StartComponent(translateStub, gameStub, routerStub) };
+};
+
+describe('StartComponent', () => {
+
+	it('resets the game on arrival', () => {
+		const { calls, make } = setup();
+
+		make();
+
+		expect(calls).toEqual(['reset']);
+	});
+
+	it('offers the configured languages', () => {
+		const { make } = setup({ langs: ['en', 'pt'] });
+
+		expect(make().languages).toEqual(['en', 'pt']);
+	});
+
+	// The spread matters: the component's list must not be the translate service's own array,
+	// or a change here would reach into the service.
+	it('copies the language list rather than sharing it', () => {
+		const { langs, make } = setup();
+		const c = make();
+
+		c.languages.push('xx');
+
+		expect(langs).not.toContain('xx');
+	});
+
+	it('starts on the active language', () => {
+		const { make } = setup({ current: 'de' });
+
+		expect(make().currentLanguage).toBe('de');
+	});
+
+	it('falls back to English when no language is active', () => {
+		const { make } = setup({ current: null });
+
+		expect(make().currentLanguage).toBe('en');
+	});
+
+	it('switches language on selection', () => {
+		const { used, make } = setup();
+		const c = make();
+
+		c.changeLanguage({ value: 'nl' } as any);
+
+		expect(used).toEqual(['nl']);
+	});
+
+	it('routes to the dynamic game', () => {
+		const { navigated, make } = setup();
+
+		make().loadDynamic();
+
+		expect(navigated).toEqual(['dynamic-game']);
+	});
+
+	it('routes to the static game', () => {
+		const { navigated, make } = setup();
+
+		make().loadStatic();
+
+		expect(navigated).toEqual(['static-game']);
+	});
+});


### PR DESCRIPTION
`StartComponent` calls `resetGame()` on construction, so it's where a finished board gets cleared. Losing that would carry the previous game into the next session — which presents as *a game that won't start* rather than one that didn't stop.

8 specs: the reset, the language list, the active language with its `'en'` fallback, switching language, and both route buttons.

## Three confirmed able to fail

| mutation | result |
|---|---|
| no `resetGame` on arrival | 1 failed |
| no `'en'` fallback | 1 failed |
| dynamic button routes to static | 1 failed |

## The fourth couldn't be mutation-tested

Worth recording rather than glossing over: removing the spread in `[...translate.getLangs()]` **doesn't compile**. `getLangs()` returns `readonly string[]`, so TypeScript rejects the assignment outright — the copy is enforced by the type system, not by the spec.

The spec still asserts the semantic (pushing to `component.languages` must not reach the service's array), but I can't demonstrate it failing, so it isn't claimed as verified.

**244 tests pass, was 236.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE