### PR TITLE
docs(registry): verify proves the round-trip, not that the images are current

### DIFF
--- a/deploy/registry/README.md
+++ b/deploy/registry/README.md
@@ -60,6 +60,11 @@ you want a real registry instead of this one.
 pulls each tag back and compares repo digests, so what the registry serves is confirmed to be what
 was built.
 
+> **It does not check that the images are current.** The comparison is registry-vs-local, so if the
+> local copy is stale the two agree and `verify` says PASS. This registry served a pre-slimming
+> `esgame-calculation` for an entire evening while `verify` passed every time. Re-run `push` after
+> changing anything the images are built from — it always rebuilds.
+
 ## Pointing a cluster at it
 
 Do **not** repoint `deploy/k8s/base` — its ghcr defaults are what a real deployment wants. Use the

--- a/deploy/registry/registry.sh
+++ b/deploy/registry/registry.sh
@@ -5,6 +5,12 @@
 #   deploy/registry/registry.sh push    # build + push everything the manifests reference
 #   deploy/registry/registry.sh ls      # catalog + tags + sizes
 #   deploy/registry/registry.sh verify  # pull each tag back and compare digests
+#
+# NOTE WHAT verify DOES NOT DO. It compares what the registry serves against the LOCAL image of
+# the same name — so it proves the round-trip, not that either matches your source tree. This
+# registry served a stale esgame-calculation for a whole evening, from before an image-slimming
+# change, and verify reported PASS the entire time because the local copy was equally stale.
+# Re-run `push` after changing anything the images are built from; it always rebuilds.
 #   deploy/registry/registry.sh down    # stop (images survive)
 #   deploy/registry/registry.sh purge   # stop AND drop the volume
 #
@@ -139,7 +145,11 @@ PY
         echo "  FAIL ${name}: pushed ${local_digest:0:19}… != pulled ${pulled_digest:0:19}…"; fail=1
       fi
     done < <(images)
-    [ "${fail}" = 0 ] && echo "registry verify: PASS" || { echo "registry verify: FAIL"; exit 1; }
+    if [ "${fail}" = 0 ]; then
+      echo "registry verify: PASS  (round-trip only — run 'push' to make these match your tree)"
+    else
+      echo "registry verify: FAIL"; exit 1
+    fi
     ;;
 
   down)  "${DC[@]}" down ;;


### PR DESCRIPTION
The registry served a **pre-slimming `esgame-calculation` for an entire evening** — 838 MB compressed where the shipped build is 702 MB — and `verify` reported **PASS** every time it ran.

It wasn't lying. `verify` compares what the registry serves against the **local image of the same name**, so when the local copy is equally stale the two agree. What it proves is that the push round-tripped intact; what it can't see is whether either side reflects the source tree.

I read PASS as *"the registry is fine"*. It only ever meant *"the registry matches what I last pushed"*.

## The drift had reached all four images

| image | before | after |
|---|---|---|
| `esgame-calculation` | 838 MB | **702 MB** |
| `places-calculation` | 840 MB | **710 MB** |
| `esgame` / `places-frontend` | stale digests | rebuilt |

All rebuilt from the current trees and re-pushed; **4/4 verify PASS** afterwards.

## The fix is wording, not logic

The header, the README, and `verify`'s own summary now say what it covers. The summary prints:

```
registry verify: PASS  (round-trip only — run 'push' to make these match your tree)
```

because the place that misled me was a bare `PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE