### PR TITLE
ci: the ingress host check validated whatever it was given, including nothing

### DIFF
--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -155,6 +155,13 @@ jobs:
           # than about setting your host.
           hosts=$(grep -oP '^\s+- host:\s*\K\S+' rendered.yaml)
           echo "$hosts"
+          # The loop below examines whatever it is given, so with no hosts it examines nothing
+          # and reports success — the same shape as the pin check. The base renders three
+          # Ingresses; if it stops rendering them, that is the failure, not a clean run.
+          n=$(printf '%s\n' "$hosts" | grep -c . || true)
+          if [ "$n" -ne 3 ]; then
+            echo "::error::expected 3 ingress hosts in the render, found $n"; exit 1
+          fi
           bad=0
           for h in $hosts; do
             if ! printf '%s' "$h" | grep -qE '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'; then


### PR DESCRIPTION
Sixth instance of the same shape today.

The loop iterates `$hosts`, sets `bad=1` on an invalid one, and exits with that flag. **With no hosts it iterates nothing**, `bad` stays 0, and the step prints *"all ingress hosts are RFC 1123 valid"* having validated nothing — so a render that stopped producing Ingresses would report success, from the very check that exists because a bad host once broke the whole apply.

Unlike the others, this one had **no sibling covering it**: nothing else in the workflow asserts the Ingresses are present.

The base renders three. That is now asserted before the loop runs.

## Verified against the real render and both failure modes

| | |
|---|---|
| real render | `ok: 3 hosts, all RFC 1123 valid` |
| no ingresses | `ERROR: expected 3 ingress hosts, found 0` |
| uppercase host | `ERROR: bad host CHANGE-ME-esgame.example.com` |

The same fix is applied to places' `test/k8s.sh`, where the sibling *did* cover it (20/20 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE