### PR TITLE
test(k8s): gate that browser-facing URLs name a host an Ingress serves

### DIFF
--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -145,6 +145,24 @@ jobs:
           fi
           echo "GeoServer public URL is separate, wired through, and used for coverage URLs"
 
+      - name: Browser-facing URLs must name a host an Ingress serves
+        run: |
+          # The check above asks whether GEOSERVER_PUBLIC_URL differs from the in-cluster
+          # Service URL. That is weaker than the question that matters: does it name a host an
+          # Ingress in the same render actually answers for? And CALC_URL — where the browser
+          # POSTs the allocation — was not checked at all.
+          #
+          # The places overlay, which consumes this base, shipped a CALC_URL pointing at a host
+          # from a different deployment while every check there passed. It rendered, it would
+          # have applied, and it would have failed only in a browser.
+          #
+          # This also renders the local-registry overlay, which nothing in CI rendered before.
+          #
+          # The render step above extracts kustomize into the workspace root rather than onto
+          # PATH; the script looks it up by name so it works the same way when run by hand.
+          export PATH="${GITHUB_WORKSPACE}:${PATH}"
+          ./deploy/k8s/render-test.sh
+
       - name: Ingress hosts must be valid RFC 1123 subdomains
         run: |
           # kubeconform does not check this: a host is just a string in the schema, so

--- a/deploy/k8s/render-test.sh
+++ b/deploy/k8s/render-test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Checks a rendered Kustomize directory for URLs the browser is given but nothing serves.
+#
+#   deploy/k8s/render-test.sh                     # base and every overlay
+#   deploy/k8s/render-test.sh deploy/k8s/base     # just one
+#
+# Two env vars in the ConfigMap are fetched by the BROWSER rather than from inside the cluster:
+#
+#   CALC_URL              the app POSTs the allocation here
+#   GEOSERVER_PUBLIC_URL  the coverage URLs the calculator hands back are built from this
+#
+# Each has to name a host an Ingress in the SAME render answers for. Nothing checked that. CI
+# asked only whether GEOSERVER_PUBLIC_URL differed from the in-cluster Service URL, which is a
+# weaker question — and the places overlay, which inherits this base, shipped a CALC_URL
+# pointing at a host from an entirely different deployment while every check passed. It renders,
+# it applies, and it fails only in a browser.
+#
+# Needs kustomize and python3. Requires no cluster.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+command -v kustomize >/dev/null || { echo "kustomize not on PATH"; exit 2; }
+
+if [ "$#" -gt 0 ]; then
+  DIRS=("$@")
+else
+  # Every kustomization under deploy/k8s, so a new overlay is covered the day it is added
+  # rather than the day someone remembers to list it here.
+  mapfile -t DIRS < <(find deploy/k8s -name kustomization.yaml -printf '%h\n' | sort)
+fi
+[ "${#DIRS[@]}" -gt 0 ] || { echo "!! no kustomization.yaml found under deploy/k8s"; exit 1; }
+
+rendered=$(mktemp); trap 'rm -f "${rendered}"' EXIT
+fail=0
+
+for d in "${DIRS[@]}"; do
+  echo "==> ${d}"
+  # Not inside $( ): with `set -e` a failed render there aborts the script with no message
+  # naming the directory that broke.
+  if ! kustomize build "${d}" > "${rendered}" 2>/dev/null; then
+    echo "  FAIL ${d} does not render"; fail=1; continue
+  fi
+
+  out=$(python3 - "${rendered}" <<'PY'
+import sys, yaml
+from urllib.parse import urlparse
+
+docs = [d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+cfgs = [d for d in docs if d.get('kind') == 'ConfigMap'
+        and d['metadata']['name'].startswith('esgame-config')]
+# Ingress hosts carry no port — a port belongs to the URL, not to the host an Ingress matches —
+# so compare hostnames only.
+hosts = {d['metadata']['name']: (d['spec'].get('rules') or [{}])[0].get('host')
+         for d in docs if d.get('kind') == 'Ingress'}
+
+if not cfgs:
+    print('FAIL\tesgame-config\tno such ConfigMap in the render'); raise SystemExit
+if not hosts:
+    print('FAIL\tingresses\tthe render contains no Ingress'); raise SystemExit
+
+data = cfgs[0].get('data') or {}
+for var, ing in (('CALC_URL', 'esgame-calculation-ingress'),
+                 ('GEOSERVER_PUBLIC_URL', 'esgame-geoserver-ingress')):
+    url = data.get(var)
+    if not url:
+        print(f'FAIL\t{var}\tnot set in the ConfigMap'); continue
+    if ing not in hosts:
+        print(f'FAIL\t{var}\t{ing} is not in the render'); continue
+    have, want = urlparse(url).hostname, hosts[ing]
+    if not have:
+        print(f'FAIL\t{var}\t{url!r} has no host'); continue
+    if not want:
+        print(f'FAIL\t{var}\t{ing} sets no host'); continue
+    if have != want:
+        print(f'FAIL\t{var}\tpoints at {have}, but {ing} serves {want}'); continue
+    # A browser cannot infer a port. Whichever port the ingress controller is published on has
+    # to be in the URL unless it is the scheme default, or the POST silently goes to 80/443.
+    port = urlparse(url).port
+    print(f'ok\t{var}\t{have}{"" if port is None else ":" + str(port)} via {ing}')
+PY
+)
+  while IFS=$'\t' read -r status var detail; do
+    [ -n "${status}" ] || continue
+    printf '  %-4s %-22s %s\n' "${status}" "${var}" "${detail}"
+    [ "${status}" = FAIL ] && fail=1
+  done <<<"${out}"
+
+  # The loop above reports whatever python printed, so no output at all would be a silent pass.
+  n=$(grep -c . <<<"${out}" || true)
+  if [ "${n}" -lt 2 ]; then
+    echo "  FAIL expected 2 URL checks for ${d}, got ${n}"; fail=1
+  fi
+done
+
+if [ "${fail}" = 0 ]; then
+  echo "public URLs name a host an Ingress serves: PASS"
+else
+  echo "public URLs name a host an Ingress serves: FAIL"; exit 1
+fi


### PR DESCRIPTION
## The weaker question

CI asked whether `GEOSERVER_PUBLIC_URL` differed from the in-cluster Service URL. The question that matters is different: does it name a host an Ingress **in the same render** actually answers for? And `CALC_URL` — where the browser POSTs the allocation — was not checked at all.

## It already happened

The [places](https://github.com/s-gebhardt/places) overlay, which consumes this base, shipped:

```yaml
# Public calculation URL the browser posts to (must match the calculation ingress host above).
CALC_URL: "https://esgame-calculation.containers.wurnet.nl/esgame"
```

…against an Ingress serving `change-me-places-calculation.example.com`. The comment says they must match. They did not — it named a host from a different deployment. All 16 checks in that repo's `test/k8s.sh` passed.

A URL like that renders, applies, and fails only in a browser.

## What this adds

`deploy/k8s/render-test.sh` — no cluster needed:

```
==> deploy/k8s/base
  ok   CALC_URL               change-me-esgame-calculation.example.com via esgame-calculation-ingress
  ok   GEOSERVER_PUBLIC_URL   change-me-esgame-geoserver.example.com via esgame-geoserver-ingress
==> deploy/k8s/overlays/local-registry
  ok   CALC_URL               esgame-calculation.local:8880 via esgame-calculation-ingress
  ok   GEOSERVER_PUBLIC_URL   esgame-geoserver.local:8880 via esgame-geoserver-ingress
public URLs name a host an Ingress serves: PASS
```

It pairs each var with its Ingress **by name** (positional matching would pass silently if the render order changed) and compares hostnames — an Ingress host carries no port. It finds kustomizations with `find`, so a new overlay is covered the day it's added.

## Every branch exercised, not assumed

| mutation | result |
|---|---|
| `CALC_URL` names an unserved host | fails — *points at esgame-calculation.wrong.local, but …-ingress serves esgame-calculation.local* |
| `CALC_URL` deleted from the overlay | fails — falls back to the base placeholder, then mismatches |
| `GEOSERVER_PUBLIC_URL` set to the Service | fails |
| synthetic render, no URL in the ConfigMap | fails — *not set in the ConfigMap* |
| synthetic render, no Ingress | fails — *the render contains no Ingress* |
| synthetic render, no `esgame-config` | fails — *no such ConfigMap in the render* |
| unmutated tree | passes |

Also verified under a reproduction of the CI environment, where `kustomize` lives in the workspace root rather than on `PATH`.

## Side effect worth noting

This is the **first time CI renders `deploy/k8s/overlays/local-registry`**. It only ever rendered the base — so the overlay the kind cluster and every local test depend on had no CI coverage at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE