### PR TITLE
fix(ui): a data.json missing a required map now names it

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -29,7 +29,7 @@ Verified working
    * - Path
      - How it was checked
    * - Static / grid game
-     - 285 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
+     - 288 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
        SEO 100. The board renders 2,436 fields; the e2e suite asserts that rather than
        just asserting the component mounted.
    * - No external runtime deps

--- a/v2/src/app/services/game.service.required-maps.spec.ts
+++ b/v2/src/app/services/game.service.required-maps.spec.ts
@@ -1,0 +1,79 @@
+import { firstValueFrom, of } from 'rxjs';
+import { GameService } from './game.service';
+
+// "One image, any deployment" is the point of this app: a site supplies its own data.json. So a
+// data.json that omits a map the code requires is a configuration mistake someone will make, and
+// what they get told about it is the whole experience of getting it wrong.
+//
+// initialiseSVGMode does:
+//
+//   const drawingMap = settings.maps.find(o => o.gameBoardType == DrawingMap)!;
+//   ...getOverlayGameBoard(drawingMap.id, drawingMap.urlToData, ...)
+//
+// The `!` is a lie when the map is absent, and the next line reads a property of undefined.
+
+const translateStub: any = { getLangs: () => [], setTranslation: () => { } };
+const scoreStub: any = { createEmptyScoreEntry: () => [], calculateScore: () => { } };
+const tiffStub: any = {
+	getOverlayGameBoard: (id: any, url: string, t: any) => of({ id, gameBoardType: t, urlToData: url }),
+	getSvgBackground: () => of({ id: 'bg' }),
+	getSvgGameBoard: (id: any, url: string, t: any) => of({ id, gameBoardType: t, urlToData: url }),
+	getGridGameBoard: (id: any, url: string, t: any) => of({ id, gameBoardType: t, urlToData: url }),
+};
+
+const base = {
+	title: { en: 'T' }, mapMode: 'svg', elementSize: 1,
+	gameBoardColumns: 4, gameBoardRows: 4,
+	productionTypes: [],
+	customColors: [{ id: 'cc', colors: [{ number: 0, color: '#000' }] }],
+	maps: [
+		{ id: '-3', gameBoardType: 'Drawing', urlToData: 'drawing.tif', productionTypes: [] },
+		{ id: '-2', gameBoardType: 'Background', urlToData: 'bg.tif', customColorId: 'cc', productionTypes: [] },
+	],
+};
+
+const withMaps = (maps: any[]) => ({ ...base, maps });
+
+describe('GameService required maps', () => {
+	let alerts: string[];
+	let errors: string[];
+	beforeEach(() => {
+		alerts = []; errors = [];
+		vi.spyOn(window, 'alert').mockImplementation((m?: any) => { alerts.push(String(m)); });
+		vi.spyOn(console, 'error').mockImplementation((...a: any[]) => { errors.push(a.map(String).join(' ')); });
+	});
+	afterEach(() => vi.restoreAllMocks());
+
+	const make = (data: any) => {
+		const service = new GameService(tiffStub, scoreStub, translateStub, {} as any);
+		service.loadSettings(JSON.parse(JSON.stringify(data)));
+		return service;
+	};
+
+	it('starts normally when both required maps are present', () => {
+		const service = make(base);
+
+		service.initialiseSVGMode();
+
+		expect(alerts).toEqual([]);
+	});
+
+	for (const [missing, maps] of [
+		['Drawing', base.maps.filter(m => m.gameBoardType !== 'Drawing')],
+		['Background', base.maps.filter(m => m.gameBoardType !== 'Background')],
+	] as const) {
+		it(`names the missing ${missing} map instead of throwing on undefined`, async () => {
+			const service = make(withMaps([...maps]));
+
+			service.initialiseSVGMode();
+
+			// The message has to name the map type. "Cannot read properties of undefined
+			// (reading 'urlToData')" does not tell a deployer what to add to data.json.
+			expect(errors.join(' ')).toContain(missing);
+			expect(alerts.length).toBeGreaterThan(0);
+			// And it must not leave the spinner up over a board that will never arrive.
+			await expect(firstValueFrom(service.loadingIndicatorObs).then(a => a.length > 0))
+				.resolves.toBe(false);
+		});
+	}
+});

--- a/v2/src/app/services/game.service.ts
+++ b/v2/src/app/services/game.service.ts
@@ -281,15 +281,33 @@ export class GameService {
 			this.customColors.push(customColor);
 		});
 
-		const drawingMap = settings.maps.find(o => o.gameBoardType == GameBoardType.DrawingMap)!;
-		const backgroundMap = settings.maps.find(o => o.gameBoardType == GameBoardType.BackgroundMap)!;
+		const drawingMap = settings.maps.find(o => o.gameBoardType == GameBoardType.DrawingMap);
+		const backgroundMap = settings.maps.find(o => o.gameBoardType == GameBoardType.BackgroundMap);
 		const otherMaps = settings.maps.filter(m => m.gameBoardType == GameBoardType.SuitabilityMap);
 
-		this.tiffService.getOverlayGameBoard(drawingMap.id, drawingMap.urlToData, GameBoardType.DrawingMap).pipe(
+		// These two were asserted non-null. The whole point of this app is that a deployment
+		// supplies its own data.json, so a data.json missing one of them is a mistake someone
+		// will make — and what they got was "Cannot read properties of undefined (reading
+		// 'urlToData')" on the next line, which names neither the map nor the file to fix.
+		// GameBoardType is a numeric enum, so interpolating a value gives "no 2 map". Name it.
+		const typeName = (t: GameBoardType) => GameBoardType[t];
+		const missing = [
+			drawingMap ? null : GameBoardType.DrawingMap,
+			backgroundMap ? null : GameBoardType.BackgroundMap,
+		].filter(t => t !== null).map(t => typeName(t as GameBoardType));
+		if (missing.length) {
+			this.failLevel(new Error(
+				`The game data defines no ${missing.join(' and no ')}. ` +
+				`SVG mode needs one of each in "maps"; it has ` +
+				`[${settings.maps.map(m => typeName(m.gameBoardType)).join(', ') || 'no maps at all'}].`));
+			return;
+		}
+
+		this.tiffService.getOverlayGameBoard(drawingMap!.id, drawingMap!.urlToData, GameBoardType.DrawingMap).pipe(
 			switchMap(overlay => {
 				level.gameBoards.push(overlay);
 				return combineLatest(
-					[this.tiffService.getSvgBackground(backgroundMap.urlToData, settings.minValue, settings.maxValue, this.customColors.find(o => o.id == backgroundMap.customColorId)!),
+					[this.tiffService.getSvgBackground(backgroundMap!.urlToData, settings.minValue, settings.maxValue, this.customColors.find(o => o.id == backgroundMap!.customColorId)!),
 					...otherMaps.map(m => { return this.getSvg(m, overlay, settings) }),]
 				);
 			})


### PR DESCRIPTION
The point of this app is that a deployment supplies its own `data.json`. So a `data.json` missing a map the code requires is a mistake someone **will** make, and what they get told is the whole experience of getting it wrong.

`initialiseSVGMode` asserted both away:

```ts
const drawingMap = settings.maps.find(o => o.gameBoardType == DrawingMap)!;
...getOverlayGameBoard(drawingMap.id, drawingMap.urlToData, ...)
```

The `!` is a lie when the map is absent, and the next line reads a property of `undefined`:

```
Cannot read properties of undefined (reading 'urlToData')
```

Names neither the map nor the file to fix — and it's thrown from a synchronous path with the loading counter already pushed, so the spinner stays up over a board that is never coming.

## Now

```
The game data defines no DrawingMap and no BackgroundMap. SVG mode needs one of each
in "maps"; it has [ConsequenceMap].
```

It routes through `failLevel`, so the counter clears and the player is told, instead of the error escaping into Angular's `ErrorHandler`.

## One thing worth recording

`GameBoardType` is a **numeric** enum, so my first version of this message said:

> The game data defines no **2** map … it has **[1]**.

The assertion `toContain('Drawing')` caught it, but only because I'd written it that way — I confirmed the fix by printing the message a deployer actually sees rather than trusting that a substring check meant it read well.

Three new specs including the both-present case, verified failing first. 288 unit, 12 e2e, and both browser rounds against the live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE