### PR TITLE
fix(ui): the loading spinner now clears when a level fails to build

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -29,7 +29,7 @@ Verified working
    * - Path
      - How it was checked
    * - Static / grid game
-     - 255 unit tests, 11 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
+     - 258 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
        SEO 100. The board renders 2,436 fields; the e2e suite asserts that rather than
        just asserting the component mounted.
    * - No external runtime deps
@@ -240,18 +240,37 @@ The committed base raster makes the game inert
    for exercising the plumbing, and a green round against it says nothing about the model.
    See :ref:`allocation-id-space`.
 
-The loading spinner does not clear when a level fails to build
-   ``prepareNextLevel`` now handles the error, clears the loading counter and tells the player
-   (:file:`v2/src/app/services/game.service.ts`, ``failLevel``) — before, a failed raster fetch
-   left the counter pushed, the level unchanged and nothing said at all. The **spinner itself
-   still does not disappear.** ``LoadingIndicatorComponent``'s subscriber does receive the
-   cleared value — verified in a browser, it runs with ``length 0`` — but its
-   ``@HostBinding('class.show')`` never reaches the DOM: the error arrives from outside Angular's
-   zone, and a host binding is evaluated by the *parent* view, not the component's own. Both
-   ``cdRef.detectChanges()`` in the component and ``NgZone.run()`` in its subscriber were tried
-   and neither updated it. Reachable today only in offline dynamic mode, which cannot finish a
-   round anyway (see above); a deployment with a working calculator does not hit it unless a
-   returned coverage URL fails.
+The loading spinner does not clear when a level fails to build — *fixed 2026-07-31*
+   The spinner covers the whole screen — ``:host.show`` gives it a white background over the
+   board — so this was not cosmetic: the game became unusable with no way out but a reload.
+   And it was reachable in any deployment, not only offline: ``prepareNextLevel`` builds the
+   level from the coverage URLs the calculator returns, so one URL GeoServer could not serve
+   was enough.
+
+   The earlier diagnosis was right about the mechanism and wrong about the remedy.
+   ``LoadingIndicatorComponent`` wrote to a plain field behind ``@HostBinding('class.show')``,
+   and a host binding is evaluated by the view that *declares* the component — assigning a
+   field tells Angular nothing about which view that is. Inside the zone something else
+   happened along to check it; from an error callback outside the zone nothing did.
+   ``cdRef.detectChanges()`` cannot help, because that ref is the component's own template
+   view and its host bindings live in the parent's.
+
+   The component now reads a **signal**. A signal read inside a host binding registers the
+   binding as a consumer, so a write marks exactly the right view — no zone involved, which
+   is why it holds on the path the old code could not reach.
+
+   Both levels were checked by mutation, not assertion. In a unit test the old implementation
+   fails two of three specs and the new one passes all three; in a real browser, with one
+   coverage URL forced to 404, the old build leaves ``class="show"`` on the element for 123
+   consecutive polls and the new build clears it. Getting there also corrected a false
+   negative of my own: the first browser run failed against a **stale ``dist``**, which is the
+   old component — evidence about the previous code, not about the fix.
+
+   One trap worth recording: a ``ComponentFixture`` is detached from ``ApplicationRef`` unless
+   ``autoDetectChanges()`` is called, and while detached *nothing* refreshes it — not
+   ``ApplicationRef.tick()``, not a scheduled task, only an explicit ``detectChanges()``. A
+   test written without it measures the harness rather than the component, and would have
+   reported this bug as unfixable a second time.
 
 No default IngressClass is assumed
    The three Ingresses set no ``ingressClassName``. If the cluster has no default

--- a/v2/e2e/round-trip.spec.ts
+++ b/v2/e2e/round-trip.spec.ts
@@ -132,6 +132,50 @@ test.describe('dynamic game round trip', () => {
 		expect(errors).toEqual([]);
 	});
 
+	// The spinner is the whole screen when it is up — `:host.show` gives it a white background
+	// over the board — so failing to clear it is not cosmetic: the game is unusable and the only
+	// way out is a reload.
+	//
+	// Reachable in any deployment. prepareNextLevel builds the level from the coverage URLs the
+	// calculator returns, so one URL GeoServer cannot serve is enough; the fetch rejects, the
+	// error arrives outside Angular's zone, and failLevel() clears the counter.
+	test('the spinner clears when a level fails to build', async ({ page }) => {
+		const errors: string[] = [];
+		page.on('pageerror', e => errors.push(e.message));
+		// failLevel alerts. Playwright dismisses dialogs by default, but be explicit — an
+		// unhandled dialog would block the page and this test would pass for the wrong reason,
+		// having never got as far as rendering anything.
+		const alerts: string[] = [];
+		page.on('dialog', d => { alerts.push(d.message()); d.dismiss(); });
+
+		const posted: any[] = [];
+		const coverageRequests: string[] = [];
+		await useDynamicGameWithCalculator(page, posted, coverageRequests);
+		// Break exactly one coverage the calculator hands back. Everything else is untouched, so
+		// the round genuinely reaches level-building and fails there rather than earlier.
+		await page.route('**/esgame_img_ag_habitat.tif*', route => route.fulfill({ status: 404 }));
+
+		await page.goto('/dynamic-game');
+		await expect(page.locator('tro-svg-game-board').first()).toBeVisible();
+		await placeFields(page, 12);
+		await dismissHelp(page);
+
+		const spinner = page.locator('tro-loading-indicator');
+		await page.locator('button.btn-next').click();
+
+		// It has to have come up, or "it is gone" proves nothing.
+		await expect(spinner).toHaveClass(/show/, { timeout: 30_000 });
+		// ...and then go away. Before the fix this class stayed for good: the subscriber ran with
+		// length 0, but a host binding is evaluated by the declaring view and assigning a plain
+		// field told Angular nothing about which view that was.
+		await expect(spinner).not.toHaveClass(/show/, { timeout: 60_000 });
+
+		// The player was told, and the board is usable again rather than behind a white sheet.
+		expect(alerts.length).toBeGreaterThan(0);
+		await expect(page.locator('tro-svg-game-board').first()).toBeVisible();
+		expect(errors).toEqual([]);
+	});
+
 	test('a second round replaces the first round\'s maps', async ({ page }) => {
 		const posted: any[] = [];
 		const coverageRequests: string[] = [];

--- a/v2/src/app/loading-indicator/loading-indicator.component.spec.ts
+++ b/v2/src/app/loading-indicator/loading-indicator.component.spec.ts
@@ -1,0 +1,63 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { NgZone } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { LoadingIndicatorComponent } from './loading-indicator.component';
+import { GameService } from '../services/game.service';
+
+// The spinner is driven by a host binding — `:host.show` in the SCSS is what makes it visible —
+// and a host binding is evaluated by the view that DECLARES the component, not by the component
+// itself. So the question that matters is not "does the subscriber run" (it does) but "does
+// anything mark the declaring view dirty when the value changes".
+//
+// That distinction is why this was reported as unfixable: the subscriber was observed running
+// with length 0 while the class stayed on the element.
+describe('LoadingIndicatorComponent', () => {
+	let fixture: ComponentFixture<LoadingIndicatorComponent>;
+	let loading: BehaviorSubject<boolean[]>;
+	let host: HTMLElement;
+
+	beforeEach(async () => {
+		loading = new BehaviorSubject<boolean[]>([]);
+		await TestBed.configureTestingModule({
+			declarations: [LoadingIndicatorComponent],
+			imports: [MatProgressSpinnerModule],
+			providers: [{ provide: GameService, useValue: { loadingIndicatorObs: loading.asObservable() } }]
+		}).compileComponents();
+
+		fixture = TestBed.createComponent(LoadingIndicatorComponent);
+		// autoDetectChanges attaches the fixture to ApplicationRef, which is the arrangement a
+		// real app is in: something ticks when Angular is told the view is dirty. Without it the
+		// fixture is detached and NOTHING but an explicit detectChanges() can ever refresh it —
+		// not ApplicationRef.tick(), not a scheduled task — so the test would measure the
+		// harness rather than the component. That was measured, not assumed.
+		fixture.autoDetectChanges();
+		host = fixture.nativeElement;   // the <tro-loading-indicator> element itself
+	});
+
+	it('is hidden with nothing loading', () => {
+		expect(host.classList.contains('show')).toBe(false);
+	});
+
+	it('shows while something is loading', async () => {
+		loading.next([true]);
+		await fixture.whenStable();
+		expect(host.classList.contains('show')).toBe(true);
+	});
+
+	// The regression. failLevel() clears the counter from an error callback — outside Angular's
+	// zone, with nothing else scheduling a check. Nothing here calls detectChanges() after the
+	// emission, which is the situation in the app: if the component does not itself cause the
+	// declaring view to be refreshed, the class never goes and the spinner covers the board
+	// forever. In a deployment this is one failed coverage fetch away.
+	it('clears when loading stops outside the zone, with no external change detection', async () => {
+		loading.next([true]);
+		await fixture.whenStable();
+		expect(host.classList.contains('show')).toBe(true);
+
+		TestBed.inject(NgZone).runOutsideAngular(() => loading.next([]));
+		await fixture.whenStable();
+
+		expect(host.classList.contains('show')).toBe(false);
+	});
+});

--- a/v2/src/app/loading-indicator/loading-indicator.component.ts
+++ b/v2/src/app/loading-indicator/loading-indicator.component.ts
@@ -1,20 +1,39 @@
-import { Component, HostBinding } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { map } from 'rxjs';
 import { GameService } from '../services/game.service';
 
 @Component({
-    selector: 'tro-loading-indicator',
-    templateUrl: './loading-indicator.component.html',
-    styleUrls: ['./loading-indicator.component.scss'],
-    standalone: false
+	selector: 'tro-loading-indicator',
+	templateUrl: './loading-indicator.component.html',
+	styleUrls: ['./loading-indicator.component.scss'],
+	standalone: false,
+	// `:host.show` in the SCSS is what makes the spinner visible, so this class is the whole
+	// component. It used to be a plain field written from an rxjs subscriber:
+	//
+	//     @HostBinding('class.show') show = false;
+	//     constructor(...) { gameService.loadingIndicatorObs.subscribe(s => this.show = s.length > 0); }
+	//
+	// which left the spinner covering the board forever whenever loading stopped from an error
+	// callback. The subscriber did run — that was verified — but a host binding is evaluated by
+	// the view that DECLARES the component, and assigning a field tells Angular nothing about
+	// which view that is. From inside the zone something else happened to trigger a check and it
+	// looked fine; from an error callback outside it, nothing did. `detectChanges()` on the
+	// component's own ChangeDetectorRef cannot help either: that ref is the component's template
+	// view, and its host bindings live in the parent's.
+	//
+	// A signal carries that information. Reading one inside a host binding registers the binding
+	// as a consumer, so a write marks exactly the right view for traversal — no zone involved,
+	// which is why this holds for the error path the old code could not reach.
+	host: { '[class.show]': 'show()' }
 })
 export class LoadingIndicatorComponent {
-	
-	@HostBinding('class.show')
-	show = false;
+	// inject() rather than a constructor parameter: field initializers run before the constructor
+	// body, so `this.gameService` would still be undefined here if it were a parameter property.
+	private readonly gameService = inject(GameService);
 
-	constructor(private gameService: GameService) {
-		this.gameService.loadingIndicatorObs.subscribe(show => {
-			this.show = show.length > 0;
-		});
-	}
+	protected readonly show = toSignal(
+		this.gameService.loadingIndicatorObs.pipe(map(loading => loading.length > 0)),
+		{ initialValue: false }
+	);
 }

--- a/v2/src/app/services/game.service.ts
+++ b/v2/src/app/services/game.service.ts
@@ -377,13 +377,12 @@ export class GameService {
 		// Clear the counter rather than popping one entry: loading() is a push/pop stack and a
 		// failed build is terminal, so nothing is loading any more whatever else had been pushed.
 		//
-		// NOTE: this makes the state correct, and the alert below means the player is told. It
-		// does NOT currently make the spinner disappear — the LoadingIndicatorComponent receives
-		// the cleared value (its subscriber runs with length 0) but its @HostBinding('class.show')
-		// never reaches the DOM, because the error arrives from outside Angular's zone and a host
-		// binding is evaluated by the PARENT view. detectChanges() on the component's own view
-		// and NgZone.run() in the subscriber were both tried and neither updated it. Left for a
-		// separate change rather than shipping a guess; see docs/verification-status.rst.
+		// This used to leave the spinner up for good, covering the board with nothing to
+		// dismiss. The value arrived (the subscriber ran with length 0) but the component wrote
+		// it to a plain field behind an @HostBinding, and a host binding is evaluated by the
+		// view that DECLARES the component — so nothing marked that view dirty. From an error
+		// callback, outside the zone, nothing else came along to check it either.
+		// LoadingIndicatorComponent now reads a signal, which does carry that information.
 		this.loadingIndicator.next([]);
 		alert("Something went wrong, please try again later");
 	}


### PR DESCRIPTION
Carried in `docs/verification-status.rst` as unfixed, with five hypotheses already disproven.

## It is not cosmetic, and not only offline

`:host.show` gives the spinner a white background over the whole board. Failing to clear it leaves the game unusable with no way out but a reload.

The note said it was reachable only in offline dynamic mode. It is reachable in **any** deployment: `prepareNextLevel` builds the level from the coverage URLs the calculator returns, so one URL GeoServer cannot serve is enough.

## The mechanism was diagnosed right; the remedy was wrong

The component wrote to a plain field behind `@HostBinding('class.show')`. A host binding is evaluated by the view that **declares** the component — and assigning a field tells Angular nothing about which view that is. Inside the zone something else came along to check it; from an error callback outside the zone nothing did. `cdRef.detectChanges()` cannot help either: that ref is the component's own *template* view, and its host bindings live in the parent's.

A **signal** does carry that information. Reading one inside a host binding registers the binding as a consumer, so a write marks exactly the right view for traversal — no zone involved, which is why it holds on the path the old code could not reach.

```ts
host: { '[class.show]': 'show()' }
...
protected readonly show = toSignal(
  this.gameService.loadingIndicatorObs.pipe(map(loading => loading.length > 0)),
  { initialValue: false }
);
```

## Mutation at both levels

| | old implementation | new |
|---|---|---|
| unit (3 specs) | **2 fail** | all pass |
| browser, one coverage URL forced to 404 | `class="show"` for **123 consecutive polls** | clears; board usable |

## Two false results discarded on the way, both mine

- **The first unit test could not have passed with any implementation.** A `ComponentFixture` is detached from `ApplicationRef` unless `autoDetectChanges()` is called, and while detached *nothing* refreshes it. Measured, not assumed:

  ```
  B signal=false        the signal DID update
  C whenStable="show"   whenStable didn't flush
  E appRefTick="show"   ApplicationRef.tick() didn't either
  F detectChanges=""    only an explicit detectChanges() cleared it
  ```

  That test was measuring the harness. It would have reported this bug unfixable a second time.

- **The first browser run failed against a stale `dist`** — which is the *old* component. Evidence about the previous code, not about the fix.

## Counts

258 unit / 12 e2e, updated in the docs. CI re-derives the unit count and fails on drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE