### PR TITLE
test(k8s): play two rounds from a browser against the cluster

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -133,6 +133,17 @@ Verified working
        ``ingress-test.sh`` now also resolves ``CALC_URL``'s own host and port and posts to
        it, so it no longer passes on that (16 checks, verified failing under the mutation
        and under an absent config).
+
+       A second spec plays **two** rounds. :file:`v2/e2e/round-trip.spec.ts` already covered
+       this, but against an intercepted calculator whose two responses were query-string
+       variants of one another; here they are two coverages GeoServer really published, and
+       the calculator turns out to isolate each round in its **own workspace**
+       (``esgame_game<uuid>_round1`` / ``_round2``). Measured: rounds 1 and 2 posted with
+       distinct ``round`` values, zero overlap between the two sets of five coverage ids, and
+       round 1's five coverages still returning 200 after round 2 published — so the history
+       accumulates rather than being overwritten. Verified by mutation: replaying round 1's
+       response for round 2 (what a failed in-place swap of ``settings.maps`` looks like on
+       the wire) fails the overlap assertion, naming all five reused coverages.
    * - Browser-facing GeoServer URL
      - The R calculators built their WCS URLs from ``GEOSERVER`` — the in-cluster
        Service name — so the browser got URLs it could not resolve while everything

--- a/v2/e2e-cluster/README.md
+++ b/v2/e2e-cluster/README.md
@@ -1,7 +1,12 @@
 # Cluster end-to-end test
 
-One spec: a real Chrome plays a real round against a **live kind cluster**. Nothing is
-intercepted and nothing is stubbed.
+A real Chrome plays real rounds against a **live kind cluster**. Nothing is intercepted and
+nothing is stubbed.
+
+1. **one round end to end** — the app builds its own allocation from clicked hexagons, POSTs
+   it to the calculation ingress, and renders the coverages GeoServer publishes.
+2. **a second round replaces the first round's maps** — two rounds, zero overlap between
+   their coverage ids, and round 1's coverages still fetchable afterwards.
 
 Everything else that claims a round works stubs something:
 

--- a/v2/e2e-cluster/browser-round.spec.ts
+++ b/v2/e2e-cluster/browser-round.spec.ts
@@ -1,6 +1,6 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 
-// A real browser playing a real round against the live cluster.
+// A real browser playing real rounds against the live cluster.
 //
 // Everything else that claims a round works stubs something: the unit specs fake the tiff
 // service, e2e/round-trip.spec.ts intercepts the calculator, and ingress-test.sh POSTs with
@@ -21,59 +21,134 @@ import { test, expect } from '@playwright/test';
 const PORT = process.env.KIND_HTTP_PORT ?? '8880';
 const APP = `http://esgame.local:${PORT}`;
 
-test.describe.configure({ mode: 'serial', timeout: 300_000 });
+/** What the browser sent to and fetched from the cluster, recorded per page. */
+interface Traffic {
+	errors: string[];
+	posts: any[];
+	coverages: string[];
+}
 
-test('a browser plays a round end to end against the cluster', async ({ page }) => {
-	const errors: string[] = [];
-	const calcPosts: any[] = [];
-	const coverageFetches: string[] = [];
-
-	page.on('pageerror', e => errors.push(e.message));
+function watch(page: Page): Traffic {
+	const t: Traffic = { errors: [], posts: [], coverages: [] };
+	page.on('pageerror', e => t.errors.push(e.message));
 	page.on('request', r => {
 		if (r.url().includes('esgame-calculation.local') && r.method() === 'POST') {
-			try { calcPosts.push(r.postDataJSON()); } catch { calcPosts.push(null); }
+			try { t.posts.push(r.postDataJSON()); } catch { t.posts.push(null); }
 		}
-		if (r.url().includes('esgame-geoserver.local')) coverageFetches.push(r.url());
+		if (r.url().includes('esgame-geoserver.local') && r.url().includes('/wcs?')) {
+			t.coverages.push(r.url());
+		}
 	});
+	return t;
+}
+
+// The instructions dialog auto-opens on every level up to 2 and its backdrop swallows clicks,
+// so it has to be dismissed before each placement, not once at the start.
+async function dismissHelp(page: Page) {
+	const backdrop = page.locator('tro-help .backdrop.--open');
+	try {
+		await backdrop.waitFor({ state: 'visible', timeout: 8_000 });
+	} catch {
+		return;   // not every transition opens it
+	}
+	await page.locator('tro-help .backdrop.--open .icon-close').first().click({ force: true });
+	await expect(backdrop).toHaveCount(0, { timeout: 15_000 });
+}
+
+// `offset` matters: a field already carrying a production type is refused by the placement
+// rules, so a second round clicking the same indices places nothing at all and submits an
+// unchanged allocation. Rounds must touch different hexagons — which is what a player does.
+async function placeAndSubmit(page: Page, count: number, offset = 0) {
+	await dismissHelp(page);
+	await page.locator('tro-production-type-button').first().click();
+	const fields = page.locator('tro-svg-game-board.main-board path[troSvgField]');
+	await expect.poll(() => fields.count(), { timeout: 120_000 }).toBeGreaterThan(offset + count * 3);
+	for (let i = 0; i < count; i++) await fields.nth(offset + i * 3).click({ force: true });
+	await page.locator('button.btn-next').click();
+}
+
+/** The coverage each WCS URL asks for — this is what changes between rounds. */
+function coverageIds(urls: string[]): string[] {
+	return urls.map(u => new URL(u).searchParams.get('coverageId') ?? u);
+}
+
+test.describe.configure({ mode: 'serial', timeout: 420_000 });
+
+test('a browser plays a round end to end against the cluster', async ({ page }) => {
+	const t = watch(page);
 
 	await page.goto(`${APP}/dynamic-game`, { waitUntil: 'domcontentloaded' });
 	await expect(page.locator('tro-svg-game-board').first()).toBeVisible({ timeout: 120_000 });
 
-	// The instructions open over the board on levels 1-2.
-	try {
-		await page.locator('tro-help .backdrop.--open').waitFor({ state: 'visible', timeout: 20_000 });
-		await page.locator('tro-help .icon-close').first().click({ force: true });
-	} catch { /* not always shown */ }
-	await page.waitForTimeout(500);
-
-	// Play: pick a production type, place hexagons.
-	await page.locator('tro-production-type-button').first().click();
-	const fields = page.locator('tro-svg-game-board.main-board path[troSvgField]');
-	await expect.poll(() => fields.count(), { timeout: 120_000 }).toBeGreaterThan(100);
-	for (let i = 0; i < 12; i++) await fields.nth(i * 3).click({ force: true });
-
-	await page.locator('button.btn-next').click();
+	await placeAndSubmit(page, 12);
 
 	// The spider plot only renders once a result carrying id -1 came back and was consumed.
 	await expect(page.locator('.expandable img')).toBeVisible({ timeout: 240_000 });
 
 	// The browser built and sent its own allocation — nothing here constructed it.
-	expect(calcPosts).toHaveLength(1);
-	const body = calcPosts[0];
+	expect(t.posts).toHaveLength(1);
+	const body = t.posts[0];
 	expect(Array.isArray(body.allocation)).toBe(true);
 	expect(body.allocation.length).toBeGreaterThan(400);
 	expect(body.allocation.every((a: any) => typeof a.id === 'number')).toBe(true);
 	console.log(`  allocation sent by the browser: ${body.allocation.length} hexagons`);
 
 	// And it fetched the coverages GeoServer published, through the geoserver ingress.
-	const wcs = coverageFetches.filter(u => u.includes('/wcs?'));
-	console.log(`  coverage URLs fetched by the browser: ${wcs.length}`);
-	expect(wcs.length).toBeGreaterThanOrEqual(5);
+	console.log(`  coverage URLs fetched by the browser: ${t.coverages.length}`);
+	expect(t.coverages.length).toBeGreaterThanOrEqual(5);
 
 	// The score board shows what came back.
 	const rows = await page.locator('tro-score-board table tr').count();
 	console.log(`  score board rows: ${rows}`);
 	expect(rows).toBeGreaterThan(1);
 
-	expect(errors).toEqual([]);
+	expect(t.errors).toEqual([]);
+});
+
+test('a second round replaces the first round\'s maps', async ({ page }) => {
+	// e2e/round-trip.spec.ts already asserts this — against an intercepted calculator whose
+	// URLs are query-string variants of one another. Here the two rounds are two genuinely
+	// different coverages, published by GeoServer under names the calculator chose, which is
+	// where the interesting failure lives: `settings.maps` is mutated in place, so a bug in
+	// the swap re-renders round 1 forever while the network shows a healthy second round.
+	const t = watch(page);
+
+	await page.goto(`${APP}/dynamic-game`, { waitUntil: 'domcontentloaded' });
+	await expect(page.locator('tro-svg-game-board').first()).toBeVisible({ timeout: 120_000 });
+
+	await placeAndSubmit(page, 12);
+	await expect(page.locator('.expandable img')).toBeVisible({ timeout: 240_000 });
+	const round1 = coverageIds(t.coverages);
+	expect(round1.length).toBeGreaterThanOrEqual(5);
+	console.log(`  round 1 coverages: ${round1.join(', ')}`);
+
+	// Round 2, on hexagons round 1 did not touch.
+	const before = t.coverages.length;
+	await placeAndSubmit(page, 12, 1);
+	await expect.poll(() => t.posts.length, { timeout: 300_000 }).toBe(2);
+	await expect.poll(() => t.coverages.length, { timeout: 300_000 }).toBeGreaterThanOrEqual(before + 5);
+
+	const round2 = coverageIds(t.coverages.slice(before));
+	console.log(`  round 2 coverages: ${round2.join(', ')}`);
+
+	// The app told the calculator which round this was, and it was a different one.
+	expect(t.posts[1].round).not.toBe(t.posts[0].round);
+	console.log(`  rounds posted: ${t.posts[0].round} then ${t.posts[1].round}`);
+
+	// The board fetched round 2's coverages, not round 1's again. Overlap of zero is the
+	// assertion: every name changed, because the calculator stamps the round into each one.
+	expect(round2.filter(c => round1.includes(c))).toEqual([]);
+
+	// And round 1's coverages still exist. The calculator publishes into one GeoServer
+	// workspace round after round; if round 2 overwrote round 1's layers instead of adding
+	// its own, the game's history would silently rot behind the player.
+	const stillThere = await page.evaluate(async (urls: string[]) => {
+		const codes: number[] = [];
+		for (const u of urls) codes.push((await fetch(u)).status);
+		return codes;
+	}, t.coverages.slice(0, 5));
+	console.log(`  round 1 coverages re-fetched after round 2: ${stillThere.join(', ')}`);
+	expect(stillThere).toEqual([200, 200, 200, 200, 200]);
+
+	expect(t.errors).toEqual([]);
 });


### PR DESCRIPTION
Follow-on to #126. That one proved a browser can play *a* round against the cluster; this proves it can play a **second** one.

## Why the existing coverage wasn't enough

`v2/e2e/round-trip.spec.ts` already asserts round 2 replaces round 1's maps — against an intercepted calculator whose two responses are query-string variants of the same asset:

```
/assets/images/esgame_img_ag_carbon.tif?round=1
/assets/images/esgame_img_ag_carbon.tif?round=2
```

That checks the app consumes a second response. It cannot check anything about how rounds are really published, because nothing really publishes them.

## What the cluster shows

The calculator isolates each round in **its own GeoServer workspace** — visible only when a real GeoServer is on the other end:

```
round 1: esgame_game<uuid>_round1:HH_Game_<uuid>_Round_1  (+ NP, WA, HC, RV)
round 2: esgame_game<uuid>_round2:HH_Game_<uuid>_Round_2  (+ NP, WA, HC, RV)
rounds posted: 1 then 2
round 1 coverages re-fetched after round 2: 200, 200, 200, 200, 200
```

Three assertions follow: the posted `round` differs, the two sets of coverage ids overlap in **zero** places, and round 1's coverages still serve 200 after round 2 published. That last one is the point of the workspace-per-round scheme — the history accumulates instead of being overwritten behind the player.

## Verified by mutation

Replaying round 1's response for round 2 — what a failed in-place swap of `settings.maps` looks like on the wire — fails the overlap assertion and names all five reused coverages.

Two earlier attempts at that mutation were **discarded because they failed for the wrong reason**: one crashed the browser during round 1, and one hit `route.fetch: getaddrinfo ENOTFOUND esgame-calculation.local` — `route.fetch` runs in Node, where Chrome's `--host-resolver-rules` does not apply. A red result is not a caught mutation.

## Note on CI

These specs need a live cluster and are not wired into CI, by design — `v2/e2e-cluster/README.md` says how to run them. `npm run e2e` does not pick them up (different `testDir`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE