### PR TITLE
fix(registry.sh): verify died instead of reporting when an image was not local

### DIFF
--- a/deploy/registry/registry.sh
+++ b/deploy/registry/registry.sh
@@ -121,11 +121,19 @@ PY
     fail=0
     while IFS=: read -r name _ctx; do
       ref="${REG}/${name}:local"
-      local_digest=$(docker image inspect "${ref}" --format '{{index .RepoDigests 0}}' 2>/dev/null | sed 's/.*@//')
+      # Guarded inside the substitution: `docker image inspect` on an image that is not present
+      # exits non-zero, and under pipefail that aborts the whole script — before the graceful
+      # "could not pull back" on the next line ever runs. `verify` before `push` is exactly that
+      # case, and it died silently instead of reporting FAIL.
+      local_digest=$( (docker image inspect "${ref}" --format '{{index .RepoDigests 0}}' 2>/dev/null || true) | sed 's/.*@//')
       docker rmi "${ref}" >/dev/null 2>&1 || true
       docker pull -q "${ref}" >/dev/null 2>&1 || { echo "  FAIL ${name}: could not pull back"; fail=1; continue; }
-      pulled_digest=$(docker image inspect "${ref}" --format '{{index .RepoDigests 0}}' 2>/dev/null | sed 's/.*@//')
-      if [ -n "${local_digest}" ] && [ "${local_digest}" = "${pulled_digest}" ]; then
+      pulled_digest=$( (docker image inspect "${ref}" --format '{{index .RepoDigests 0}}' 2>/dev/null || true) | sed 's/.*@//')
+      if [ -z "${local_digest}" ]; then
+        # Nothing local to compare against — `verify` was run without a preceding `push`, so it
+        # can confirm the registry serves something but not that it serves what was built.
+        echo "  FAIL ${name}: no local image to compare against; run 'push' first"; fail=1
+      elif [ "${local_digest}" = "${pulled_digest}" ]; then
         echo "  ok   ${name}  ${pulled_digest:0:19}…"
       else
         echo "  FAIL ${name}: pushed ${local_digest:0:19}… != pulled ${pulled_digest:0:19}…"; fail=1


### PR DESCRIPTION
`registry.sh verify` compares the digest of what was pushed against what comes back. The first half was:

```bash
local_digest=$(docker image inspect "${ref}" ... 2>/dev/null | sed 's/.*@//')
```

`docker image inspect` on an image that isn't present exits non-zero, and under `pipefail` that **aborts the whole script** — before the graceful `|| { echo FAIL; continue; }` on the *very next line* ever runs. Running `verify` without a preceding `push` is exactly that case, and it died silently.

The intent was already visible one line down; the guard was just missing one line up.

## Also: a misleading message

An empty local digest produced `FAIL name: pushed … != pulled sha256:…`, which reads as a **digest mismatch** when the real situation is *there is nothing to compare against*. It now says so.

## Both paths exercised

| | |
|---|---|
| one image absent locally | `FAIL esgame: no local image to compare against; run 'push' first`, `ok` for the other three, verdict FAIL |
| after restoring | **4/4 ok**, verdict PASS |

## A wrong hypothesis, recorded

I expected a locally built image to have **no** `RepoDigests` and abort on that. It does have one — buildkit assigns it — so that path was never broken. The real trigger is the image being absent entirely. I tested rather than assumed, and the first guess was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE