### PR TITLE
test(k8s): a real browser plays a real round against the cluster

### DIFF
--- a/deploy/k8s/ingress-test.sh
+++ b/deploy/k8s/ingress-test.sh
@@ -55,6 +55,26 @@ echo "     ConfigMap CALC_URL=${want}"
 echo "     served    calcUrl =${got}"
 check "CALC_URL reached the served config" "[ -n '${want}' ] && [ '${want}' = '${got}' ]"
 
+# ...but agreeing with the ConfigMap only proves the env var was plumbed. It says nothing about
+# whether the URL WORKS, and the rest of this script never finds out: every other request here is
+# built from ${BASE} plus a Host header, so it reaches the ingress no matter what the served config
+# says. A CALC_URL with no port passed every check in this file while no browser could play a
+# round — the browser resolves the host and posts to :80, where nothing listens.
+#
+# So take the served URL at its word: resolve ITS host and ITS port the way a client would.
+calc_host=$(sed -E 's|^https?://([^:/]+).*|\1|' <<<"${got}")
+calc_port=$(sed -nE 's|^https?://[^:/]+:([0-9]+).*|\1|p' <<<"${got}")
+[ -n "${calc_port}" ] || calc_port=$(grep -q '^https' <<<"${got}" && echo 443 || echo 80)
+calc_path=$(sed -E 's|^https?://[^/]+||' <<<"${got}")
+echo "     as a client reads it: host=${calc_host} port=${calc_port} path=${calc_path}"
+# --resolve is what a browser's DNS would do; the port is the one the URL actually names.
+calc_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 \
+  --resolve "${calc_host}:${calc_port}:127.0.0.1" \
+  "http://${calc_host}:${calc_port}${calc_path}" -X POST \
+  -H 'Content-Type: application/json' -d '{"allocation":[]}' 2>/dev/null || true)
+# Any HTTP response proves something is listening and routing there; 000 means it is not.
+check "CALC_URL is reachable as written"    "[ -n '${calc_code}' ] && [ '${calc_code}' != 000 ]"
+
 echo "==> a wrong Host must NOT be served by our app"
 # If this returns the app, the Ingress is matching everything and host routing is not working.
 # Only meaningful once the ingress is serving SOMETHING: with nothing listening every request

--- a/deploy/k8s/kind.sh
+++ b/deploy/k8s/kind.sh
@@ -176,7 +176,28 @@ PROBE
       --from-file=LU_and_NEW_hexa.tif="${REPO}/v2/src/assets/images/LU_and_NEW_hexa.tif" \
       --dry-run=client -o yaml | "${K[@]}" apply -f -
 
+    # The overlay hard-codes the ingress port into the browser-facing URLs, because a browser
+    # cannot infer it. If someone moves KIND_HTTP_PORT without moving those, the cluster comes
+    # up fine and only a real browser notices — say so now instead.
+    for v in CALC_URL GEOSERVER_PUBLIC_URL; do
+      want=$(grep -oE "^      - ${v}=.*" overlays/local-registry/kustomization.yaml | head -1)
+      case "${want}" in
+        *":${HTTP_PORT}/"*) ;;
+        "") echo "!! ${v} not found in the overlay"; exit 1 ;;
+        *) echo "!! ${v} in the overlay does not use KIND_HTTP_PORT=${HTTP_PORT}:"
+           echo "   ${want}"
+           echo "   a browser would post to the wrong port; curl with a Host header would not notice"
+           exit 1 ;;
+      esac
+    done
+
     "${K[@]}" apply -k overlays/local-registry
+    # esgame-config is consumed as environment variables, which are fixed when a container
+    # starts, and the ConfigMap's name is stable — so `apply` updates it while every running pod
+    # keeps the old value. Nothing reports a problem: the apply succeeds, the pods stay ready,
+    # and the app serves a stale CALC_URL. Restart so what runs matches what was applied.
+    "${K[@]}" rollout restart deploy/esgame-angular deploy/esgame-calculation >/dev/null
+
     for d in esgame-angular esgame-geoserver esgame-calculation; do
       "${K[@]}" rollout status "deploy/${d}" --timeout=300s
     done

--- a/deploy/k8s/overlays/local-registry/kustomization.yaml
+++ b/deploy/k8s/overlays/local-registry/kustomization.yaml
@@ -108,5 +108,10 @@ configMapGenerator:
     literals:
       # Both of these are fetched by the BROWSER, so they must be the ingress hosts above — not
       # Service names. Plain http: no TLS on a .local cluster.
-      - CALC_URL=http://esgame-calculation.local/esgame
-      - GEOSERVER_PUBLIC_URL=http://esgame-geoserver.local/geoserver
+      #
+      # The :8880 is load-bearing. kind publishes the ingress controller on a host port, not on
+      # 80, so a browser given a portless URL posts to port 80 where nothing listens — the round
+      # fails with a connection error while every Host-header curl in ingress-test.sh passes.
+      # Keep in step with KIND_HTTP_PORT; kind.sh checks that they agree and refuses otherwise.
+      - CALC_URL=http://esgame-calculation.local:8880/esgame
+      - GEOSERVER_PUBLIC_URL=http://esgame-geoserver.local:8880/geoserver

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -111,6 +111,28 @@ Verified working
        The host's ``fs.inotify.max_user_instances`` had to be raised from 128 to 512 first;
        below that ``kube-proxy`` crash-loops and the ingress controller never gets its
        certificate.
+   * - .. _A browser plays a round:
+
+       A browser plays a round
+     - **Closed 2026-07-31.** :file:`v2/e2e-cluster/browser-round.spec.ts` — real Chrome,
+       nothing intercepted, against the live cluster. It loads ``http://esgame.local:8880``
+       through the ingress, clicks 12 hexagons on the board, and presses *Next Level*; the
+       app builds its own allocation and POSTs it to the calculation ingress. Measured:
+       **465 hexagons sent by the browser** (not constructed by the test), 5 WCS coverages
+       fetched from the geoserver ingress, 7 score-board rows, the spider plot rendered, and
+       no page errors. The only accommodation is DNS — Chrome's ``--host-resolver-rules``
+       maps the three ``.local`` hosts to 127.0.0.1, so :file:`/etc/hosts` need not be edited.
+
+       This is the check that made ``CALC_URL`` honest. It was portless, which no test in
+       the repository could see: ``ingress-test.sh`` builds every request from ``BASE`` plus
+       a ``Host`` header, so it reaches the ingress whatever the served config says, and its
+       ``CALC_URL`` check compared the ConfigMap to the served file — consistency, not
+       usability. Both agreed on a URL that pointed at port 80, where nothing listens.
+       Confirmed by mutation: with the portless value restored, ``ingress-test.sh`` reported
+       ``PASS`` on a cluster where a browser could not finish a round, and this spec failed.
+       ``ingress-test.sh`` now also resolves ``CALC_URL``'s own host and port and posts to
+       it, so it no longer passes on that (16 checks, verified failing under the mutation
+       and under an absent config).
    * - Browser-facing GeoServer URL
      - The R calculators built their WCS URLs from ``GEOSERVER`` — the in-cluster
        Service name — so the browser got URLs it could not resolve while everything
@@ -285,9 +307,10 @@ Not verified
 
 Honest gaps, so nobody assumes otherwise.
 
-* **Allocations were synthetic.** Generated from the raster's id set, not produced by a
-  player. They satisfy the id-space contract (see :doc:`reference/calculator`) but are
-  not real play.
+* **Allocations were synthetic** — *closed 2026-07-31*. They were generated from the
+  raster's id set rather than produced by a player: they satisfied the id-space contract
+  (see :doc:`reference/calculator`) but were not real play. ``v2/e2e-cluster`` now closes
+  this. See `A browser plays a round`_.
 * **Timing numbers move.** Lighthouse timings swing with machine load — 57 to 90 for
   identical code on one host. Only the byte budgets are stable; compare timings A/B in
   one sitting or not at all.

--- a/v2/e2e-cluster/README.md
+++ b/v2/e2e-cluster/README.md
@@ -1,0 +1,45 @@
+# Cluster end-to-end test
+
+One spec: a real Chrome plays a real round against a **live kind cluster**. Nothing is
+intercepted and nothing is stubbed.
+
+Everything else that claims a round works stubs something:
+
+| test | what it fakes |
+|---|---|
+| `v2/src/**/*.spec.ts` | the tiff and calculation services |
+| `v2/e2e/round-trip.spec.ts` | the calculator, via `page.route` |
+| `deploy/k8s/ingress-test.sh` | the client — `curl` with a `Host` header, not a browser |
+
+That last row is why this exists. `curl` builds its requests from a base URL, so it reaches
+the ingress no matter what the app was configured with. A browser reads `calcUrl` out of
+`assets/config.json` and goes where it says. The two disagree in exactly one place — and
+that is where a bug lived: `CALC_URL` had no port, so the browser posted to `:80` while
+every `curl`-based check passed.
+
+## Running it
+
+```sh
+deploy/registry/registry.sh up && deploy/registry/registry.sh push
+deploy/k8s/kind.sh up && deploy/k8s/kind.sh deploy
+
+cd v2 && npx playwright test --config e2e-cluster/browser-round.config.ts
+```
+
+It is **not** part of `npm run e2e`. That command builds and serves a local `dist`, which is
+the opposite of what this wants; `testDir` here is `e2e-cluster`, and the default config's is
+`e2e`, so neither picks up the other.
+
+Set `KIND_HTTP_PORT` if the cluster is not on 8880 — the same variable `kind.sh` takes.
+
+## The .local hosts
+
+The three ingress hosts are not in `/etc/hosts`, and this should not require editing it. So
+Chrome is told to resolve them itself:
+
+```
+--host-resolver-rules=MAP esgame.local 127.0.0.1, ...
+```
+
+That is the only accommodation. The app, the calculator and GeoServer are all reached the
+way a user reaches them.

--- a/v2/e2e-cluster/browser-round.config.ts
+++ b/v2/e2e-cluster/browser-round.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from '@playwright/test';
+
+// Playwright config for browser-round.spec.ts, which drives the LIVE kind cluster rather than a
+// local build — so there is no webServer here and no baseURL: the spec addresses the ingress
+// hosts directly.
+//
+// host-resolver-rules is the only accommodation made. The .local hosts are not in /etc/hosts and
+// this should not require editing it, so Chrome is told to resolve them itself. Everything else
+// — the app, the calculator, GeoServer — is reached exactly as a user would reach it.
+export default defineConfig({
+	testDir: '.',   // v2/e2e-cluster — deliberately NOT ./e2e, so `npm run e2e` does not pick it up
+	testMatch: 'browser-round.spec.ts',
+	timeout: 300_000,
+	expect: { timeout: 120_000 },
+	workers: 1,
+	reporter: 'list',
+	use: {
+		channel: 'chrome',
+		headless: true,
+		launchOptions: {
+			args: [
+				'--no-sandbox',
+				'--disable-gpu',
+				'--host-resolver-rules=MAP esgame.local 127.0.0.1, MAP esgame-calculation.local 127.0.0.1, MAP esgame-geoserver.local 127.0.0.1',
+			],
+		},
+	},
+});

--- a/v2/e2e-cluster/browser-round.spec.ts
+++ b/v2/e2e-cluster/browser-round.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '@playwright/test';
+
+// A real browser playing a real round against the live cluster.
+//
+// Everything else that claims a round works stubs something: the unit specs fake the tiff
+// service, e2e/round-trip.spec.ts intercepts the calculator, and ingress-test.sh POSTs with
+// curl and a Host header. This closes the last of those — "Allocations were synthetic" in
+// docs/verification-status.rst — by having Chrome fetch the app through the ingress, build
+// its own allocation from what the player clicked, POST it to the calculation ingress, and
+// render the coverage URLs GeoServer hands back.
+//
+// Nothing is intercepted. The only accommodation is DNS: the .local hosts resolve to 127.0.0.1
+// via Chrome's host-resolver-rules, because there is no entry for them in /etc/hosts.
+//
+//   deploy/k8s/kind.sh up && deploy/k8s/kind.sh deploy
+//   cd v2 && npx playwright test --config e2e-cluster/browser-round.config.ts
+//
+// It lives under v2/ because that is where Playwright is installed, and in e2e-cluster/ rather
+// than e2e/ so `npm run e2e` — which builds and serves a local dist — does not try to run it.
+
+const PORT = process.env.KIND_HTTP_PORT ?? '8880';
+const APP = `http://esgame.local:${PORT}`;
+
+test.describe.configure({ mode: 'serial', timeout: 300_000 });
+
+test('a browser plays a round end to end against the cluster', async ({ page }) => {
+	const errors: string[] = [];
+	const calcPosts: any[] = [];
+	const coverageFetches: string[] = [];
+
+	page.on('pageerror', e => errors.push(e.message));
+	page.on('request', r => {
+		if (r.url().includes('esgame-calculation.local') && r.method() === 'POST') {
+			try { calcPosts.push(r.postDataJSON()); } catch { calcPosts.push(null); }
+		}
+		if (r.url().includes('esgame-geoserver.local')) coverageFetches.push(r.url());
+	});
+
+	await page.goto(`${APP}/dynamic-game`, { waitUntil: 'domcontentloaded' });
+	await expect(page.locator('tro-svg-game-board').first()).toBeVisible({ timeout: 120_000 });
+
+	// The instructions open over the board on levels 1-2.
+	try {
+		await page.locator('tro-help .backdrop.--open').waitFor({ state: 'visible', timeout: 20_000 });
+		await page.locator('tro-help .icon-close').first().click({ force: true });
+	} catch { /* not always shown */ }
+	await page.waitForTimeout(500);
+
+	// Play: pick a production type, place hexagons.
+	await page.locator('tro-production-type-button').first().click();
+	const fields = page.locator('tro-svg-game-board.main-board path[troSvgField]');
+	await expect.poll(() => fields.count(), { timeout: 120_000 }).toBeGreaterThan(100);
+	for (let i = 0; i < 12; i++) await fields.nth(i * 3).click({ force: true });
+
+	await page.locator('button.btn-next').click();
+
+	// The spider plot only renders once a result carrying id -1 came back and was consumed.
+	await expect(page.locator('.expandable img')).toBeVisible({ timeout: 240_000 });
+
+	// The browser built and sent its own allocation — nothing here constructed it.
+	expect(calcPosts).toHaveLength(1);
+	const body = calcPosts[0];
+	expect(Array.isArray(body.allocation)).toBe(true);
+	expect(body.allocation.length).toBeGreaterThan(400);
+	expect(body.allocation.every((a: any) => typeof a.id === 'number')).toBe(true);
+	console.log(`  allocation sent by the browser: ${body.allocation.length} hexagons`);
+
+	// And it fetched the coverages GeoServer published, through the geoserver ingress.
+	const wcs = coverageFetches.filter(u => u.includes('/wcs?'));
+	console.log(`  coverage URLs fetched by the browser: ${wcs.length}`);
+	expect(wcs.length).toBeGreaterThanOrEqual(5);
+
+	// The score board shows what came back.
+	const rows = await page.locator('tro-score-board table tr').count();
+	console.log(`  score board rows: ${rows}`);
+	expect(rows).toBeGreaterThan(1);
+
+	expect(errors).toEqual([]);
+});


### PR DESCRIPTION
## The gap

`docs/verification-status.rst` has carried this since the k8s work started:

> **Allocations were synthetic.** Generated from the raster's id set, not produced by a player.

Every check that claims a round works stubs something — the unit specs fake the tiff service, `e2e/round-trip.spec.ts` intercepts the calculator, and `deploy/k8s/ingress-test.sh` stubs the **client**: it is `curl` with a `Host` header.

## Why the client mattered

`curl` builds each request from a base URL, so it reaches the ingress whatever the app was configured with. A browser reads `calcUrl` out of `assets/config.json` and goes where it says.

The overlay's `CALC_URL` had no port. kind publishes ingress-nginx on 8880, not 80, so a browser posted to port 80 where nothing listens. No test in the repository could see it — including the one check that looked like it should, which compared the ConfigMap to the served file. They agreed. On a URL that did not work.

## Verified by mutation, not by assertion

With the portless value put back:

```
ingress-test.sh  →  ingress round-trip: PASS      # on a cluster no browser can play on
browser-round    →  1 failed
```

Restored, on the live cluster:

```
allocation sent by the browser: 465 hexagons
coverage URLs fetched by the browser: 5
score board rows: 7
1 passed (44.3s)
```

The 465 hexagons are built by the app from what was clicked — the test constructs no allocation.

## Changes

- **`v2/e2e-cluster/`** — the spec, its config, a README. Its own `testDir` so `npm run e2e` (which serves a local `dist`) does not try to run it. The only accommodation is DNS: Chrome's `--host-resolver-rules` maps the three `.local` hosts to 127.0.0.1, so `/etc/hosts` need not be edited.
- **`overlays/local-registry`** — the ingress port in `CALC_URL` and `GEOSERVER_PUBLIC_URL`.
- **`kind.sh`** — refuse to deploy when those disagree with `KIND_HTTP_PORT`; `rollout restart` after applying. `esgame-config` is consumed as env vars, fixed at container start, under a stable name — so `apply` updated the ConfigMap while every running pod kept the old value. That is how the fix looked like it had not worked.
- **`ingress-test.sh`** — resolve `CALC_URL`'s own host and port and post to it. Checked against all three states: correct (passes), portless (fails), absent config (fails).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE