### PR TITLE
docs: the dynamic-round fix is confirmed on the published site

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -143,8 +143,11 @@ The dynamic game's consequence rasters are not in the repository — **and this 
    calculator — the ``urlToData`` in ``data.json`` are placeholders it overwrites — so with no
    ``calcUrl`` there is nothing to compute and nothing to fetch. ``goToNextLevel`` says so
    instead of going ahead: *"This game needs a calculation backend, and none is configured."*
-   Measured in a browser afterwards — **zero 404s, no spinner**, level unchanged. The missing
-   rasters are still missing; nothing now walks into them.
+
+   Confirmed **on the published site**, not just locally — the same round that produced five
+   ``404``\ s and a stuck spinner an hour earlier now gives that message, **zero 404s and no
+   spinner** on https://mlacayoemery.github.io/esgame/dynamic-game. The missing rasters are
+   still missing; nothing now walks into them.
 
    That also removes the only reachable trigger for the spinner that would not clear (see
    below). The host-binding problem underneath it is still unfixed.


### PR DESCRIPTION
#107 was verified in a *local* browser. The reason it existed was behaviour measured on **GitHub Pages**, so the claim is only closed when it's re-measured there.

Same round, same page, after the Pages deploy of `b51fecd`:

| | before | after |
|---|---|---|
| 404 requests | 5 | **0** |
| level | stuck at 1 | unchanged (correctly — nothing to advance to) |
| spinner | never cleared | **not visible** |
| message | generic | *"This game needs a calculation backend, and none is configured."* |

Found live, fixed, verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE