### PR TITLE
test(game-board): cover the arithmetic under every number the player sees

### DIFF
--- a/v2/src/app/shared/models/game-board.spec.ts
+++ b/v2/src/app/shared/models/game-board.spec.ts
@@ -1,0 +1,63 @@
+import { GameBoard } from './game-board';
+import { Field } from './field';
+import { FieldType } from './field-type';
+import { GameBoardType } from './game-board-type';
+
+// GameBoard.getScore is the arithmetic under every number the player sees: SelectedField.
+// updateScore calls it once for the suitability map and once per consequence map, and
+// ScoreService then sums those across fields. It had no direct coverage.
+
+const field = (id: number, score: number) => new Field(id, new FieldType('#000'), score);
+
+const board = (...fields: Field[]) =>
+	new GameBoard('b', GameBoardType.SuitabilityMap, fields);
+
+describe('GameBoard.getScore', () => {
+
+	it('sums the scores of the requested fields', () => {
+		expect(board(field(1, 3), field(2, 4), field(3, 5)).getScore([1, 3])).toBe(8);
+	});
+
+	it('is zero when nothing is requested', () => {
+		expect(board(field(1, 3)).getScore([])).toBe(0);
+	});
+
+	it('is zero when no requested id is on the board', () => {
+		expect(board(field(1, 3)).getScore([99])).toBe(0);
+	});
+
+	it('ignores ids that are not on the board', () => {
+		expect(board(field(1, 3), field(2, 4)).getScore([1, 99])).toBe(3);
+	});
+
+	// The filter runs over the board's fields, not over the requested ids, so a duplicate in the
+	// request cannot double-count a field. Worth pinning: an allocation is user-supplied.
+	it('counts a field once even if its id is asked for twice', () => {
+		expect(board(field(1, 3)).getScore([1, 1, 1])).toBe(3);
+	});
+
+	it('keeps negative scores rather than clamping them', () => {
+		expect(board(field(1, 5), field(2, -8)).getScore([1, 2])).toBe(-3);
+	});
+
+	it('is zero for an empty board', () => {
+		expect(board().getScore([1, 2])).toBe(0);
+	});
+
+	// A consequence map's contribution is negated by the caller, not here — getScore itself is
+	// always a plain sum, whichever kind of board it belongs to.
+	it('does not negate anything itself', () => {
+		const consequence = new GameBoard('c', GameBoardType.ConsequenceMap, [field(1, 6)]);
+
+		expect(consequence.getScore([1])).toBe(6);
+	});
+});
+
+describe('GameBoard.isPositive', () => {
+	it('is true only for a suitability map', () => {
+		expect(new GameBoard('s', GameBoardType.SuitabilityMap, []).isPositive).toBe(true);
+		expect(new GameBoard('c', GameBoardType.ConsequenceMap, []).isPositive).toBe(false);
+		expect(new GameBoard('d', GameBoardType.DrawingMap, []).isPositive).toBe(false);
+		expect(new GameBoard('b', GameBoardType.BackgroundMap, []).isPositive).toBe(false);
+	});
+});


### PR DESCRIPTION
`GameBoard.getScore` is what `SelectedField.updateScore` calls — once for the suitability map and once per consequence map — and `ScoreService` then sums those across fields. It's the bottom of the scoring stack and had no direct coverage.

9 specs.

## The one that matters most

The filter runs over the **board's fields**, not over the requested ids, so a duplicate in the request cannot double-count a field. Allocations are user-supplied, so that's a real input. Rewriting it to iterate the ids instead fails the spec.

Also covered: summing only the requested fields, ignoring ids not on the board, zero for an empty request / empty board / no match, keeping negatives rather than clamping, and `getScore` never negating anything itself — the caller does that for consequence maps. Plus `isPositive` being true only for a suitability map.

## Confirmed able to fail

| mutation | result |
|---|---|
| iterate over ids instead of fields | 1 failed |
| clamp negatives | 1 failed |
| `isPositive` widened | 1 failed |

## Incidental finding

While checking who calls what, **`ProductionType.getScore()` turns out to be unreferenced** — nothing in the app calls it.

That matters more than it sounds: it reads like *the* authoritative scoring formula (suitability minus the sum of consequences), so a maintainer would reasonably take it as the source of truth. The rule actually in force lives in `SelectedField.updateScore` and `ScoreService.calculateScore`. Left in place here; removing it is a separate change.

**253 tests pass, was 244.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE