### PR TITLE
fix(ingress-test): the script died instead of failing, and two more checks passed on nothing

### DIFF
--- a/deploy/k8s/ingress-test.sh
+++ b/deploy/k8s/ingress-test.sh
@@ -12,6 +12,12 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
+# NOTE ON `set -e` AND THE ASSIGNMENTS BELOW. Every value read from the cluster or over the
+# network is suffixed `|| true`. Without it a failed kubectl or curl makes the assignment
+# non-zero, `set -e` aborts, and the script stops mid-run: no FAIL line for the check that
+# would have caught it, no summary, just silence. A missing Ingress should read as
+# "FAIL: adopted by a controller", not as the test harness disappearing.
+
 CLUSTER="${KIND_CLUSTER:-esgame}"
 PORT="${KIND_HTTP_PORT:-8880}"
 K=(kubectl --context "kind-${CLUSTER}")
@@ -20,7 +26,6 @@ BASE="http://localhost:${PORT}"
 # Every request carries a Host header and none of them use port-forward.
 ing()  { curl -s -H "Host: $1" "${BASE}${2:-/}" "${@:3}"; }
 code() { curl -s -o /dev/null -w '%{http_code}' -H "Host: $1" "${BASE}${2:-/}" "${@:3}"; }
-ctype(){ curl -s -o /dev/null -w '%{content_type}' -H "Host: $1" "${BASE}${2:-/}" "${@:3}"; }
 
 fail=0
 check() { if eval "$2" >/dev/null 2>&1; then echo "  ok   $1"; else echo "  FAIL $1"; fail=1; fi; }
@@ -29,8 +34,8 @@ echo "==> the controller is actually wired to our Ingresses"
 # An Ingress only gets a status.loadBalancer address once a controller has adopted it. Empty here
 # means the class did not match and nothing is routing, however healthy everything looks.
 for i in esgame-angular-ingress esgame-calculation-ingress esgame-geoserver-ingress; do
-  addr=$("${K[@]}" get ingress "$i" -o jsonpath='{.status.loadBalancer.ingress[*].ip}{.status.loadBalancer.ingress[*].hostname}' 2>/dev/null)
-  cls=$("${K[@]}" get ingress "$i" -o jsonpath='{.spec.ingressClassName}' 2>/dev/null)
+  addr=$("${K[@]}" get ingress "$i" -o jsonpath='{.status.loadBalancer.ingress[*].ip}{.status.loadBalancer.ingress[*].hostname}' 2>/dev/null || true)
+  cls=$("${K[@]}" get ingress "$i" -o jsonpath='{.spec.ingressClassName}' 2>/dev/null || true)
   check "${i} adopted by a controller (class=${cls:-none})" "[ -n '${addr}' ]"
 done
 
@@ -39,32 +44,37 @@ check "esgame.local serves the app"        "[ \"\$(code esgame.local /)\" = 200 
 check "index.html is really the app"       "ing esgame.local / | grep -qi '<app-root\|<title'"
 check "assets/config.json served"          "[ \"\$(code esgame.local /assets/config.json)\" = 200 ]"
 # The premise of the whole deployment: one image, retargeted by env var at container start.
-want=$("${K[@]}" get cm esgame-config -o jsonpath='{.data.CALC_URL}')
-got=$(ing esgame.local /assets/config.json | sed -n 's/.*"calcUrl"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+want=$("${K[@]}" get cm esgame-config -o jsonpath='{.data.CALC_URL}' 2>/dev/null || true)
+got=$(ing esgame.local /assets/config.json 2>/dev/null | sed -n 's/.*"calcUrl"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' || true)
 echo "     ConfigMap CALC_URL=${want}"
 echo "     served    calcUrl =${got}"
 check "CALC_URL reached the served config" "[ -n '${want}' ] && [ '${want}' = '${got}' ]"
 
 echo "==> a wrong Host must NOT be served by our app"
 # If this returns the app, the Ingress is matching everything and host routing is not working.
-check "unknown host is not the esgame app"  "[ \"\$(code no-such-host.local /)\" != 200 ] || ! ing no-such-host.local / | grep -qi '<app-root'"
+# Only meaningful once the ingress is serving SOMETHING: with nothing listening every request
+# is 000, which is != 200, and this passes without having tested host routing at all.
+check "unknown host is not the esgame app" \
+  "[ \"\$(code esgame.local /)\" = 200 ] && { [ \"\$(code no-such-host.local /)\" != 200 ] || ! ing no-such-host.local / | grep -qi '<app-root'; }"
 
 echo "==> geoserver through the ingress"
-gs_user=$("${K[@]}" get secret esgame-geoserver-admin -o jsonpath='{.data.username}' | base64 -d)
-gs_pass=$("${K[@]}" get secret esgame-geoserver-admin -o jsonpath='{.data.password}' | base64 -d)
+gs_user=$("${K[@]}" get secret esgame-geoserver-admin -o jsonpath='{.data.username}' 2>/dev/null | base64 -d 2>/dev/null || true)
+gs_pass=$("${K[@]}" get secret esgame-geoserver-admin -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null || true)
 check "geoserver REST answers with the Secret creds" \
   "[ \"\$(code esgame-geoserver.local /geoserver/rest/about/version.json -u '${gs_user}:${gs_pass}')\" = 200 ]"
+# Same shape: with GeoServer unreachable the default login "fails" for the wrong reason. Require
+# the Secret's credentials to work first, so this only ever compares two live answers.
 check "the image default password does NOT work" \
-  "[ \"\$(code esgame-geoserver.local /geoserver/rest/about/version.json -u admin:geoserver)\" != 200 ]"
+  "[ \"\$(code esgame-geoserver.local /geoserver/rest/about/version.json -u '${gs_user}:${gs_pass}')\" = 200 ] && [ \"\$(code esgame-geoserver.local /geoserver/rest/about/version.json -u admin:geoserver)\" != 200 ]"
 
 echo "==> a real round through the calculation ingress"
 # Ids come from the raster the deployed calculator actually reads, not from an assumption.
-pod=$("${K[@]}" get pod -l app=esgame-calculation -o jsonpath='{.items[0].metadata.name}')
+pod=$("${K[@]}" get pod -l app=esgame-calculation -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
 "${K[@]}" exec "${pod}" -- R -q -e '
   suppressMessages(library(raster))
   v <- sort(unique(na.omit(values(raster("/app/data/LU_and_NEW_hexa.tif")))))
   cat("IDS:", paste(v[v >= 9], collapse=","), "\n")' 2>/dev/null \
-  | tr -d '\r' | sed -n 's/^IDS: //p' | tr -d ' ' > /tmp/esgame-ingress-ids.txt
+  | tr -d '\r' | sed -n 's/^IDS: //p' | tr -d ' ' > /tmp/esgame-ingress-ids.txt || true
 n=$(tr ',' '\n' < /tmp/esgame-ingress-ids.txt | grep -c . || echo 0)
 echo "     ${n} allocatable ids read from the deployed raster"
 check "read the id space from the pod"     "[ '${n}' -gt 100 ]"
@@ -78,13 +88,18 @@ json.dump({"game_id": "ingress", "round": 1, "score": 42,
 PY
 
 start=$(date +%s)
+# Assign, then default on failure. `|| echo 000` would append to curl's own "000" and report
+# a six-digit status.
+rm -f /tmp/esgame-ingress-round.json
 http=$(curl -s -o /tmp/esgame-ingress-round.json -w '%{http_code}' -m 900 \
   -H 'Host: esgame-calculation.local' -H 'Content-Type: application/json' \
-  --data @/tmp/esgame-ingress-payload.json "${BASE}/esgame")
+  --data @/tmp/esgame-ingress-payload.json "${BASE}/esgame") || http=000
 echo "     POST /esgame via ingress -> ${http} in $(( $(date +%s) - start ))s"
 check "round returns 200 through the ingress" "[ '${http}' = 200 ]"
 
-python3 - /tmp/esgame-ingress-round.json > /tmp/esgame-ingress-summary.txt <<'PY' || true
+# Only if the round actually produced a response; otherwise the summary would be a traceback.
+: > /tmp/esgame-ingress-summary.txt
+[ -s /tmp/esgame-ingress-round.json ] && python3 - /tmp/esgame-ingress-round.json > /tmp/esgame-ingress-summary.txt <<'PY' || true
 import json, sys, math
 rows = json.load(open(sys.argv[1]))["results"]
 scored, urls = 0, []
@@ -99,9 +114,9 @@ for it in rows:
 print(f"SCORED={scored}")
 print("URLS=" + " ".join(urls))
 PY
-grep -v '^SCORED=\|^URLS=' /tmp/esgame-ingress-summary.txt
-scored=$(sed -n 's/^SCORED=//p' /tmp/esgame-ingress-summary.txt)
-urls=$(sed -n 's/^URLS=//p' /tmp/esgame-ingress-summary.txt)
+grep -v '^SCORED=\|^URLS=' /tmp/esgame-ingress-summary.txt || true
+scored=$(sed -n 's/^SCORED=//p' /tmp/esgame-ingress-summary.txt || true)
+urls=$(sed -n 's/^URLS=//p' /tmp/esgame-ingress-summary.txt || true)
 check "indicators scored (not NaN)"        "[ -n '${scored}' ] && [ '${scored}' -ge 5 ]"
 
 echo "==> the returned coverage URLs are fetchable as a browser would fetch them"
@@ -114,7 +129,7 @@ for u in ${urls}; do
   tot=$((tot + 1))
   host=$(sed -E 's|https?://([^/:]+).*|\1|' <<<"${u}")
   path=$(sed -E 's|https?://[^/]+||' <<<"${u}")
-  ct=$(curl -s -o /dev/null -w '%{content_type}' -m 180 -H "Host: ${host}" "${BASE}${path}")
+  ct=$(curl -s -o /dev/null -w '%{content_type}' -m 180 -H "Host: ${host}" "${BASE}${path}" || true)
   case "${ct}" in *tiff*) ok=$((ok + 1));; *) echo "     unfetchable via ingress: ${host} (${ct:-none})";; esac
 done
 echo "     WCS GetCoverage through the ingress: ${ok}/${tot}"


### PR DESCRIPTION
`deploy/k8s/ingress-test.sh` has **never run end to end** — the inotify limit on this host blocks the cluster — so it shipped unproven. Reviewing it rather than waiting to run it turned up five defects, three structural.

## It aborted instead of reporting

Under `set -euo pipefail`, `addr=$(kubectl ...)` on a missing resource makes the assignment non-zero and **the script exits on the spot**: no FAIL line for the check that would have caught it, no summary, just silence.

A missing Ingress should read as *"FAIL: adopted by a controller"*, not as the harness disappearing. Six such assignments, plus the `kubectl exec` pipeline reading the id space and a `grep -v` over an empty summary, now tolerate failure.

## Smaller ones

- **The round's status came back `000000`** — `|| echo 000` appends to curl's own `000`. Assign-then-default instead.
- **The summary was a Python traceback** when no round file existed. Guarded.

## Two more vacuous checks — instances 8 and 9

| check | why it passed on nothing |
|---|---|
| `unknown host is not the esgame app` | with nothing listening every request is `000`, which is `!= 200` — so it passed without testing host routing at all |
| `the image default password does NOT work` | with GeoServer unreachable, the default login "fails" for the wrong reason |

Both now require a live answer first — the app serving, the Secret's credentials working — so they only ever compare two real responses.

## Verified against a cluster that doesn't exist

| | |
|---|---|
| before | dies after 10 lines; **2 of the checks it reached reported ok** |
| after | runs to completion, **15/15 FAIL**, exits 1 |

That's the behaviour I can prove without a cluster. Whether it **passes** against a real one is still untested, and still recorded as such.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE