### PR TITLE
docs: the broken dynamic round is reachable on the public site, measured not inferred

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -77,6 +77,12 @@ Verified working
        compose network**, spider plot served as a PNG. 21 checks in places'
        ``test/stack.sh``. That repo's geodata now loads for real in both paths —
        a loader service in compose, the ``load-geodata`` init container in k8s.
+   * - Published GitHub Pages site
+     - The canonical grid game, checked live rather than by a green workflow
+       (2026-07-30, ``f391875``): <https://mlacayoemery.github.io/esgame/> renders
+       **2,436 fields** from real GeoTIFFs with no page errors, ``assets/config.json``
+       serves ``defaultMode: static`` / ``calcUrl: ""``, and the published docs resolve —
+       including the links places' README points at.
    * - Multi-round game
      - Three consecutive rounds against the real ``tools/R``: three distinct GeoServer
        workspaces, scores that moved with each allocation, and 15/15 coverages still
@@ -108,7 +114,7 @@ Placeholders must be replaced
    ``CHANGE-ME-registry/…`` image names. Keep hosts lowercase: an Ingress host must be a
    valid RFC 1123 subdomain, and the API server rejects the whole apply otherwise.
 
-The dynamic game's consequence rasters are not in the repository
+The dynamic game's consequence rasters are not in the repository — **and this is reachable in production**
    :file:`v2/src/assets/data.json` names five consequence maps —
    ``Consequence_1_Clip.tif`` … ``Consequence_4_Clip.tif`` — and **none of those files exists**,
    in ``src`` or in a build. In dynamic mode with no calculator configured (``calcUrl: ""``,
@@ -125,7 +131,15 @@ The dynamic game's consequence rasters are not in the repository
 
    A deployment with a real calculator is unaffected: the URLs in ``data.json`` are placeholders
    that ``prepareNextLevel`` overwrites with whatever the calculator returns. So this only bites
-   the backend-less dynamic build.
+   the backend-less dynamic build — which is exactly what GitHub Pages serves.
+
+   **Measured on the live site, not inferred.** ``/dynamic-game`` is reachable on Pages via the
+   ``404.html`` SPA redirect, and the SVG board renders its 466 hexagons there. Placing hexagons
+   and pressing *Next Level* on https://mlacayoemery.github.io/esgame/dynamic-game produces five
+   ``404``\ s, a level that stays at 1, and a spinner that does not clear. Any visitor can reach
+   it. Since the level-failure handler shipped they are at least told — one "Something went
+   wrong" alert now appears where previously nothing did — but the round still cannot complete,
+   and the spinner remains the unresolved half of that fix.
 
 The committed base raster makes the game inert
    :file:`v2/src/assets/images/LU_and_NEW_hexa.tif` numbers its hexagons ``10``–``474``


### PR DESCRIPTION
Two live checks, because a green deploy workflow says the artifact was *uploaded*, not that it works.

## The canonical grid game is fine

<https://mlacayoemery.github.io/esgame/> renders **2,436 fields** from real GeoTIFFs with no page errors, `config.json` serves `defaultMode: static` with an empty `calcUrl`, and the published docs resolve — including the links places' README now points at.

Recorded as its own row rather than folded into the local test numbers, because *"the suite passes"* and *"the deployed site works"* are different claims.

## The dynamic game's missing rasters are a production problem, not a local quirk

I had written that entry as though it only bit a backend-less dev build. **Pages *is* a backend-less build.**

`/dynamic-game` is reachable there through the `404.html` SPA redirect, the SVG board renders its 466 hexagons, and pressing *Next Level* gives:

```
5 × 404 on Consequence_*_Clip.tif
level stays at 1
spinner never clears
1 alert shown to the user
```

Any visitor can reach that.

The alert is the level-failure handler from #94 doing its job — before it, the same click produced *nothing at all* — and the spinner is the half of that fix I couldn't land. Both are now stated against a measurement rather than a description.

Docs build clean under `sphinx-build -W`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE