### PR TITLE
docs: the test counts in this file were stale

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -11,6 +11,13 @@ never rendered, a schema check reporting 10/10 valid on manifests the API server
 
 Last updated: **2026-07-30**.
 
+.. note::
+
+   The counts below drift. "135 unit tests" sat here while the suite grew to 255, because it
+   was written mid-session and never revisited — the same shape as the stale registry images
+   recorded further down: a number that was true when written and is not re-derived when read.
+   Re-measure before trusting one.
+
 
 Verified working
 ----------------
@@ -22,7 +29,7 @@ Verified working
    * - Path
      - How it was checked
    * - Static / grid game
-     - 135 unit tests, 11 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
+     - 255 unit tests, 11 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
        SEO 100. The board renders 2,436 fields; the e2e suite asserts that rather than
        just asserting the component mounted.
    * - No external runtime deps
@@ -68,7 +75,7 @@ Verified working
        plot PNG, and no run-time package installation.
    * - places overlay
      - Renders 11 resources, all valid under ``kubeconform -strict``; ingress-host
-       patches apply; the GeoServer pin flows through from this base. 19 checks in
+       patches apply; the GeoServer pin flows through from this base. 20 checks in
        places' ``test/k8s.sh``, three of them confirmed able to fail by mutation.
    * - places local stack
      - The full compose stack up from a clean slate and a real round played through


### PR DESCRIPTION
**"135 unit tests"** while the suite is at **255**, and **"19 checks"** for a places script that now runs **20**. Both numbers were true when written; neither is re-derived when read.

That's the same shape as two other things found today:

- the registry that served **pre-slimming images** while `verify` reported PASS (#121)
- the checks that **asserted nothing** (#111–#115)

In each case a stated fact stopped tracking reality and nothing noticed, because nothing re-measures it.

Corrected, with a note at the top saying the counts drift and to re-measure before trusting one.

**Measured rather than counted from source:** the places k8s figure is 20 from an *actual run*, not the 17 literal `check` calls in the file — one of them sits in a loop over four env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE