### PR TITLE
feat(k8s): an overlay that runs the whole stack with nothing built

### DIFF
--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -76,20 +76,34 @@ reload). See [../../docs/ARCHITECTURE.md](../../docs/ARCHITECTURE.md).
 
 ## Running it locally, for real
 
-To exercise the whole stack — including an actual ingress controller rather than `port-forward`.
-The local registry is not required now that both images are published, but it is still what
-lets you run a build you have not pushed:
+To exercise the whole stack — with an actual ingress controller rather than `port-forward`.
+
+**Nothing to build.** Both images are published, so this pulls everything from ghcr:
+
+```sh
+deploy/k8s/kind.sh up                                # cluster + ingress-nginx
+ESGAME_OVERLAY=published deploy/k8s/kind.sh deploy   # pull both images from ghcr
+deploy/k8s/ingress-test.sh                           # a real round through the ingress, by Host header
+```
+
+That was not possible until `esgame-calculation` was published — the image existed nowhere, so
+the only way to have anything to pull was to build ~2.6 GB of R first.
+
+**To run a build you have not pushed** — still the only way to test a change to `v2` or `tools/R`
+before it is on master — use the local registry, which is the default:
 
 ```sh
 deploy/registry/registry.sh up && deploy/registry/registry.sh push   # build + serve the images
-deploy/k8s/kind.sh up          # cluster wired to that registry + ingress-nginx
-deploy/k8s/kind.sh deploy      # apply overlays/local-registry, wait for rollout
-deploy/k8s/ingress-test.sh     # a real round through the ingress, by Host header
+deploy/k8s/kind.sh up && deploy/k8s/kind.sh deploy                   # overlays/local-registry
 ```
 
-`overlays/local-registry` is where everything local lives — the images, `.local` hosts,
-`ingressClassName: nginx`, and the two public URLs. The base's ghcr defaults and `change-me` hosts
-are what a real deployment wants and are left alone.
+`overlays/local-registry` is where everything local lives — the `.local` hosts,
+`ingressClassName: nginx`, the geodata, and the two public URLs with the ingress port in them.
+`overlays/published` is that same overlay with only the images repointed at ghcr. The base's
+`change-me` hosts are what a real deployment wants and are left alone.
+
+Both are covered by [`render-test.sh`](render-test.sh), which finds kustomizations rather than
+listing them, so a new overlay is checked the day it is added.
 
 Two things `kind.sh` does that a bare `kind create cluster` does not, both of which fail silently
 otherwise:

--- a/deploy/k8s/kind.sh
+++ b/deploy/k8s/kind.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
 # A local cluster that can actually pull the esgame images and route real ingress traffic.
 #
-#   deploy/registry/registry.sh up && deploy/registry/registry.sh push   # images first
-#   deploy/k8s/kind.sh up            # cluster + registry wiring + ingress-nginx
-#   deploy/k8s/kind.sh deploy        # apply the local-registry overlay, wait for rollout
-#   deploy/k8s/kind.sh test          # a real round THROUGH the ingress
+# Nothing to build — both images are published:
+#
+#   deploy/k8s/kind.sh up                              # cluster + ingress-nginx
+#   ESGAME_OVERLAY=published deploy/k8s/kind.sh deploy # pull esgame + esgame-calculation from ghcr
+#   deploy/k8s/kind.sh test                            # a real round THROUGH the ingress
 #   deploy/k8s/kind.sh down
+#
+# To run a build you have NOT pushed, use the local registry instead (the default):
+#
+#   deploy/registry/registry.sh up && deploy/registry/registry.sh push
+#   deploy/k8s/kind.sh up && deploy/k8s/kind.sh deploy
 #
 # Two things this sets up that a bare `kind create cluster` does not:
 #
@@ -30,6 +36,10 @@ REG_PORT="${ESGAME_REGISTRY_PORT:-5001}"
 HTTP_PORT="${KIND_HTTP_PORT:-8880}"
 HTTPS_PORT="${KIND_HTTPS_PORT:-8843}"
 HOSTS=(esgame.local esgame-calculation.local esgame-geoserver.local)
+# Which overlay `deploy` applies. `local-registry` pulls from deploy/registry — use it to run a
+# build you have not pushed. `published` pulls both images from ghcr, so nothing has to be built
+# at all; that only became possible once esgame-calculation was published.
+OVERLAY="${ESGAME_OVERLAY:-local-registry}"
 
 need() { command -v "$1" >/dev/null || { echo "!! $1 not on PATH" >&2; exit 2; }; }
 
@@ -176,22 +186,30 @@ PROBE
       --from-file=LU_and_NEW_hexa.tif="${REPO}/v2/src/assets/images/LU_and_NEW_hexa.tif" \
       --dry-run=client -o yaml | "${K[@]}" apply -f -
 
+    echo "deploying overlays/${OVERLAY}"
+
     # The overlay hard-codes the ingress port into the browser-facing URLs, because a browser
     # cannot infer it. If someone moves KIND_HTTP_PORT without moving those, the cluster comes
     # up fine and only a real browser notices — say so now instead.
+    #
+    # Read from the RENDER, not from the overlay's own file: overlays/published sets no URLs of
+    # its own, it inherits them, so grepping its kustomization.yaml would find nothing and this
+    # would refuse a perfectly good overlay. What matters is the value that ends up deployed.
+    rendered_cfg=$(kubectl kustomize "overlays/${OVERLAY}" 2>/dev/null || true)
+    [ -n "${rendered_cfg}" ] || { echo "!! overlays/${OVERLAY} does not render"; exit 1; }
     for v in CALC_URL GEOSERVER_PUBLIC_URL; do
-      want=$(grep -oE "^      - ${v}=.*" overlays/local-registry/kustomization.yaml | head -1)
+      want=$(grep -oE "^  ${v}: .*" <<<"${rendered_cfg}" | head -1)
       case "${want}" in
         *":${HTTP_PORT}/"*) ;;
-        "") echo "!! ${v} not found in the overlay"; exit 1 ;;
-        *) echo "!! ${v} in the overlay does not use KIND_HTTP_PORT=${HTTP_PORT}:"
+        "") echo "!! ${v} is not in the render of overlays/${OVERLAY}"; exit 1 ;;
+        *) echo "!! ${v} does not use KIND_HTTP_PORT=${HTTP_PORT}:"
            echo "   ${want}"
            echo "   a browser would post to the wrong port; curl with a Host header would not notice"
            exit 1 ;;
       esac
     done
 
-    "${K[@]}" apply -k overlays/local-registry
+    "${K[@]}" apply -k "overlays/${OVERLAY}"
     # esgame-config is consumed as environment variables, which are fixed when a container
     # starts, and the ConfigMap's name is stable — so `apply` updates it while every running pod
     # keeps the old value. Nothing reports a problem: the apply succeeds, the pods stay ready,

--- a/deploy/k8s/overlays/published/kustomization.yaml
+++ b/deploy/k8s/overlays/published/kustomization.yaml
@@ -1,0 +1,34 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# The local-registry overlay, but pulling the images from ghcr instead of a registry you run.
+#
+# Until esgame-calculation was published there was no such option: the calculation image existed
+# nowhere, so exercising the stack meant building ~2.6 GB of R and standing up deploy/registry
+# first. Both images are published now, so this brings the whole thing up with nothing built:
+#
+#   deploy/k8s/kind.sh up
+#   ESGAME_OVERLAY=published deploy/k8s/kind.sh deploy
+#   deploy/k8s/ingress-test.sh
+#
+# Use local-registry instead when you want to run a build you have not pushed — which is still
+# the only way to test a change to tools/R or v2 before it is on master.
+resources:
+  - ../local-registry
+
+# THESE KEY ON THE NAME local-registry REWROTE THE IMAGES TO, not on the base's logical names.
+#
+# Kustomize applies each overlay's images transformer in turn, so by the time this one runs
+# `esgame-angular` no longer appears anywhere and neither does `ghcr.io/mlacayoemery/esgame` —
+# what is in the manifests is `localhost:5001/esgame`. An entry keyed on anything else matches
+# nothing, does not warn, and silently leaves the local-registry images in place. That exact
+# mistake shipped once in the places overlay against this same base.
+#
+# Check with: kustomize build deploy/k8s/overlays/published | grep 'image:'
+images:
+  - name: localhost:5001/esgame
+    newName: ghcr.io/mlacayoemery/esgame
+    newTag: master
+  - name: localhost:5001/esgame-calculation
+    newName: ghcr.io/mlacayoemery/esgame-calculation
+    newTag: master

--- a/deploy/k8s/render-test.sh
+++ b/deploy/k8s/render-test.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
-# Checks a rendered Kustomize directory for URLs the browser is given but nothing serves.
+# Checks each rendered Kustomize directory for two things kustomize itself is happy to get wrong.
 #
 #   deploy/k8s/render-test.sh                     # base and every overlay
 #   deploy/k8s/render-test.sh deploy/k8s/base     # just one
 #
+# 1. URLs the browser is given that nothing serves.
+# 2. `images:` entries that matched nothing and therefore did nothing.
+#
+# Both render cleanly, apply cleanly, and fail somewhere else entirely.
+#
+# --- 1 ---
 # Two env vars in the ConfigMap are fetched by the BROWSER rather than from inside the cluster:
 #
 #   CALC_URL              the app POSTs the allocation here
@@ -14,6 +20,12 @@
 # weaker question — and the places overlay, which inherits this base, shipped a CALC_URL
 # pointing at a host from an entirely different deployment while every check passed. It renders,
 # it applies, and it fails only in a browser.
+#
+# --- 2 ---
+# An overlay's `images:` entries must key on the name the PREVIOUS transformer rewrote to, since
+# the base's logical names are gone by then. An entry that matches nothing is not an error —
+# kustomize renders cleanly and leaves the earlier image deployed. That is how the places overlay
+# shipped upstream esgame images while every check there passed.
 #
 # Needs kustomize and python3. Requires no cluster.
 set -euo pipefail
@@ -90,10 +102,45 @@ PY
   if [ "${n}" -lt 2 ]; then
     echo "  FAIL expected 2 URL checks for ${d}, got ${n}"; fail=1
   fi
+
+  # Every `images:` entry must actually have taken effect.
+  #
+  # Kustomize applies each overlay's images transformer in turn, so an overlay has to key on the
+  # name the PREVIOUS one rewrote to — not on the base's logical name, which no longer appears by
+  # then. An entry that matches nothing is not an error: kustomize renders cleanly, says nothing,
+  # and leaves the earlier image in place. That is how the places overlay deployed upstream esgame
+  # images while every check passed, and the same trap is one edit away in overlays/published.
+  #
+  # So rather than trusting the entries, check the result: whatever each entry claims to produce
+  # has to be in the render.
+  imgout=$(python3 - "${d}/kustomization.yaml" "${rendered}" <<'PY'
+import sys, yaml
+k = yaml.safe_load(open(sys.argv[1])) or {}
+entries = k.get('images') or []
+if not entries:
+    print('skip\t-\tno images: entries'); raise SystemExit
+used = {l.split('image:', 1)[1].strip()
+        for l in open(sys.argv[2]) if l.lstrip().startswith('image:')}
+for e in entries:
+    name = e.get('newName', e.get('name', ''))
+    tag = e.get('newTag')
+    want = f"{name}:{tag}" if tag else name
+    # Without newTag the entry only rewrites the name, so match on the name alone.
+    hit = want in used if tag else any(u.split(':')[0] == name for u in used)
+    print(f"{'ok' if hit else 'FAIL'}\t{e.get('name','?')}\t-> {want}"
+          + ('' if hit else '  (matched nothing; the earlier image is still deployed)'))
+PY
+)
+  while IFS=$'\t' read -r status name detail; do
+    [ -n "${status}" ] || continue
+    printf '  %-4s %-22s %s\n' "${status}" "${name}" "${detail}"
+    [ "${status}" = FAIL ] && fail=1
+  done <<<"${imgout}"
+  [ -n "${imgout}" ] || { echo "  FAIL the images check for ${d} produced nothing"; fail=1; }
 done
 
 if [ "${fail}" = 0 ]; then
-  echo "public URLs name a host an Ingress serves: PASS"
+  echo "renders are consistent (public URLs + images): PASS"
 else
-  echo "public URLs name a host an Ingress serves: FAIL"; exit 1
+  echo "renders are consistent (public URLs + images): FAIL"; exit 1
 fi

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -176,6 +176,11 @@ None of these are defects to fix here — they are things a deployment must supp
    both referenced an image that existed nowhere and the calculation pod was a permanent
    ``ErrImagePull`` — which is why every local test had to stand up its own registry first.
 
+   Verified as a cluster uses it, not only as CI built it: pulled anonymously from ghcr, then
+   deployed to the kind cluster through the new ``overlays/published`` and put through a full
+   round — 16/16 in ``ingress-test.sh`` and both browser specs in ``v2/e2e-cluster`` (465
+   hexagons, 5 coverages, two rounds in separate workspaces), with nothing built locally.
+
    The workflow does not stop at pushing. A push proves bytes were uploaded, not that the
    thing runs, so it starts the published image and requires it to answer on ``:8000`` and
    to survive a ``POST /esgame``. Measured against the same image locally: plumber binds


### PR DESCRIPTION
Follow-on to #130. Now that both images are published, a local cluster does not have to build anything:

```sh
deploy/k8s/kind.sh up
ESGAME_OVERLAY=published deploy/k8s/kind.sh deploy
deploy/k8s/ingress-test.sh
```

Impossible until yesterday: `esgame-calculation` existed nowhere, so having anything to pull meant building ~2.6 GB of R and standing up `deploy/registry` first.

`overlays/published` is `overlays/local-registry` with only the images repointed — the `.local` hosts, ingress class, geodata and port-carrying URLs are inherited, not copied.

## Verified on the live cluster, not rendered and assumed

```
esgame-angular-79b59764cc-45lvh      ghcr.io/mlacayoemery/esgame:master
esgame-calculation-cff5d7ff6-2qpjk   ghcr.io/mlacayoemery/esgame-calculation:master

ingress round-trip: PASS   (455 ids, 5 scores, 5/5 coverages)
2 passed — browser rounds: 465 hexagons, 5 coverages, two rounds in separate workspaces
```

Nothing built locally.

## Two things this turned up

**The port guard would have refused a good overlay.** `kind.sh` grepped `CALC_URL` out of `overlays/local-registry/kustomization.yaml`. `overlays/published` sets no URLs of its own, so that grep finds nothing and the guard fails closed on a correct config. It now reads the **render** — the value that actually gets deployed. Re-checked on all three paths: wrong port on either overlay, and an overlay that does not render.

**`render-test.sh` now checks that `images:` entries matched something.** An overlay must key on the name the *previous* transformer rewrote to. `esgame-angular` is gone once the base runs; `ghcr.io/mlacayoemery/esgame` is gone once `local-registry` runs. An entry keyed on the wrong one matches nothing, warns about nothing, and silently leaves the earlier image deployed.

That is exactly how the places overlay shipped upstream esgame images while all 16 of its checks passed — and it is one edit away here. Verified by making the mistake on purpose:

```
==> deploy/k8s/overlays/published
  FAIL esgame-angular  -> ghcr.io/mlacayoemery/esgame:master  (matched nothing; the earlier image is still deployed)
```

…with the render still containing `localhost:5001/esgame:local`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE