### PR TITLE
docs: measure the backward compatibility that #84 only asserted

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -96,6 +96,13 @@ Verified working
        returned 200. Split into ``GEOSERVER_PUBLIC_URL``; measured 6/6 coverages
        fetchable from outside the network in the places stack. Gated in CI, with all
        four failure modes checked by mutation.
+   * - …and its backward compatibility
+     - The split was claimed to leave an existing single-address deployment unchanged.
+       That was an assertion until it was run: ``tools/R`` with ``GEOSERVER`` set and
+       ``GEOSERVER_PUBLIC_URL`` deliberately **unset** returns 200, five finite scores,
+       logs ``GEOSERVER_PUBLIC_URL is unset …`` and falls back to the ``GEOSERVER``
+       address for its coverage URLs — which a client inside the network still fetches
+       as ``image/geotiff``. Exactly the pre-split behaviour, now measured.
 
 
 Known incomplete


### PR DESCRIPTION
#84 split `GEOSERVER` into a server-to-server address and a browser-facing one, and said the new variable *"defaults to `GEOSERVER`, so an existing single-address deployment behaves exactly as before"*.

That was **reasoning about the code, not a result** — the kind of claim this file exists to stop.

## Run it

`tools/R` with `GEOSERVER` set and `GEOSERVER_PUBLIC_URL` deliberately **unset**:

| | |
|---|---|
| `POST /esgame` | **200** |
| scores | **5 finite**, none NaN |
| log | *"GEOSERVER_PUBLIC_URL is unset, so coverage URLs will use the internal GeoServer address (…). A browser probably cannot resolve it."* |
| returned URLs | `http://bc-gs:8080/geoserver/wcs?…` — the `GEOSERVER` address |
| fetched from inside the network | **200 `image/geotiff`** |

So the fallback works, it *says so* rather than doing it quietly, and a pre-split client is unaffected.

Now recorded as measured rather than argued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE