### PR TITLE
fix(deps): resolve the @hono/node-server advisory (GHSA, < 2.0.5)

### DIFF
--- a/v2/package-lock.json
+++ b/v2/package-lock.json
@@ -1487,13 +1487,13 @@
       "optional": true
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.17",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
-      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -2194,13 +2194,13 @@
       ]
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",

--- a/v2/package.json
+++ b/v2/package.json
@@ -44,6 +44,8 @@
     "glob": "^13.0.6",
     "rimraf": "^6.1.3",
     "tmp": "^0.2.7",
-    "uuid": "^14.0.1"
+    "uuid": "^14.0.1",
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "@hono/node-server": "^2.0.5"
   }
 }


### PR DESCRIPTION
Closes Dependabot alert [145](https://github.com/mlacayoemery/esgame/security/dependabot/145). The only open alert on the repository.

## Why it could not be fixed by upgrading

```
@angular/cli@22.1.0
└─ @modelcontextprotocol/sdk@1.29.0   ← pinned exactly by the CLI
   └─ @hono/node-server@1.19.17       ← vulnerable; SDK 1.29.0 accepts only ^1.19.9
```

`@angular/cli@22.1.2` (the newest release) still pins the SDK at 1.29.0, and every version in `^1.19.9` is vulnerable — the fix landed in 2.0.5.

## The override goes one level above the vulnerable package

`@modelcontextprotocol/sdk@1.30.0` widened its range to `^1.19.9 || ^2.0.5`. Overriding the SDK first means the `@hono/node-server` pin sits *inside* a range the package declares, instead of being forced past one it rejects:

```json
"@modelcontextprotocol/sdk": "^1.30.0",
"@hono/node-server": "^2.0.5"
```

Both entries are needed — with only the SDK overridden, npm kept 1.19.17, which still satisfies the widened range.

## Verified

| check | result |
|---|---|
| `npm audit` | 0 vulnerabilities |
| `npm audit --omit=dev` | 0 vulnerabilities |
| `npm run build` | succeeds |
| `npm test` | 255 passed / 27 files |
| `ng mcp` handshake | responds with `serverInfo: angular-cli-server 22.1.0` on hono 2.0.12 |

That last row is the one that matters: the path is dev-only and never reaches a browser, so no existing test touches it. `ng mcp` is the CLI feature that actually loads the SDK, and it is what this override could plausibly break. It completes a real JSON-RPC `initialize`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE