### PR TITLE
ci: make the documented test count re-measure itself

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,35 @@ jobs:
         run: npm run build -- --configuration production
 
       - name: Unit tests
-        run: npm test -- --watch=false
+        run: |
+          # set -o pipefail, or `| tee` masks a failing suite: the pipeline's status would be
+          # tee's. That is the same shape as the vacuous checks fixed in #111-#115.
+          set -o pipefail
+          npm test -- --watch=false 2>&1 | tee /tmp/unit.log
+
+      - name: The documented test count is current
+        run: |
+          # docs/verification-status.rst claims a unit-test count as evidence of coverage. It
+          # said 135 while the suite was at 255 — true when written, never re-derived. A claim
+          # nothing re-measures drifts, so this re-measures it.
+          actual=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/unit.log | grep -oE 'Tests +[0-9]+ passed' | grep -oE '[0-9]+' | head -1)
+          # Anchored to the table row, not any mention: the prose above it discusses a stale
+          # "135 unit tests" and an unanchored grep matched THAT, so the first version of this
+          # check compared the suite against a number quoted in a story about staleness.
+          claimed=$(grep -oE '^\s+- [0-9]+ unit tests,' ../docs/verification-status.rst | grep -oE '[0-9]+' | head -1)
+          echo "suite reports: ${actual:-<none>}   docs claim: ${claimed:-<none>}"
+          # Both must be found, or the check is measuring nothing.
+          if [ -z "$actual" ]; then
+            echo "::error::could not read the test count from the suite output"; exit 1
+          fi
+          if [ -z "$claimed" ]; then
+            echo "::error file=docs/verification-status.rst::no '<n> unit tests' claim found to check"; exit 1
+          fi
+          if [ "$actual" != "$claimed" ]; then
+            echo "::error file=docs/verification-status.rst::says $claimed unit tests, the suite runs $actual — update it"
+            exit 1
+          fi
+          echo "documented count matches the suite"
 
       - name: E2E (Playwright)
         run: npm run e2e


### PR DESCRIPTION
`docs/verification-status.rst` cites a unit-test count as evidence of coverage. It said **135 while the suite was at 255** — true when written, never re-derived, and **nothing in CI reads that file**.

A claim nothing re-measures drifts. This re-measures it every run and fails the build when it disagrees.

## Two things worth recording about writing it

**The first version compared against the wrong number.** `grep -oE '[0-9]+ unit tests'` matched the prose *above* the table — where the note explaining the earlier staleness quotes `"135 unit tests"`. So the check compared the suite against a number inside a story about a stale number, and reported a mismatch on a correct document. Now anchored to the table row (`^\s+- [0-9]+ unit tests,`), which the prose doesn't match.

**The `| tee` this needs is a trap.** GitHub Actions runs bash without `pipefail`, so `npm test | tee log` reports *tee's* status — **a failing suite would pass**. `set -o pipefail` added. Same shape as the vacuous checks in #111–#115, and it would have been a much worse instance.

## Refuses to pass on a missing side

Deleting the claim from the doc fails rather than silently disabling the check. Verified in three states:

| | |
|---|---|
| real doc | `suite=255 doc=255` → ok |
| doc gone stale | `suite=255 doc=135` → ERROR: mismatch |
| claim removed | `suite=255 doc=none` → ERROR: no claim to check |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE