### PR TITLE
fix(ingress-test): a seventh check that could pass on nothing — the audit missed a file

### DIFF
--- a/deploy/k8s/ingress-test.sh
+++ b/deploy/k8s/ingress-test.sh
@@ -118,7 +118,11 @@ for u in ${urls}; do
   case "${ct}" in *tiff*) ok=$((ok + 1));; *) echo "     unfetchable via ingress: ${host} (${ct:-none})";; esac
 done
 echo "     WCS GetCoverage through the ingress: ${ok}/${tot}"
-check "coverage URLs use an ingress host"  "! grep -q 'esgame-geoserver-service' <<<'${urls}'"
+# The -n guard is load-bearing: `! grep -q` over an EMPTY list finds nothing and inverts to
+# true, so a round that returned no URLs at all would report this as green — and this is the
+# check that proves GEOSERVER_PUBLIC_URL reached the client. Seventh instance of that shape
+# found on 2026-07-30; see docs/verification-status.rst, "The checks were audited for vacuity".
+check "coverage URLs use an ingress host"  "[ -n '${urls}' ] && ! grep -q 'esgame-geoserver-service' <<<'${urls}'"
 check "coverage URLs return GeoTIFFs"      "[ ${tot} -gt 0 ] && [ ${ok} = ${tot} ]"
 
 echo

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -205,8 +205,11 @@ The checks were audited for vacuity
 
 A check that cannot fail is worse than no check: it reports success and stops anyone
 looking. On 2026-07-30 every check added that day was re-read for that shape — an
-assertion that also holds when the thing being examined is absent — and **six were
-found, all written the same day**:
+assertion that also holds when the thing being examined is absent — and **seven were
+found, all written the same day**. Six in the first pass; the seventh turned up afterwards
+in :file:`deploy/k8s/ingress-test.sh`, which the first pass had skipped because the inotify
+limit on this host means it cannot be run — a reminder that "not run" and "not audited" are
+easy to conflate:
 
 .. list-table::
    :header-rows: 1
@@ -233,6 +236,10 @@ found, all written the same day**:
      - no
    * - RFC 1123 hosts (CI)
      - same empty-loop shape, and nothing else asserted the Ingresses existed
+     - **no**
+   * - coverage URLs use an ingress host (``deploy/k8s/ingress-test.sh``)
+     - same ``! grep -q`` over a possibly-empty list — found *after* this audit was
+       written, in the one file the audit had skipped because it cannot be run here
      - **no**
 
 None produced a false green — the ones with siblings were caught, and the others happened


### PR DESCRIPTION
```sh
check "coverage URLs use an ingress host" "! grep -q 'esgame-geoserver-service' <<<'${urls}'"
```

Same shape as the six fixed in #111/#112: `! grep -q` over an **empty** list finds nothing and inverts to true, so a round that returned no URLs would report this green. And this is the check that proves `GEOSERVER_PUBLIC_URL` reached the client — the whole point of the file.

## How it was missed

Worth recording rather than quietly adding to the tally.

The audit walked places' test suite and the CI workflow. It **skipped `deploy/k8s/ingress-test.sh`** because that script can't run on this host — the inotify limit blocks the cluster — and *"can't run it"* quietly became *"nothing to look at"*.

Reading a file doesn't require being able to execute it.

## Verified in isolation

The script still can't be run here, so the check logic was tested on its own:

| | old | new |
|---|---|---|
| empty (no URLs returned) | ok | **FAIL** |
| good ingress URLs | ok | ok |
| Service name (the bug) | FAIL | FAIL |

`docs/verification-status.rst`'s audit table now says **seven**, names this one, and says why the first pass missed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE