### PR TITLE
fix(kind.sh): a retry loop that died on the first transient failure

### DIFF
--- a/deploy/k8s/kind.sh
+++ b/deploy/k8s/kind.sh
@@ -121,9 +121,12 @@ EOF
     "${K[@]}" -n ingress-nginx wait --for=condition=complete job/ingress-nginx-admission-patch --timeout=180s 2>/dev/null || true
     echo ">> waiting for the admission webhook to have endpoints"
     for _ in $(seq 1 60); do
-      n=$("${K[@]}" -n ingress-nginx get endpointslice \
+      # `|| true` inside the substitution, not after it: with pipefail a transient kubectl
+      # failure makes the whole pipeline non-zero, `set -e` fires, and the script dies inside
+      # the very loop whose job is to tolerate the resource not being ready yet.
+      n=$( ("${K[@]}" -n ingress-nginx get endpointslice \
             -l kubernetes.io/service-name=ingress-nginx-controller-admission \
-            -o jsonpath='{.items[*].endpoints[*].addresses[*]}' 2>/dev/null | wc -w)
+            -o jsonpath='{.items[*].endpoints[*].addresses[*]}' 2>/dev/null || true) | wc -w)
       [ "${n}" -ge 1 ] && break
       sleep 3
     done
@@ -147,8 +150,8 @@ EOF
     done
     # A Service whose selector matches nothing still applies without error, so assert endpoints.
     for s in esgame-angular-service esgame-geoserver-service esgame-calculation-service; do
-      n=$("${K[@]}" get endpointslice -l "kubernetes.io/service-name=${s}" \
-            -o jsonpath='{.items[*].endpoints[*].addresses[*]}' | wc -w)
+      n=$( ("${K[@]}" get endpointslice -l "kubernetes.io/service-name=${s}" \
+            -o jsonpath='{.items[*].endpoints[*].addresses[*]}' 2>/dev/null || true) | wc -w)
       [ "${n}" -ge 1 ] || { echo "!! ${s} has no endpoints"; exit 1; }
       echo "  ${s} -> ${n} endpoint(s)"
     done


### PR DESCRIPTION
```bash
for _ in $(seq 1 60); do
  n=$(kubectl ... 2>/dev/null | wc -w)
  [ "${n}" -ge 1 ] && break
  sleep 3
done
```

`2>/dev/null` hides kubectl's *message* but not its *exit status*, and under `set -euo pipefail` a non-zero component makes the whole pipeline non-zero. So a transient API failure kills the script **inside the very loop whose job is to tolerate the resource not being ready yet** — and it dies before the `admission webhook never got endpoints` message that would explain it.

Demonstrated in isolation: three iterations become zero, exit 1, no output.

The guard has to be **inside** the substitution — `$( (cmd || true) | wc -w )` — because `|| true` after the assignment is too late; `set -e` has already fired.

Same treatment for the endpoint assertion in `deploy`, the check that catches a Service selector matching nothing. Its exposure is narrower (kubectl succeeds and returns empty in the case it exists to catch, so it worked) but the shape is identical.

Preflight still reports the inotify blocker, and `deploy` against a missing cluster still says so rather than hanging. **What this script does against a working cluster remains untested here.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE