### PR TITLE
docs(registry): the config-path warning was right, its example was not

### DIFF
--- a/deploy/registry/README.md
+++ b/deploy/registry/README.md
@@ -44,7 +44,13 @@ Modeled on ord-x's `deploy/build/build-docker-registry.yml`, with two deliberate
   two are separate stores — esgame images have no business in ord-x's volume.
 - **distribution v3, not `registry:2`.** v3 reads `/etc/distribution/config.yml`. Mounting a config
   at v2's `/etc/docker/registry/config.yml` against a v3 image is **silently ignored**: the registry
-  starts happily on its built-in defaults, `delete.enabled` quietly goes away, and nothing says so.
+  starts happily on its built-in defaults and nothing says so. Measured by counting the
+  `X-Content-Type-Options` header this config sets — 0 with no config, 0 with the config at the v2
+  path, 1 at the v3 path.
+
+  An earlier version of this note used `delete.enabled` as the example casualty. That was wrong:
+  v3 enables delete by default, so it survives either way and proves nothing about whether your
+  config was read.
 
 Plain HTTP, no auth. Docker treats `localhost` as insecure-by-default, so pushing from this host
 needs no `daemon.json` change. Anything *not* on this host would — and that is the point at which

--- a/deploy/registry/docker-compose.yml
+++ b/deploy/registry/docker-compose.yml
@@ -19,7 +19,8 @@
 #   * Port 5001, not 5000. ord-x's own registry already holds 0.0.0.0:5000 on this host, and
 #     the two are separate stores — esgame images have no business in ord-x's volume.
 #   * distribution v3, not registry:2. v3 reads /etc/distribution/config.yml; mounting a config
-#     at v2's /etc/docker/registry/config.yml is silently ignored (see registry-config.yml).
+#     at v2's /etc/docker/registry/config.yml is silently ignored — measured, see
+#     registry-config.yml for the three-way comparison that shows it.
 #
 # Plain HTTP, no auth. Docker treats localhost as insecure-by-default, so pushing from this host
 # needs no daemon.json change. Anything NOT on this host would — which is the point at which you

--- a/deploy/registry/registry-config.yml
+++ b/deploy/registry/registry-config.yml
@@ -3,7 +3,18 @@
 # NOTE THE MOUNT PATH. v2 read /etc/docker/registry/config.yml; v3 reads
 # /etc/distribution/config.yml, and its entrypoint passes that path explicitly. Mount a config
 # at the v2 path against a v3 image and it is silently ignored — the registry starts happily on
-# its built-in defaults, so `delete.enabled` quietly goes away and nothing says so.
+# its built-in defaults and nothing says so.
+#
+# Measured, because the first version of this note picked the wrong example. Sending a HEAD to
+# /v2/ and counting the X-Content-Type-Options header set below:
+#
+#   no config mounted        0    <- defaults
+#   config at the v2 path    0    <- ignored, which is the point
+#   config at this v3 path   1    <- read
+#
+# The example that note originally gave — "delete.enabled quietly goes away" — was wrong:
+# distribution v3 enables delete in its own default config, so that setting survives either
+# way and cannot tell you whether your file was read.
 version: 0.1
 
 log:
@@ -13,8 +24,9 @@ storage:
   filesystem:
     rootdirectory: /var/lib/registry
   delete:
-    # Needed by the UI's delete button, and to reclaim space from an image this size:
-    # esgame-calculation is ~3.35 GB per tag.
+    # Needed by the UI's delete button, and to reclaim space from an image this size.
+    # Redundant with v3's default (which already enables delete) but kept explicit, since
+    # relying on a default that changed once already is how the v2/v3 confusion started.
     enabled: true
 
 http:


### PR DESCRIPTION
The note said mounting the config at v2's path against a v3 image is silently ignored, and gave `delete.enabled` as what you lose.

Going to demonstrate that, **the demonstration failed**: `DELETE` returned `202` with the config at the v2 path, which looked like the warning was wrong.

It isn't wrong — **the example was.** distribution v3 enables delete in its *own default config*, so that setting survives whether or not your file is read, and can't tell you anything.

## A discriminator that does work

The `X-Content-Type-Options` header this config sets, since the default doesn't set it. `HEAD /v2/` against three registries:

| | nosniff header |
|---|---|
| no config mounted | **0** — defaults |
| config at the v2 path | **0** — ignored, which is the point |
| config at this v3 path | **1** — read |

So the mount path matters exactly as claimed, now for a reason that's been **measured rather than assumed**. Corrected in `registry-config.yml`, the compose file, and the README — all three repeated the wrong example.

`delete: enabled: true` stays despite being redundant with v3's default: relying on a default that already changed once between majors is how this confusion started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE