### PR TITLE
fix(config): a broken config.json is no longer indistinguishable from an absent one

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -29,7 +29,7 @@ Verified working
    * - Path
      - How it was checked
    * - Static / grid game
-     - 268 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
+     - 274 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
        SEO 100. The board renders 2,436 fields; the e2e suite asserts that rather than
        just asserting the component mounted.
    * - No external runtime deps

--- a/v2/src/app/services/config.service.spec.ts
+++ b/v2/src/app/services/config.service.spec.ts
@@ -42,3 +42,73 @@ describe('ConfigService', () => {
 		expect((await data).foo).toBe(1);
 	});
 });
+
+// assets/config.json IS the deployment mechanism — one image retargeted by mounting a file over
+// it. So the difference between "there is no config here" and "the config is broken" matters a
+// great deal, and load() collapsed both into a silent fallback to defaults.
+//
+// The dangerous case is not a 404. It is a config.json that is served but unusable: a typo'd
+// mount, a 500, or a server answering every path with index.html. The app then boots pointing at
+// a different backend than intended, and says nothing at all.
+describe('ConfigService load() failure reporting', () => {
+	let service: ConfigService;
+	let http: HttpTestingController;
+	let errors: string[];
+	let originalError: typeof console.error;
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({ imports: [HttpClientTestingModule] });
+		service = TestBed.inject(ConfigService);
+		http = TestBed.inject(HttpTestingController);
+		errors = [];
+		originalError = console.error;
+		console.error = (...a: any[]) => errors.push(a.map(String).join(' '));
+	});
+	afterEach(() => { console.error = originalError; http.verify(); });
+
+	it('is quiet when config.json is simply absent — that is a supported deployment', async () => {
+		const done = service.load();
+		http.expectOne('assets/config.json').flush('', { status: 404, statusText: 'Not Found' });
+		await done;
+
+		expect(service.appConfig.defaultMode).toBe('static');
+		expect(errors).toEqual([]);
+	});
+
+	it('says so when the server fails, and still boots', async () => {
+		const done = service.load();
+		http.expectOne('assets/config.json').flush('', { status: 500, statusText: 'Server Error' });
+		await done;
+
+		// Booting on defaults is right — refusing to start would be worse. Being silent is not.
+		expect(service.appConfig.defaultMode).toBe('static');
+		expect(errors.join(' ')).toContain('assets/config.json');
+		expect(errors.join(' ')).toContain('500');
+	});
+
+	// The SPA-fallback case: 200, but the body is index.html. This one was worse than silent —
+	// the string was spread CHARACTER BY CHARACTER into the config, so Object.keys() came back
+	// as "0", "1", "2", … and nothing anywhere objected.
+	it('says so when config.json is served but is not a JSON object', async () => {
+		const done = service.load();
+		http.expectOne('assets/config.json').flush('<!doctype html><html></html>',
+			{ status: 200, statusText: 'OK' });
+		await done;
+
+		expect(service.appConfig.defaultMode).toBe('static');
+		expect(errors.join(' ')).toContain('assets/config.json');
+		// The config must be the defaults, not the defaults plus 28 numbered properties.
+		expect(Object.keys(service.appConfig)).toEqual(['staticDataUrl', 'dynamicDataUrl', 'defaultMode']);
+	});
+
+	for (const [name, body] of [['an array', []], ['null', null], ['a number', 7]] as const) {
+		it(`says so when config.json contains ${name}`, async () => {
+			const done = service.load();
+			http.expectOne('assets/config.json').flush(body as any, { status: 200, statusText: 'OK' });
+			await done;
+
+			expect(service.appConfig.defaultMode).toBe('static');
+			expect(errors.join(' ')).toContain('assets/config.json');
+		});
+	}
+});

--- a/v2/src/app/services/config.service.ts
+++ b/v2/src/app/services/config.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Observable, catchError, firstValueFrom, map, of } from 'rxjs';
 
 export interface AppConfig {
@@ -43,13 +43,55 @@ export class ConfigService {
 
 	constructor(private http: HttpClient) { }
 
-	/** Resolved once at startup via APP_INITIALIZER. Falls back to defaults if config.json is absent. */
+	/**
+	 * Resolved once at startup via APP_INITIALIZER. Falls back to defaults if config.json is
+	 * absent — a build with no config.json is a supported deployment, so a 404 is quiet.
+	 *
+	 * Everything else is not. This file IS the deployment mechanism: one image retargeted by
+	 * mounting a config over it. A 500, or a config.json served as index.html by a server
+	 * without an assets rule, or one with a trailing comma, used to be indistinguishable from
+	 * absent — the app booted on defaults, pointing at a different backend than intended, and
+	 * said nothing at all.
+	 *
+	 * It still boots on defaults, because refusing to start would be worse. It is no longer
+	 * silent about why.
+	 */
 	load(): Promise<void> {
 		return firstValueFrom(
 			this.http.get<Partial<AppConfig>>('assets/config.json').pipe(
-				catchError(() => of({} as Partial<AppConfig>))
+				catchError((err: HttpErrorResponse) => {
+					if (err.status !== 404) {
+						// status 0 is a network failure or CORS; HttpClient reports a body that did
+						// not parse as JSON with status 200 and the parse error in err.message.
+						console.error(
+							`[esgame] assets/config.json could not be loaded (status ${err.status}` +
+							`${err.statusText ? ' ' + err.statusText : ''}): ${err.message}. ` +
+							`Starting with built-in defaults — calcUrl and defaultMode are NOT the ` +
+							`ones you configured.`);
+					}
+					return of({} as Partial<AppConfig>);
+				})
 			)
-		).then(cfg => { this.config = { ...DEFAULT_CONFIG, ...cfg }; });
+		).then(cfg => { this.config = { ...DEFAULT_CONFIG, ...this.asConfigObject(cfg) }; });
+	}
+
+	/**
+	 * Spreading whatever came back is not safe. `{...DEFAULT_CONFIG, ...cfg}` assumes cfg is an
+	 * object, and a string spreads CHARACTER BY CHARACTER — a config.json served as index.html
+	 * produced a config whose keys were "0", "1", "2", …, with no error anywhere. An array or a
+	 * bare `null` merge to nothing just as quietly.
+	 *
+	 * Anything that is not a plain object is a broken config, not a config.
+	 */
+	private asConfigObject(cfg: unknown): Partial<AppConfig> {
+		if (cfg && typeof cfg === 'object' && !Array.isArray(cfg)) return cfg as Partial<AppConfig>;
+		console.error(
+			`[esgame] assets/config.json did not contain a JSON object (got ` +
+			`${Array.isArray(cfg) ? 'an array' : typeof cfg}: ` +
+			`${JSON.stringify(cfg)?.slice(0, 80) ?? String(cfg)}). ` +
+			`Starting with built-in defaults — calcUrl and defaultMode are NOT the ones you ` +
+			`configured. A server answering every path with index.html does exactly this.`);
+		return {};
 	}
 
 	get appConfig(): AppConfig { return this.config; }


### PR DESCRIPTION
`assets/config.json` **is** the deployment mechanism — one image retargeted by mounting a file over it. `load()` collapsed every failure into the same silent fallback:

```ts
catchError(() => of({} as Partial<AppConfig>))
```

A 500, a config served as `index.html` by a server with no assets rule, or one with a trailing comma — all indistinguishable from *"there is no config here"*, which is a **supported** deployment. The app booted pointing at a different backend than intended and said nothing.

A 404 stays quiet. Everything else says what happened, and that the running config is not the configured one. It still boots on defaults — refusing to start would be worse.

## Writing the test turned up something worse than silence

```ts
this.config = { ...DEFAULT_CONFIG, ...cfg };
```

assumes `cfg` is an object. **A string spreads character by character.** A `config.json` served as `index.html` produced:

```json
{"keys":["0","1","2","3","4","5","6","7"], "staticDataUrl":"assets/dataGridExample.json"}
```

Measured with a throwaway diagnostic printing `Object.keys()`, not reasoned about. An array or a bare `null` merge to nothing just as quietly.

So the guard is on the **shape**, not only the HTTP status — which also makes it independent of whether the parse fails in the browser or the body arrives unparsed, as it does under `HttpTestingController`.

## Verified

| | |
|---|---|
| mutation (naive spread restored) | all four shape assertions fail |
| 404 | quiet, as before |
| 500 / non-object bodies | logged, still boots |
| good-config path | 274 unit, 12 e2e, **both browser rounds against the live cluster**, which serves a genuinely mounted config |

That last row is the one that matters — the risk in adding a guard is rejecting the real thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE