### PR TITLE
docs: a duplicated gap and one that had stopped being true

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -103,6 +103,11 @@ Verified working
        returned 200. Split into ``GEOSERVER_PUBLIC_URL``; measured 6/6 coverages
        fetchable from outside the network in the places stack. Gated in CI, with all
        four failure modes checked by mutation.
+   * - ``tools/R`` after the URL split
+     - Listed under "Not verified" until 2026-07-30 as "esgame's own image has not played a
+       round with ``GEOSERVER_PUBLIC_URL`` set". It has now, repeatedly: through the image
+       pulled from the local registry (200 in 58s, five finite scores, WCS 5/5) and in the
+       single-address configuration below.
    * - …and its backward compatibility
      - The split was claimed to leave an existing single-address deployment unchanged.
        That was an assertion until it was run: ``tools/R`` with ``GEOSERVER`` set and
@@ -266,14 +271,6 @@ Not verified
 
 Honest gaps, so nobody assumes otherwise.
 
-* **No cluster ingress traffic.** Everything k8s was reached by ``port-forward``. No
-  request has gone through an actual ingress controller with a real host and TLS. So
-  ``GEOSERVER_PUBLIC_URL`` was proved end to end in *compose* (6/6 coverages fetched from
-  outside the network) and only statically in k8s — rendered, wired, and gated in CI, but
-  no browser has followed one of those URLs through a real geoserver ingress.
-* **``tools/R`` was not re-run after the URL split.** The change is the same one verified
-  in places' ``calculation.r``, and it defaults to the previous single-address behaviour,
-  but esgame's own image has not played a round with ``GEOSERVER_PUBLIC_URL`` set.
 * **Allocations were synthetic.** Generated from the raster's id set, not produced by a
   player. They satisfy the id-space contract (see :doc:`reference/calculator`) but are
   not real play.
@@ -282,7 +279,11 @@ Honest gaps, so nobody assumes otherwise.
   drives a round through it by ``Host`` header. Neither has been run green: this host's
   ``fs.inotify.max_user_instances`` is 128 where kind needs 512, which crash-loops
   ``kube-proxy`` and cascades into an ingress controller that never gets its certificate.
-  ``kind.sh up`` preflights that and prints the ``sysctl``.
+  ``kind.sh up`` preflights that and prints the ``sysctl``. Everything k8s in this repository
+  has therefore been reached by ``port-forward`` only: ``GEOSERVER_PUBLIC_URL`` is proved end
+  to end in *compose* (6/6 coverages fetched from outside the network) and only statically in
+  k8s — rendered, wired and gated in CI, but no browser has followed one of those URLs through
+  a real geoserver ingress.
 
   Retested on 2026-07-30 at 21:40 with the preflight overridden
   (``KIND_SKIP_SYSCTL_CHECK=1``), several hours and many torn-down containers after the


### PR DESCRIPTION
Two defects in this file, both mine.

## "No cluster ingress traffic" was listed twice

Rewriting that entry in #118 added the detailed version **without removing the original**, so the file carried two bullets saying the same thing with different amounts of detail.

Merged — and the survivor now also carries the half the old one had that the new one lacked: that everything k8s has been reached by `port-forward` only, and what that means for `GEOSERVER_PUBLIC_URL`.

## "`tools/R` was not re-run after the URL split" was false

esgame's own image played a round with `GEOSERVER_PUBLIC_URL` **set** (through the registry-pulled image — 200 in 58s, five finite scores, WCS 5/5), and another with it deliberately **unset** to check the fallback (#110).

Both were recorded elsewhere in this file while the *"not verified"* bullet stayed put. Moved to *Verified working*, saying what it used to claim and what replaced it.

## The pattern

Third kind of drift found today, after checks that couldn't fail (#111–#115) and counts that stopped tracking the suite (#122):

> an entry that was accurate when written, superseded by work recorded **two sections away**, and never reconciled.

Nothing re-reads the file as a whole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE