### PR TITLE
fix(ui): components no longer leak their service subscriptions

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -29,7 +29,7 @@ Verified working
    * - Path
      - How it was checked
    * - Static / grid game
-     - 258 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
+     - 259 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
        SEO 100. The board renders 2,436 fields; the e2e suite asserts that rather than
        just asserting the component mounted.
    * - No external runtime deps

--- a/v2/src/app/field/field-base.component.spec.ts
+++ b/v2/src/app/field/field-base.component.spec.ts
@@ -1,3 +1,4 @@
+import { TestBed } from '@angular/core/testing';
 import { ChangeDetectorRef, ElementRef, Renderer2 } from '@angular/core';
 import { FieldBaseComponent } from './field-base.component';
 import { Field, HighlightSide } from '../shared/models/field';
@@ -60,7 +61,10 @@ function setup() {
 	const r = fakeRenderer();
 	const g = makeGameService();
 	const cd = { markForCheck: () => { } } as ChangeDetectorRef;
-	const c = new TestField(g.service, r.renderer, new ElementRef({}), cd);
+	// FieldBaseComponent injects DestroyRef so subclasses can use takeUntilDestroyed from a
+	// lifecycle hook, and inject() needs a context — same as GridFieldComponent's spec.
+	const c = TestBed.runInInjectionContext(
+		() => new TestField(g.service, r.renderer, new ElementRef({}), cd));
 	return { c, r, g };
 }
 

--- a/v2/src/app/field/field-base.component.ts
+++ b/v2/src/app/field/field-base.component.ts
@@ -1,7 +1,7 @@
 import { GameService } from "src/app/services/game.service";
 import { Field, HighlightSide } from "../shared/models/field";
 import { ProductionType } from "../shared/models/production-type";
-import { ChangeDetectorRef, Component, ElementRef, HostBinding, Input, OnDestroy, Renderer2 } from '@angular/core';
+import { ChangeDetectorRef, Component, DestroyRef, ElementRef, HostBinding, Input, OnDestroy, Renderer2, inject } from '@angular/core';
 
 @Component({
     template: '',
@@ -12,6 +12,9 @@ export abstract class FieldBaseComponent implements OnDestroy {
 	@HostBinding('class.--is-assigned') public isAssigned = false;
 	@HostBinding('class.--missing-selection') public isMissingSelection = false;
 	@HostBinding('class.--is-editable') public isEditable = false;
+	// Explicit ref so subclasses can use takeUntilDestroyed(this.destroyRef) from lifecycle
+	// hooks, where the implicit injection context is gone. Mirrors GameBoardBaseComponent.
+	protected readonly destroyRef = inject(DestroyRef);
 	protected _field: Field;
 	private _listeners: (() => void)[] = [];
 	private _clickable = false;

--- a/v2/src/app/field/svg-field/svg-field.component.spec.ts
+++ b/v2/src/app/field/svg-field/svg-field.component.spec.ts
@@ -226,3 +226,28 @@ describe('SvgFieldComponent grid-line settings', () => {
 		expect(c.highlightColor).toBe('#ff0000');
 	});
 });
+
+// There are 466 of these on the default board, and the dynamic game builds a fresh set of
+// boards every round — so anything a field subscribes to without tearing down is leaked 466
+// times per board per round, and each leaked subscription keeps the destroyed component and
+// its DOM element alive for the lifetime of the app.
+//
+// settingsObs comes from a BehaviorSubject on the root-provided GameService, so it outlives
+// every field by definition. Counting the subject's subscribers is the only way to see this:
+// a leaked subscription is invisible from the DOM and from every other assertion here.
+describe('SvgFieldComponent subscription lifetime', () => {
+	it('unsubscribes from the service when destroyed', () => {
+		const { c, g } = build();
+		const observers = () => (g.settings as any).observers?.length
+			?? (g.settings as any).currentObservers?.length ?? 0;
+
+		const before = observers();
+		c.ngOnInit();
+
+		// Presence first: if the field never subscribed, "it unsubscribed" proves nothing.
+		expect(observers()).toBe(before + 1);
+
+		TestBed.resetTestingModule();   // runs the DestroyRef callbacks for the injection context
+		expect(observers()).toBe(before);
+	});
+});

--- a/v2/src/app/field/svg-field/svg-field.component.ts
+++ b/v2/src/app/field/svg-field/svg-field.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, HostBinding, Input, OnInit, RendererStyleFlags2 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { HighlightSide } from '../../shared/models/field';
 import { ProductionType } from '../../shared/models/production-type';
 import { FieldBaseComponent } from '../field-base.component';
@@ -29,7 +30,7 @@ export class SvgFieldComponent extends FieldBaseComponent implements OnInit {
 	@Input() hasOpacity = false;
 
 	ngOnInit(): void {
-		this.gameService.settingsObs.subscribe(o => {
+		this.gameService.settingsObs.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(o => {
 			this.highlightColor = o.highlightColor;
 			// Optional per-deployment cell-border (grid line) styling; CSS falls back to the default.
 			if (o.gridLineColor) this.renderer.setStyle(this.elementRef.nativeElement, '--cell-stroke', o.gridLineColor, RendererStyleFlags2.DashCase);

--- a/v2/src/app/help/help.component.spec.ts
+++ b/v2/src/app/help/help.component.spec.ts
@@ -1,3 +1,4 @@
+import { TestBed } from '@angular/core/testing';
 import { BehaviorSubject, firstValueFrom } from 'rxjs';
 import { HelpComponent } from './help.component';
 
@@ -20,7 +21,7 @@ const setup = (settingsValue: any = {
 		settingsObs: settings,
 		openHelp: (close = false) => closed.push(close)
 	};
-	return { helpWindow, level, settings, closed, component: new HelpComponent(gameStub, cdRefStub) };
+	return { helpWindow, level, settings, closed, component: TestBed.runInInjectionContext(() => new HelpComponent(gameStub, cdRefStub)) };
 };
 
 describe('HelpComponent', () => {

--- a/v2/src/app/help/help.component.ts
+++ b/v2/src/app/help/help.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { GameService } from '../services/game.service';
 import { map } from 'rxjs';
 
@@ -18,12 +19,12 @@ export class HelpComponent {
 		private gameService: GameService,
 		private cdRef: ChangeDetectorRef,
 	) {
-		this.gameService.helpWindowObs.subscribe(o => {
+		this.gameService.helpWindowObs.pipe(takeUntilDestroyed()).subscribe(o => {
 			this.isOpen = o;
 			this.cdRef.markForCheck();
 		});
 
-		this.gameService.currentLevelObs.subscribe(o => {
+		this.gameService.currentLevelObs.pipe(takeUntilDestroyed()).subscribe(o => {
 			if (!o || o.levelNumber == 1) {
 				this.helpText = 'basic_instructions';
 				this.imageUrl = this.gameService.settingsObs.pipe(map(o => o.basicInstructionsImageUrl));

--- a/v2/src/app/level/level-base.component.spec.ts
+++ b/v2/src/app/level/level-base.component.spec.ts
@@ -1,3 +1,4 @@
+import { TestBed } from '@angular/core/testing';
 import { BehaviorSubject, firstValueFrom } from 'rxjs';
 import { LevelBaseComponent } from './level-base.component';
 import { GameBoardType } from '../shared/models/game-board-type';
@@ -31,7 +32,8 @@ const setup = () => {
 	};
 	return {
 		level, selectedProductionType, focusedGameBoard, productionTypes, selectedBoards, calls,
-		make: () => new TestLevel(gameStub)
+		// LevelBaseComponent's constructor now uses takeUntilDestroyed, which needs a context.
+		make: () => TestBed.runInInjectionContext(() => new TestLevel(gameStub))
 	};
 };
 

--- a/v2/src/app/level/level-base.component.ts
+++ b/v2/src/app/level/level-base.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { GameService } from '../services/game.service';
 import { GameBoardClickMode } from '../shared/models/game-board';
 import { ProductionType } from '../shared/models/production-type';
@@ -30,11 +31,11 @@ export abstract class LevelBaseComponent {
 	clickMode = GameBoardClickMode;
 
 	protected constructor(protected gameService: GameService) {
-		this.gameService.productionTypesObs.subscribe(productionTypes => {
+		this.gameService.productionTypesObs.pipe(takeUntilDestroyed()).subscribe(productionTypes => {
 			this.productionTypes = productionTypes;
 		});
 
-		this.gameService.selectedProductionTypeObs.subscribe(productionType => {
+		this.gameService.selectedProductionTypeObs.pipe(takeUntilDestroyed()).subscribe(productionType => {
 			if (productionType) this.gameService.selectGameBoard(productionType.suitabilityMap);
 		})
 	}

--- a/v2/src/app/level/svg-level/svg-level.component.spec.ts
+++ b/v2/src/app/level/svg-level/svg-level.component.spec.ts
@@ -1,3 +1,4 @@
+import { TestBed } from '@angular/core/testing';
 import { BehaviorSubject, of } from 'rxjs';
 import { SvgLevelComponent } from './svg-level.component';
 
@@ -35,7 +36,7 @@ const setup = (opts: { minSelected?: number, percentage?: number } = {}) => {
 	document.getElementById = ((id: string) =>
 		id === 'svg-level-dialog' ? dialog : originalGetElementById.call(document, id)) as any;
 
-	const component = new SvgLevelComponent(gameStub, configStub);
+	const component = TestBed.runInInjectionContext(() => new SvgLevelComponent(gameStub, configStub));
 	return {
 		component, level, settings, calls, dialog,
 		setPercentage: (p: number) => { percentage = p; },

--- a/v2/src/app/level/svg-level/svg-level.component.ts
+++ b/v2/src/app/level/svg-level/svg-level.component.ts
@@ -1,4 +1,5 @@
 import { Component, HostBinding } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { LevelBaseComponent } from '../level-base.component';
 import { GameService } from 'src/app/services/game.service';
 import { map, tap } from 'rxjs';
@@ -52,7 +53,7 @@ export class SvgLevelComponent extends LevelBaseComponent {
 			this.gameService.loadSettings(data);
 			gameService.initialiseSVGMode();
 		});
-		this.settings.subscribe(o => {
+		this.settings.pipe(takeUntilDestroyed()).subscribe(o => {
 			this.minSelected = o?.minSelected ?? 0;
 			this.highlightFocusedBoard = o?.visualOptions?.highlightFocusedBoard ?? false;
 			this.neutralScoreColors = o?.visualOptions?.neutralScoreColors ?? false;

--- a/v2/src/app/product-type-button/production-type-button.component.spec.ts
+++ b/v2/src/app/product-type-button/production-type-button.component.spec.ts
@@ -1,3 +1,4 @@
+import { TestBed } from '@angular/core/testing';
 import { BehaviorSubject } from 'rxjs';
 import { ProductionTypeButtonComponent } from './production-type-button.component';
 import { ProductionType } from '../shared/models/production-type';
@@ -18,7 +19,7 @@ const setup = (opts: { imageMode?: boolean } = {}) => {
 		selectedProductionTypeObs: selected,
 		setSelectedProductionType: (pt: ProductionType) => chosen.push(pt)
 	};
-	return { settings, selected, chosen, make: () => new ProductionTypeButtonComponent(gameStub) };
+	return { settings, selected, chosen, make: () => TestBed.runInInjectionContext(() => new ProductionTypeButtonComponent(gameStub)) };
 };
 
 describe('ProductionTypeButtonComponent', () => {

--- a/v2/src/app/product-type-button/production-type-button.component.ts
+++ b/v2/src/app/product-type-button/production-type-button.component.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component, HostBinding, HostListener, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, HostBinding, HostListener, Input, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ProductionType } from '../shared/models/production-type';
 import { GameService } from '../services/game.service';
 
@@ -16,15 +17,17 @@ export class ProductionTypeButtonComponent implements OnInit {
 	@HostBinding('class.--image-mode') isImageMode = false;
 	backgroundColor = '';
 
+	private readonly destroyRef = inject(DestroyRef);
+
 	constructor(private gameService: GameService) {
 	}
 
 	ngOnInit(): void {
-		this.gameService.settingsObs.subscribe(o => {
+		this.gameService.settingsObs.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(o => {
 			this.isImageMode = o.imageMode;
 			this.backgroundColor = this.productionType.fieldColor;
 		});
-		this.gameService.selectedProductionTypeObs.subscribe(o => {
+		this.gameService.selectedProductionTypeObs.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(o => {
 			this.isActive = o == this.productionType;
 		});
 	}

--- a/v2/src/app/score-board/score-board.component.spec.ts
+++ b/v2/src/app/score-board/score-board.component.spec.ts
@@ -1,3 +1,4 @@
+import { TestBed } from '@angular/core/testing';
 import { BehaviorSubject } from 'rxjs';
 import { ScoreBoardComponent } from './score-board.component';
 import { ScoreEntry } from '../services/score.service';
@@ -37,7 +38,7 @@ const newComponent = (opts: {
 		createEmptyScoreEntry: () => [],
 		calculateScore: () => { }
 	};
-	return new ScoreBoardComponent(gameStub, cdRefStub, scoreStub, translateStub);
+	return TestBed.runInInjectionContext(() => new ScoreBoardComponent(gameStub, cdRefStub, scoreStub, translateStub));
 };
 
 describe('ScoreBoardComponent', () => {

--- a/v2/src/app/score-board/score-board.component.ts
+++ b/v2/src/app/score-board/score-board.component.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, Input, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { GameService } from '../services/game.service';
 import { ScoreEntry, ScoreService } from '../services/score.service';
 import { TranslateService } from '@ngx-translate/core';
@@ -37,6 +38,9 @@ export class ScoreBoardComponent implements OnInit {
 		this._isStatic = value !== false;
 	}
 
+	// ngOnInit is outside the implicit injection context, so takeUntilDestroyed needs this.
+	private readonly destroyRef = inject(DestroyRef);
+
 	constructor(
 		private gameService: GameService,
 		private cdRef: ChangeDetectorRef,
@@ -46,12 +50,12 @@ export class ScoreBoardComponent implements OnInit {
 
 	ngOnInit() {
 		if (!this._isStatic) {
-			this.gameService.currentLevelObs.subscribe(level => {
+			this.gameService.currentLevelObs.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(level => {
 				this._scores = this.scoreService.createEmptyScoreEntry(level);
 				this.cdRef.markForCheck();
 			});
 
-			this.gameService.selectedFieldsObs.subscribe(fields => {
+			this.gameService.selectedFieldsObs.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(fields => {
 				this.scoreService.calculateScore(this._scores, fields);
 				this.calculateTotalScore();
 				this.cdRef.markForCheck();

--- a/v2/src/app/score-indicator/score-indicator.component.spec.ts
+++ b/v2/src/app/score-indicator/score-indicator.component.spec.ts
@@ -1,3 +1,4 @@
+import { TestBed } from '@angular/core/testing';
 import { BehaviorSubject } from 'rxjs';
 import { ScoreIndicatorComponent } from './score-indicator.component';
 
@@ -12,7 +13,7 @@ const field = (...scores: number[]) => ({ scores: scores.map((score, i) => ({ id
 const setup = () => {
 	const selected = new BehaviorSubject<any>(null);
 	const gameStub: any = { currentlySelectedFieldObs: selected };
-	return { selected, make: () => new ScoreIndicatorComponent(gameStub, cdRefStub) };
+	return { selected, make: () => TestBed.runInInjectionContext(() => new ScoreIndicatorComponent(gameStub, cdRefStub)) };
 };
 
 describe('ScoreIndicatorComponent', () => {

--- a/v2/src/app/score-indicator/score-indicator.component.ts
+++ b/v2/src/app/score-indicator/score-indicator.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { GameService } from '../services/game.service';
 
 @Component({
@@ -12,7 +13,7 @@ export class ScoreIndicatorComponent {
 	score: number | null = null;
 
 	constructor(private gameService: GameService, private cdRef: ChangeDetectorRef) {
-		this.gameService.currentlySelectedFieldObs.subscribe(o => {
+		this.gameService.currentlySelectedFieldObs.pipe(takeUntilDestroyed()).subscribe(o => {
 			if (o) {
 				this.score = o.scores.reduce((a, b) => a + b.score, 0);
 			} else {


### PR DESCRIPTION
Six components subscribed to `GameService` observables and never unsubscribed. Those are `BehaviorSubject`s on a root-provided service, so they outlive every component **by definition** — each subscription keeps the destroyed component, and the DOM element it holds, alive for the rest of the session.

## Scale

`SvgFieldComponent` is the one that matters:

> 466 of them on the default board × a fresh set of boards every round

The others — `ProductionTypeButton`, `ScoreBoard`, `Help`, `ScoreIndicator`, `LevelBase`, `SvgLevel` — leak one or two each, per instance.

## Nothing new was invented

`GameBoardBase`, `GridGameBoard`, `SvgGameBoard` and `GridField` already do this correctly with `takeUntilDestroyed`. This applies the same pattern to the rest, with an injected `DestroyRef` where the subscription happens in `ngOnInit` rather than the constructor.

## Deliberately left alone, having checked each

| | why |
|---|---|
| `ConfiguratorComponent` | subscribes to `valueChanges` on its own `FormGroup`, which dies with it |
| `ImportConfig` | `take(1)` — completes |
| `GridLevel` / `SvgLevel` `getGameData()` | HTTP, completes |

## Measured, not asserted

The new spec counts the subject's own subscriber list. That is the only way to see this — a leaked subscription is invisible from the DOM and from every other assertion in that file.

```
expect(observers()).toBe(before + 1);   // presence first, or "it unsubscribed" proves nothing
TestBed.resetTestingModule();
expect(observers()).toBe(before);
```

Verified failing with `takeUntilDestroyed` removed.

## Test-harness fallout

Six existing specs construct these components with `new` and now need an injection context for `inject()`/`takeUntilDestroyed`. Wrapped in `TestBed.runInInjectionContext` — which is what `GridFieldComponent`'s spec already did.

## One thing to flag

I destroyed the existing 18-test `svg-field` spec with `cat >` while writing this. Caught it because the suite total dropped from 258 to 245; restored from master, and the new test is appended rather than replacing.

259 unit tests, 12 e2e, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE