### PR TITLE
fix(config): a game-data file that will not load now says so

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -29,7 +29,7 @@ Verified working
    * - Path
      - How it was checked
    * - Static / grid game
-     - 274 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
+     - 278 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
        SEO 100. The board renders 2,436 fields; the e2e suite asserts that rather than
        just asserting the component mounted.
    * - No external runtime deps

--- a/v2/src/app/level/grid-level/grid-level.component.ts
+++ b/v2/src/app/level/grid-level/grid-level.component.ts
@@ -13,9 +13,18 @@ export class GridLevelComponent extends LevelBaseComponent {
 	settings = this.gameService.settingsObs;
 	constructor(gameService: GameService, configService: ConfigService) {
 		super(gameService);
-		configService.getGameData('static').subscribe(data => {
-			this.gameService.loadSettings(data);
-			this.gameService.initialiseGridMode();
+		configService.getGameData('static').subscribe({
+			next: data => {
+				this.gameService.loadSettings(data);
+				this.gameService.initialiseGridMode();
+			},
+			error: (err) => {
+				// Without the game data there is no board at all, so this is terminal. It used to
+				// have no error handler: the observable errored, Angular's ErrorHandler logged it,
+				// and the player got a blank page with nothing to read.
+				console.error(err);
+				alert("The game could not be loaded. Its configuration data is missing or unreadable.");
+			}
 		});
 	}
 }

--- a/v2/src/app/level/svg-level/svg-level.component.ts
+++ b/v2/src/app/level/svg-level/svg-level.component.ts
@@ -49,9 +49,18 @@ export class SvgLevelComponent extends LevelBaseComponent {
 
 	constructor(gameService: GameService, configService: ConfigService) {
 		super(gameService);
-		configService.getGameData('dynamic').subscribe(data => {
-			this.gameService.loadSettings(data);
-			gameService.initialiseSVGMode();
+		configService.getGameData('dynamic').subscribe({
+			next: data => {
+				this.gameService.loadSettings(data);
+				gameService.initialiseSVGMode();
+			},
+			error: (err) => {
+				// Without the game data there is no board at all, so this is terminal. It used to
+				// have no error handler: the observable errored, Angular's ErrorHandler logged it,
+				// and the player got a blank page with nothing to read.
+				console.error(err);
+				alert("The game could not be loaded. Its configuration data is missing or unreadable.");
+			}
 		});
 		this.settings.pipe(takeUntilDestroyed()).subscribe(o => {
 			this.minSelected = o?.minSelected ?? 0;

--- a/v2/src/app/services/config.service.spec.ts
+++ b/v2/src/app/services/config.service.spec.ts
@@ -112,3 +112,42 @@ describe('ConfigService load() failure reporting', () => {
 		});
 	}
 });
+
+// The game data IS the game — the maps, the production types, the board dimensions. A data file
+// served as index.html used to spread character by character into Settings, exactly as
+// config.json did, and produced a board with nothing on it and no explanation.
+describe('ConfigService getGameData() shape', () => {
+	let service: ConfigService;
+	let http: HttpTestingController;
+
+	beforeEach(async () => {
+		TestBed.configureTestingModule({ imports: [HttpClientTestingModule] });
+		service = TestBed.inject(ConfigService);
+		http = TestBed.inject(HttpTestingController);
+		const loaded = service.load();
+		http.expectOne('assets/config.json').flush({});
+		await loaded;
+	});
+	afterEach(() => http.verify());
+
+	it('passes a real settings object through', async () => {
+		const p = firstValueFrom(service.getGameData('dynamic'));
+		http.expectOne('assets/data.json').flush({ minSelected: 1, maps: [] });
+		await expect(p).resolves.toMatchObject({ minSelected: 1 });
+	});
+
+	for (const [name, body] of [
+		['index.html', '<!doctype html><html></html>'],
+		['an array', []],
+		['null', null],
+	] as const) {
+		it(`rejects ${name} rather than building a board from it`, async () => {
+			const p = firstValueFrom(service.getGameData('dynamic'));
+			http.expectOne('assets/data.json').flush(body as any, { status: 200, statusText: 'OK' });
+
+			const err = await p.then(() => null, (e: Error) => e);
+			expect(err).toBeInstanceOf(Error);
+			expect(err!.message).toContain('assets/data.json');
+		});
+	}
+});

--- a/v2/src/app/services/config.service.ts
+++ b/v2/src/app/services/config.service.ts
@@ -96,11 +96,26 @@ export class ConfigService {
 
 	get appConfig(): AppConfig { return this.config; }
 
-	/** Fetch the game settings JSON for the given mode, applying any overrides from config.json. */
+	/**
+	 * Fetch the game settings JSON for the given mode, applying any overrides from config.json.
+	 *
+	 * The shape is checked for the same reason it is in load(): `{ ...data }` on a string spreads
+	 * it character by character, so a data file served as index.html produced a Settings object
+	 * built from { "0": "<", "1": "!", … } — a board with no maps and no production types, and
+	 * nothing anywhere saying why. An HTTP failure already errors with a usable message; this
+	 * covers the 200 that is not what it claims to be.
+	 */
 	getGameData(mode: 'static' | 'dynamic'): Observable<any> {
 		const url = mode === 'static' ? this.config.staticDataUrl : this.config.dynamicDataUrl;
 		return this.http.get<any>(url).pipe(
 			map(data => {
+				if (!data || typeof data !== 'object' || Array.isArray(data)) {
+					throw new Error(
+						`${url} did not contain a JSON object (got ` +
+						`${Array.isArray(data) ? 'an array' : typeof data}: ` +
+						`${JSON.stringify(data)?.slice(0, 80) ?? String(data)}). ` +
+						`A server answering every path with index.html does exactly this.`);
+				}
 				const out = { ...data };
 				if (this.config.calcUrl !== undefined) out.calcUrl = this.config.calcUrl;
 				if (this.config.gridLineColor !== undefined) out.gridLineColor = this.config.gridLineColor;


### PR DESCRIPTION
Follow-on to #136. `getGameData` had the same defect, and the two level components that consume it had **no error handler at all**.

## Same shape bug

`{ ...data }` on a string spreads it character by character. A data file served as `index.html` built a `Settings` out of `{ "0": "<", "1": "!", … }` — a board with no maps, no production types, no dimensions, and nothing anywhere saying why:

```
{"keys":["0","1","2","3","4","5"]}
```

Measured, not reasoned about, same as last time.

## The missing error handler

An HTTP failure *already* produced a usable message:

```
Http failure response for assets/data.json: 404 Not Found
```

…and both level components subscribed with only a `next` callback, so it went to Angular's `ErrorHandler` and the player got a blank page. They now report it the way the rest of the app does.

## Verified

| | |
|---|---|
| mutation (guard removed) | three reject cases fail; the real-settings case still passes |
| suite | 278 unit, 12 e2e |
| live cluster | both browser rounds, against genuine `data.json` and `config.json` |

## One thing worth flagging

While undoing a mutation I ran `git checkout --` on `config.service.ts` and reverted the uncommitted guard along with it. Caught by counting the guard's message in the file rather than assuming the restore did what I meant — `grep -c` returned 1 where it should have been 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE