### PR TITLE
fix(dynamic): refuse a round with no calculator instead of walking into a 404

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -135,11 +135,19 @@ The dynamic game's consequence rasters are not in the repository — **and this 
 
    **Measured on the live site, not inferred.** ``/dynamic-game`` is reachable on Pages via the
    ``404.html`` SPA redirect, and the SVG board renders its 466 hexagons there. Placing hexagons
-   and pressing *Next Level* on https://mlacayoemery.github.io/esgame/dynamic-game produces five
-   ``404``\ s, a level that stays at 1, and a spinner that does not clear. Any visitor can reach
-   it. Since the level-failure handler shipped they are at least told — one "Something went
-   wrong" alert now appears where previously nothing did — but the round still cannot complete,
-   and the spinner remains the unresolved half of that fix.
+   and pressing *Next Level* on https://mlacayoemery.github.io/esgame/dynamic-game produced five
+   ``404``\ s, a level that stayed at 1, and a spinner that never cleared. Any visitor could
+   reach it.
+
+   **Now refused rather than attempted.** The dynamic game's consequence maps come *from* the
+   calculator — the ``urlToData`` in ``data.json`` are placeholders it overwrites — so with no
+   ``calcUrl`` there is nothing to compute and nothing to fetch. ``goToNextLevel`` says so
+   instead of going ahead: *"This game needs a calculation backend, and none is configured."*
+   Measured in a browser afterwards — **zero 404s, no spinner**, level unchanged. The missing
+   rasters are still missing; nothing now walks into them.
+
+   That also removes the only reachable trigger for the spinner that would not clear (see
+   below). The host-binding problem underneath it is still unfixed.
 
 The committed base raster makes the game inert
    :file:`v2/src/assets/images/LU_and_NEW_hexa.tif` numbers its hexagons ``10``–``474``

--- a/v2/src/app/services/game.service.loading.spec.ts
+++ b/v2/src/app/services/game.service.loading.spec.ts
@@ -133,3 +133,41 @@ describe('GameService loading indicator', () => {
 		expect(await isLoading(service)).toBe(false);
 	});
 });
+
+// The dynamic game with no calculator configured. Its consequence maps come from the
+// calculator, so there is nothing to build — but this used to call prepareNextLevel anyway,
+// which fetched data.json's placeholder URLs (not real assets), 404'd, and hung on a spinner
+// that never cleared. Reachable on the published GitHub Pages site.
+describe('GameService dynamic mode without a calculator', () => {
+	let alertSpy: any;
+	beforeEach(() => {
+		alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => { });
+		vi.spyOn(console, 'error').mockImplementation(() => { });
+	});
+	afterEach(() => vi.restoreAllMocks());
+
+	const svgServiceWithoutCalcUrl = () => {
+		const service = makeService();
+		// loadSettings sets mode from mapMode: 'svg', and calcUrl is absent.
+		return service;
+	};
+
+	it('says a backend is needed rather than hanging', async () => {
+		const service = svgServiceWithoutCalcUrl();
+		const before = await firstValueFrom(service.currentLevelObs);
+
+		service.goToNextLevel();
+
+		expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining('calculation backend'));
+		// And the level is untouched — no half-built level left behind.
+		expect(await firstValueFrom(service.currentLevelObs)).toBe(before);
+	});
+
+	it('does not leave the loading indicator running', async () => {
+		const service = svgServiceWithoutCalcUrl();
+
+		service.goToNextLevel();
+
+		expect(await isLoading(service)).toBe(false);
+	});
+});

--- a/v2/src/app/services/game.service.ts
+++ b/v2/src/app/services/game.service.ts
@@ -128,6 +128,14 @@ export class GameService {
 						this.loading(false);
 					}
 				});
+			} else if (this.settings.value.mode == 'SVG') {
+				// The dynamic game has no consequence maps of its own — they come back from the
+				// calculator, and the urlToData in data.json are placeholders it overwrites.
+				// Without a calcUrl there is nothing to compute and nothing to show, but this
+				// used to go ahead anyway: it fetched those placeholders, they 404'd (they are
+				// not real assets, and never were), the combineLatest errored, and the player
+				// got a spinner that never cleared. Reachable on the published site.
+				alert("This game needs a calculation backend, and none is configured.");
 			} else {
 				this.prepareNextLevel();
 			}


### PR DESCRIPTION
The dynamic game's consequence maps come **from** the calculator — the `urlToData` in `data.json` are placeholders it overwrites. With no `calcUrl` there is nothing to compute and nothing to fetch.

`goToNextLevel` went ahead anyway: it called `prepareNextLevel`, which fetched those placeholders, got five **404**s (they aren't real assets and never were — they appear nowhere in either repository's history), errored the `combineLatest`, and left a spinner that never cleared.

**That's not a local-dev edge case.** GitHub Pages serves exactly this configuration, so any visitor to `/dynamic-game` could reach it — measured on the live site earlier today (#106).

It now says: *"This game needs a calculation backend, and none is configured."*

## Verified in a browser, not inferred

| | before | after |
|---|---|---|
| 404 requests | 5 | **0** |
| spinner | stuck visible | **not visible** |
| message | generic "something went wrong" | names the actual problem |

The **with-calculator path is untouched** — all four round-trip e2e still pass, including two real rounds and the score board.

This also removes the only reachable trigger for the spinner that wouldn't clear (#94). The host-binding problem underneath it is still unfixed and still recorded — nothing can now walk into it.

## Both branches confirmed able to fail

| mutation | result |
|---|---|
| guard removed (hang returns) | 1 failed |
| message removed (silent refusal) | 1 failed |

**255 tests** (was 253), **11 e2e**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE