### PR TITLE
fix(ui): raster failures now say which raster, and why

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -29,7 +29,7 @@ Verified working
    * - Path
      - How it was checked
    * - Static / grid game
-     - 259 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
+     - 268 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
        SEO 100. The board renders 2,436 fields; the e2e suite asserts that rather than
        just asserting the component mounted.
    * - No external runtime deps

--- a/v2/src/app/services/tiff.service.spec.ts
+++ b/v2/src/app/services/tiff.service.spec.ts
@@ -1,0 +1,120 @@
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
+import { TiffService } from './tiff.service';
+
+// Every raster the board renders goes through here, including the coverage URLs the calculator
+// returns. When one of those cannot be served, what the player and the console get should say
+// so — not a decoding error from three layers down.
+describe('TiffService raster fetching', () => {
+	let service: TiffService;
+	let originalFetch: typeof fetch;
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({});
+		service = TestBed.inject(TiffService);
+		originalFetch = globalThis.fetch;
+	});
+	afterEach(() => { globalThis.fetch = originalFetch; });
+
+	// The real shape of this failure, taken from docs/verification-status.rst: a missing raster
+	// 404s with an HTML body, fetch RESOLVES (it only rejects on network errors), .blob() is
+	// happy, and geotiff.js reads "<!" as the byte order.
+	it('reports the HTTP status when a raster cannot be fetched', async () => {
+		globalThis.fetch = (async () => new Response('<!doctype html><html>Not Found</html>',
+			{ status: 404, statusText: 'Not Found', headers: { 'Content-Type': 'text/html' } })) as any;
+
+		const err = await firstValueFrom(service.getTiffSvgDataUrl('/assets/images/missing.tif', 0, 1))
+			.then(() => null, (e: Error) => e);
+
+		expect(err).toBeInstanceOf(Error);
+		// Must name the status and the URL. "Invalid byte order value" tells you nothing about
+		// which raster is missing, or that anything was missing at all.
+		expect(err!.message).toContain('404');
+		expect(err!.message).toContain('missing.tif');
+	});
+
+	it('says so when the server returns something that is not a GeoTIFF', async () => {
+		// A 200 that is not a raster — what the e2e test server used to do for every path, and
+		// what a misconfigured SPA fallback still does.
+		globalThis.fetch = (async () => new Response('<!doctype html><html>index</html>',
+			{ status: 200, headers: { 'Content-Type': 'text/html' } })) as any;
+
+		const err = await firstValueFrom(service.getTiffSvgDataUrl('/assets/images/index-instead.tif', 0, 1))
+			.then(() => null, (e: Error) => e);
+
+		expect(err).toBeInstanceOf(Error);
+		expect(err!.message).toContain('index-instead.tif');
+	});
+});
+
+// The guard must not reject files the decoder can actually read. It checks the byte order and
+// the version word, and BigTIFF (43) is as valid as TIFF (42) as far as geotiff.js is concerned.
+describe('TiffService raster header acceptance', () => {
+	let service: TiffService;
+	let originalFetch: typeof fetch;
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({});
+		service = TestBed.inject(TiffService);
+		originalFetch = globalThis.fetch;
+	});
+	afterEach(() => { globalThis.fetch = originalFetch; });
+
+	// Header only — geotiff.js will fail later on the truncated body, and it should, but with a
+	// decoding error rather than this guard's message. That is the distinction being tested.
+	const header = (bytes: number[]) => (async () =>
+		new Response(new Uint8Array(bytes), { status: 200 })) as any;
+
+	const accepted = [
+		['little-endian TIFF (II 42)', [0x49, 0x49, 0x2a, 0x00]],
+		['big-endian TIFF (MM 42)', [0x4d, 0x4d, 0x00, 0x2a]],
+		['little-endian BigTIFF (II 43)', [0x49, 0x49, 0x2b, 0x00]],
+		['big-endian BigTIFF (MM 43)', [0x4d, 0x4d, 0x00, 0x2b]],
+	] as const;
+
+	for (const [name, bytes] of accepted) {
+		it(`lets ${name} through to the decoder`, async () => {
+			globalThis.fetch = header([...bytes]);
+			const err = await firstValueFrom(service.getTiffSvgDataUrl('/x.tif', 0, 1))
+				.then(() => null, (e: Error) => e);
+			// It still fails — the body is four bytes — but not with the not-a-GeoTIFF message.
+			expect(err?.message ?? '').not.toContain('not a GeoTIFF');
+		});
+	}
+
+	it('rejects a plausible-looking header with the wrong version word', async () => {
+		globalThis.fetch = header([0x49, 0x49, 0x2c, 0x00]);
+		const err = await firstValueFrom(service.getTiffSvgDataUrl('/x.tif', 0, 1))
+			.then(() => null, (e: Error) => e);
+		expect(err!.message).toContain('not a GeoTIFF');
+	});
+});
+
+// The grid board and the overlay board use geotiff's own fetcher rather than fetch(), because
+// they read the file in ranges instead of pulling it whole. Its failure message is
+// "Error fetching data." — no status, no URL, and identical for every raster on the board.
+describe('TiffService range-fetched rasters', () => {
+	let service: TiffService;
+	let originalFetch: typeof fetch;
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({});
+		service = TestBed.inject(TiffService);
+		originalFetch = globalThis.fetch;
+		globalThis.fetch = (async () => new Response('<!doctype html>',
+			{ status: 404, statusText: 'Not Found' })) as any;
+	});
+	afterEach(() => { globalThis.fetch = originalFetch; });
+
+	it('names the raster when the grid board cannot be read', async () => {
+		const err = await firstValueFrom(service.getTiffData('/assets/missing-grid.tif'))
+			.then(() => null, (e: Error) => e);
+		expect(err!.message).toContain('missing-grid.tif');
+	});
+
+	it('names the raster when the overlay board cannot be read', async () => {
+		const err = await firstValueFrom(service.getTiffSvgData('/assets/missing-overlay.tif'))
+			.then(() => null, (e: Error) => e);
+		expect(err!.message).toContain('missing-overlay.tif');
+	});
+});

--- a/v2/src/app/services/tiff.service.ts
+++ b/v2/src/app/services/tiff.service.ts
@@ -87,9 +87,53 @@ export class TiffService {
 		return from(this.tiffToPaths(url));
 	}
 
+	/**
+	 * Fetch a raster, failing with a message that names what actually went wrong.
+	 *
+	 * `fetch` only rejects on network errors, so a 404 resolves and its HTML body flows
+	 * happily into `blob()`. geotiff.js then reads `<!` as the byte order and throws
+	 * "Invalid byte order value." — which names neither the status nor the file, and is
+	 * indistinguishable from a genuinely corrupt raster.
+	 *
+	 * That is not hypothetical: it is how the missing `Consequence_*_Clip.tif` files went
+	 * unnoticed (see docs/verification-status.rst), because the e2e server answered every
+	 * path with index.html.
+	 */
+	private async fetchRaster(url: string): Promise<Blob> {
+		let response: Response;
+		try {
+			response = await fetch(url);
+		} catch (cause) {
+			// A genuine network error. Re-thrown with the URL, which the original does not carry.
+			throw new Error(`Could not reach ${url}: ${(cause as Error)?.message ?? cause}`, { cause });
+		}
+		if (!response.ok) {
+			throw new Error(`Could not load raster ${url}: ${response.status} ${response.statusText}`);
+		}
+		const blob = await response.blob();
+		// A 200 is not proof of a raster. An SPA fallback serving index.html is the common case,
+		// and it is worth naming here rather than leaving it to the decoder — checked by sniffing
+		// the content rather than trusting Content-Type, which servers get wrong for .tif.
+		const head = new Uint8Array(await blob.slice(0, 4).arrayBuffer());
+		// Byte order, then the version word read in that order. 42 is TIFF; 43 is BigTIFF, which
+		// geotiff.js also reads — rejecting it here would break files the decoder handles fine.
+		const littleEndian = head[0] === 0x49 && head[1] === 0x49;
+		const bigEndian = head[0] === 0x4d && head[1] === 0x4d;
+		const version = littleEndian ? head[2] | (head[3] << 8)
+			: bigEndian ? (head[2] << 8) | head[3]
+				: -1;
+		const isTiff = head.length >= 4 && (littleEndian || bigEndian) && (version === 42 || version === 43);
+		if (!isTiff) {
+			throw new Error(
+				`${url} returned ${response.status} but the body is not a GeoTIFF `
+				+ `(starts with ${JSON.stringify(await blob.slice(0, 16).text())}). `
+				+ `A server answering every path with index.html does exactly this.`);
+		}
+		return blob;
+	}
+
 	private async prepareDataUrl(url: string, minValue: number, maxValue: number, gradient?: Gradient, colors?: CustomColors) {
-		//fromURL throws error
-		const tmp = await fetch(url).then(r => r.blob());
+		const tmp = await this.fetchRaster(url);
 		const tiff = await fromBlob(tmp);
 		const image = await tiff.getImage();
 		const raster = await image.readRasters({ interleave: true });
@@ -102,8 +146,22 @@ export class TiffService {
 		return { width, height, dataUrl, nodata, numRaster };
 	}
 
+	/**
+	 * geotiff's own fetcher, used where the whole file is not wanted up front. Its failures say
+	 * "Error fetching data." and nothing else — not the status, not which raster — so they are
+	 * re-thrown carrying the URL. The magic-byte check in fetchRaster does not apply here:
+	 * fromUrl issues range requests and never holds the whole body.
+	 */
+	private async openRemote(url: string) {
+		try {
+			return await fromUrl(url);
+		} catch (cause) {
+			throw new Error(`Could not load raster ${url}: ${(cause as Error)?.message ?? cause}`, { cause });
+		}
+	}
+
 	private async tiffToPaths(url: string) {
-		const tiff = await fromUrl(url);
+		const tiff = await this.openRemote(url);
 		const image = await tiff.getImage();
 		const raster = await image.readRasters({ interleave: true });
 		const numRaster = Array.from(raster.map(c => Number.parseFloat(c.toString())));
@@ -120,7 +178,7 @@ export class TiffService {
 	}
 
 	private async tiffToArray(url: string): Promise<number[]> {
-		const tiff = await fromUrl(url);
+		const tiff = await this.openRemote(url);
 		const image = await tiff.getImage();
 		const raster = await image.readRasters({ interleave: true });
 		return Array.from(raster.map(c => Number.parseFloat(c.toString())));


### PR DESCRIPTION
Every board the game renders comes through `TiffService`, including the coverage URLs the calculator returns. When one could not be served, the error was:

```
Invalid byte order value.
```

No status. No URL. Indistinguishable from a genuinely corrupt raster.

`fetch` only rejects on **network** errors, so a 404's HTML body resolved happily, `.blob()` was happy, and geotiff.js read `<!` as the byte order three layers down.

## Not hypothetical

This is exactly how the missing `Consequence_*_Clip.tif` files went unnoticed for so long (`docs/verification-status.rst`): the e2e server answered every path with `index.html`, so the request came back `200 text/html` and died the same way.

## Now

```
Could not load raster /assets/images/missing.tif: 404 Not Found

/x.tif returned 200 but the body is not a GeoTIFF (starts with "<!doctype html>").
A server answering every path with index.html does exactly this.
```

The 200 case sniffs the first four bytes rather than trusting `Content-Type`, which servers routinely get wrong for `.tif`.

## The risk in adding a guard is rejecting valid files

So it accepts byte order `II` or `MM` **and version 42 or 43** — BigTIFF is 43, geotiff.js reads it, and rejecting it here would break files the decoder handles fine. Covered: four accepted headers, plus a plausible-but-wrong version word that must be rejected.

More importantly, verified against **real** rasters: 12 e2e specs against the committed GeoTIFFs, and both `v2/e2e-cluster` browser rounds against coverages GeoServer actually produced.

## The other two paths

The grid and overlay boards use geotiff's own range-fetching `fromUrl`, not `fetch`. Its failure message is `Error fetching data.` — for every raster on the board, identically. Measured with a throwaway diagnostic rather than assumed, then re-thrown carrying the URL. The magic-byte check doesn't apply there, since `fromUrl` never holds the whole body.

Every new assertion checked by mutation. 268 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE