### PR TITLE
ci: publish esgame-calculation, and check the base names a tag that exists

### DIFF
--- a/.github/workflows/image-calculation.yml
+++ b/.github/workflows/image-calculation.yml
@@ -1,0 +1,130 @@
+name: Build & publish the calculation image
+
+# Publishes the R/Plumber calculation backend to GitHub Container Registry.
+# Image: ghcr.io/<owner>/esgame-calculation  (branch, semver and commit-sha tags)
+#
+# This is the image deploy/k8s/base already names. Until now nothing built it, so
+# `kubectl apply -k deploy/k8s/base` produced a permanent ErrImagePull on the calculation pod
+# and every local test had to run its own registry to have anything to pull. That was the
+# largest entry under "Known incomplete" in docs/verification-status.rst.
+#
+# Kept separate from image.yml rather than added as a second job:
+#   * different trigger paths — the frontend rebuilds on v2/**, this on tools/R/**
+#   * ~15 minutes against the frontend's ~2, so sharing a workflow would make every frontend
+#     publish look slow and would couple two unrelated failures
+
+on:
+  push:
+    branches: [master]
+    tags: ['v*']
+    paths:
+      - 'tools/R/**'
+      - '.github/workflows/image-calculation.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    # The image installs eleven R packages from source against GDAL/PROJ/GEOS. 15 minutes is
+    # normal for a cold build; the default 360 is long enough to hide a hang for hours.
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Reclaim runner disk
+        # The image is ~2.6 GB and the build needs several times that in layers. A runner
+        # arrives with ~25 GB free, and "no space left on device" here surfaces as an
+        # unrelated-looking R compile error partway through.
+        run: |
+          df -h / | tail -1
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
+          df -h / | tail -1
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository }}-calculation
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=sha
+
+      - uses: docker/build-push-action@v7
+        id: build
+        with:
+          context: tools/R
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # No GHA layer cache on purpose. The image is ~2.6 GB, the repository-wide Actions
+          # cache is 10 GB, and mode=max would store every intermediate layer — evicting the
+          # caches other workflows depend on to save time on a build that only runs when
+          # tools/R changes, which is rarely.
+
+      - name: The published image must actually answer
+        # A push proves bytes were uploaded, not that the thing runs. The Dockerfile's own
+        # verification layers check that the R packages load at BUILD time; this checks the
+        # published artefact starts and serves, which is what the cluster will do with it.
+        run: |
+          set -euo pipefail
+          tag=$(printf '%s\n' '${{ steps.meta.outputs.tags }}' | head -1)
+          echo "probing ${tag}"
+          docker run -d --name calc -p 8000:8000 "${tag}"
+
+          # Plumber takes ~12s to bind. Poll rather than sleep-and-hope: a fixed sleep that is
+          # too short reads as "the image is broken". There is no /health route, so the test is
+          # simply whether anything answers — a refused connection gives 000, while a running
+          # plumber gives 404 for an unrouted path. Those are the two states worth telling
+          # apart; the next step decides whether what answered is really the calculator.
+          for i in $(seq 1 60); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8000/ || true)
+            if [ "${code}" != 000 ]; then ok=1; echo "answered ${code} after ${i} attempts"; break; fi
+            sleep 2
+          done
+
+          if [ "${ok:-0}" != 1 ]; then
+            echo "::error::the published image never accepted a connection on :8000"
+            docker logs calc || true
+            exit 1
+          fi
+
+          # It answered. Now check it is the calculator and not merely something listening:
+          # POST an empty allocation and require a structured refusal rather than a crash.
+          code=$(curl -s -o body.txt -w '%{http_code}' --max-time 60 \
+            -X POST http://127.0.0.1:8000/esgame \
+            -H 'Content-Type: application/json' -d '{"allocation":[]}' || true)
+          echo "POST /esgame -> ${code}"
+          head -c 400 body.txt || true
+          echo
+          # Any HTTP status is fine — with no geodata mounted it cannot score a real round. A
+          # 000 means the process died on the request, which is the failure worth catching.
+          if [ "${code}" = 000 ]; then
+            echo "::error::the calculator died handling a request"
+            docker logs calc || true
+            exit 1
+          fi
+          docker rm -f calc >/dev/null
+
+      - name: Say what was published
+        run: |
+          {
+            echo "### Published"
+            echo
+            echo '```'
+            printf '%s\n' '${{ steps.meta.outputs.tags }}'
+            echo '```'
+            echo
+            echo "digest: \`${{ steps.build.outputs.digest }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -145,6 +145,36 @@ jobs:
           fi
           echo "GeoServer public URL is separate, wired through, and used for coverage URLs"
 
+      - name: ghcr images must use a tag some workflow actually publishes
+        run: |
+          # The base pointed at ghcr.io/mlacayoemery/esgame-calculation:latest while the
+          # publishing workflow tags with the branch, the semver and the sha — so `latest` was
+          # a tag nothing ever pushed. Nothing here pulls these images, so the mistake could
+          # only surface as ErrImagePull in someone's cluster.
+          #
+          # Both images roll on `master`. Assert that, and assert the workflows that produce
+          # them still emit a branch tag, so this does not quietly stop meaning anything.
+          bad=0
+          imgs=$(grep -oP '^\s+image:\s*\Kghcr\.io/\S+' rendered.yaml || true)
+          n=$(printf '%s\n' "$imgs" | grep -c . || true)
+          echo "$imgs"
+          if [ "$n" -ne 2 ]; then
+            echo "::error::expected 2 ghcr images in the render, found $n"; exit 1
+          fi
+          for i in $imgs; do
+            case "$i" in
+              *:master) ;;
+              *) echo "::error::$i does not use the :master tag the workflows publish"; bad=1 ;;
+            esac
+          done
+          for w in .github/workflows/image.yml .github/workflows/image-calculation.yml; do
+            [ -e "$w" ] || { echo "::error::$w is gone; nothing publishes that image"; bad=1; continue; }
+            grep -q 'type=ref,event=branch' "$w" \
+              || { echo "::error::$w no longer emits a branch tag, so :master is not published"; bad=1; }
+          done
+          [ "$bad" = 0 ] && echo "both ghcr images use a tag their workflow publishes"
+          exit $bad
+
       - name: Browser-facing URLs must name a host an Ingress serves
         run: |
           # The check above asks whether GEOSERVER_PUBLIC_URL differs from the in-cluster

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -25,7 +25,9 @@ deploy/k8s/base/          # this Kustomize base (angular + calculation + geoserv
 
 1. **Images** — in `base/kustomization.yaml` set the `images:` entries:
    - `esgame-angular` → your published frontend tag (defaults to `ghcr.io/mlacayoemery/esgame:master`).
-   - `esgame-calculation` → build [`../../tools/R`](../../tools/R) and push it, then point here (or override in an overlay).
+   - `esgame-calculation` → defaults to `ghcr.io/mlacayoemery/esgame-calculation:master`, published by
+     [`image-calculation.yml`](../../.github/workflows/image-calculation.yml) from [`../../tools/R`](../../tools/R).
+     Point it elsewhere (or override in an overlay) to run your own build.
 2. **Hosts** — replace the `change-me-*.example.com` hosts in the three `*-ingress.yaml` files,
    and the matching `CALC_URL` in `base/configmap.yaml`. Keep them lowercase: an Ingress host
    must be a valid RFC 1123 subdomain, so a single uppercase letter makes the API server
@@ -74,8 +76,9 @@ reload). See [../../docs/ARCHITECTURE.md](../../docs/ARCHITECTURE.md).
 
 ## Running it locally, for real
 
-`esgame-calculation` is published nowhere, so the base cannot come up as-is (step 1). To exercise
-the whole stack — including an actual ingress controller rather than `port-forward`:
+To exercise the whole stack — including an actual ingress controller rather than `port-forward`.
+The local registry is not required now that both images are published, but it is still what
+lets you run a build you have not pushed:
 
 ```sh
 deploy/registry/registry.sh up && deploy/registry/registry.sh push   # build + serve the images

--- a/deploy/k8s/base/kustomization.yaml
+++ b/deploy/k8s/base/kustomization.yaml
@@ -33,6 +33,10 @@ images:
     newName: ghcr.io/mlacayoemery/esgame
     newTag: master
   - name: esgame-calculation
-    # Build from ../../../tools/R and publish, or override in your overlay.
+    # Published by .github/workflows/image-calculation.yml from ../../../tools/R.
+    # `master`, not `latest`: that workflow tags with the branch, the semver and the sha, so
+    # `latest` was a tag nothing ever pushed — an ErrImagePull that no amount of green CI
+    # would have shown, since CI never pulls these. Same rolling tag as the frontend above;
+    # the "images match a tag some workflow publishes" step in manifests.yml now checks it.
     newName: ghcr.io/mlacayoemery/esgame-calculation
-    newTag: latest
+    newTag: master

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -169,11 +169,20 @@ Known incomplete
 
 None of these are defects to fix here — they are things a deployment must supply.
 
-``esgame-calculation`` is not published
-   No workflow builds or pushes it, and the registry has no such image. The k8s base and
-   the places overlay both reference it, so the calculation pod is ``ErrImagePull`` until
-   someone builds :file:`tools/R` and pushes it. Documented in
-   :file:`deploy/k8s/README.md` step 1.
+``esgame-calculation`` is not published — *closed 2026-07-31*
+   It is now, by :file:`.github/workflows/image-calculation.yml`, to
+   ``ghcr.io/mlacayoemery/esgame-calculation`` on pushes to master that touch
+   :file:`tools/R`. Before that no workflow built it, so the k8s base and the places overlay
+   both referenced an image that existed nowhere and the calculation pod was a permanent
+   ``ErrImagePull`` — which is why every local test had to stand up its own registry first.
+
+   The workflow does not stop at pushing. A push proves bytes were uploaded, not that the
+   thing runs, so it starts the published image and requires it to answer on ``:8000`` and
+   to survive a ``POST /esgame``. Measured against the same image locally: plumber binds
+   after ~12s and returns 404 for an unrouted path, and an empty allocation comes back
+   ``500 {"error":"500 - Internal server error"}`` — a structured refusal with no geodata
+   mounted, rather than a dead process. A connection that is refused (``000``) is the
+   failure the probe exists to catch.
 
 Placeholders must be replaced
    ``change-me-*.example.com`` hosts, ``CALC_URL``, and — in the places overlay —


### PR DESCRIPTION
Closes the largest entry under **Known incomplete** in `docs/verification-status.rst`.

`deploy/k8s/base` and the places overlay both reference `esgame-calculation`. Nothing built it. `kubectl apply -k deploy/k8s/base` gave a permanent `ErrImagePull` on the calculation pod — which is the entire reason `deploy/registry/` exists and why every local test has to stand up its own registry first.

## The publish

`image-calculation.yml`, on pushes to master touching `tools/R/**`.

Separate from `image.yml` on purpose: different trigger paths, and ~15 minutes against the frontend's ~2 — sharing a workflow would make every frontend publish look slow and couple two unrelated failures. No GHA layer cache: a 2.6 GB image with `mode=max` would evict the 10 GB repository-wide cache other workflows depend on, to speed up a build that runs rarely.

## A push is not a working image

So the workflow starts what it published and requires it to answer. Both branches were checked against the real image locally rather than guessed:

```
answered 404 after 6 attempts          # plumber binds after ~12s; 404 for an unrouted path
POST /esgame -> 500
{"error":"500 - Internal server error"}   # structured refusal, no geodata mounted
```

A refused connection (`000`) is the failure the probe exists to catch — either at startup, or as a process that dies handling the request.

## The bug writing it turned up

The base pointed at:

```yaml
newName: ghcr.io/mlacayoemery/esgame-calculation
newTag: latest
```

The tag scheme is branch + semver + sha. **`latest` is a tag nothing would ever push.** Adding the workflow would have "closed" the gap while leaving exactly the same `ErrImagePull` — and since nothing in CI pulls these images, no run would have said so.

Both images now roll on `:master` (the frontend already did). A new `validate` step asserts the rendered ghcr images use a tag whose workflow still emits `type=ref,event=branch`:

| mutation | result |
|---|---|
| tag reverted to `:latest` | fails — *ghcr.io/…/esgame-calculation:latest not :master* |
| workflow no longer emits a branch tag | fails — *…image-calculation.yml no branch tag* |
| current tree | passes |

## Note

Merging this publishes a new public package, `ghcr.io/mlacayoemery/esgame-calculation`, under your account — the workflow's own file is in its trigger paths, so it fires on merge. That is the documented intent of `deploy/k8s/README.md` step 1 and matches how the frontend is already published, but it is an outward-facing side effect worth naming rather than burying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE