### PR TITLE
chore(models): remove ProductionType.getScore, which nothing called

### DIFF
--- a/v2/src/app/shared/models/production-type.ts
+++ b/v2/src/app/shared/models/production-type.ts
@@ -16,9 +16,12 @@ export class ProductionType {
 		this.maxElements = maxElements;
 	}
 
-	getScore(ids: number[]) {
-		let score = this.suitabilityMap.getScore(ids);
-		let minusScore = this.consequenceMaps?.map(o => o.getScore(ids)).reduce((a, b) => a+b, 0) ?? 0;
-		return score - minusScore;
-	}
+	// getScore() was here: suitability minus the sum of the consequence maps. Nothing called it.
+	//
+	// Worth a note rather than a silent deletion, because it read like the authoritative scoring
+	// rule and it is not even the right shape. The rule actually in force is in
+	// SelectedField.updateScore, which records the suitability score and EACH consequence
+	// separately (negated), and ScoreService.calculateScore, which then sums per map id across
+	// fields. That per-indicator breakdown is what the score board renders; collapsing it to one
+	// number, as this did, would not have served any caller.
 }


### PR DESCRIPTION
Found while covering `GameBoard.getScore` in #105 and left in place there deliberately, so the removal would be its own change.

It computed *suitability minus the sum of the consequence maps* and returned a single number. **Nothing in the app called it** — the only `getScore()` calls are on `GameBoard`, from `SelectedField.updateScore`.

## Why remove it rather than leave it harmlessly

It reads like **the** scoring rule. A maintainer looking for how a score is produced finds a method on `ProductionType` that plausibly answers the question — and it isn't the answer.

The rule in force records the suitability score and **each consequence separately** (negated) in `SelectedField.updateScore`, and `ScoreService.calculateScore` then sums per map id across fields. That per-indicator breakdown is what the score board renders; collapsing it to one number, as this did, wouldn't have served any caller.

A comment stands in its place saying so, so the next person to wonder where the formula lives is pointed at the real one rather than re-adding this.

**255 tests**, **11 e2e**, bundle 752.17 → 752.05 kB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE