### PR TITLE
fix(ui): unresolvable ids in data.json no longer crash level navigation

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -29,7 +29,7 @@ Verified working
    * - Path
      - How it was checked
    * - Static / grid game
-     - 288 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
+     - 293 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
        SEO 100. The board renders 2,436 fields; the e2e suite asserts that rather than
        just asserting the component mounted.
    * - No external runtime deps

--- a/v2/src/app/services/game.service.bad-references.spec.ts
+++ b/v2/src/app/services/game.service.bad-references.spec.ts
@@ -1,0 +1,107 @@
+import { firstValueFrom, of } from 'rxjs';
+import { GameService } from './game.service';
+import { CalculationResult } from '../shared/models/calculation-result';
+
+// A deployment writes its own data.json, and the ids inside it are cross-references: a map's
+// `productionTypes` lists ids that must exist in the top-level `productionTypes`. Nothing checks
+// that, and the place it is dereferenced asserts non-null:
+//
+//   currentPt.find(c => c.id == ptId)!.consequenceMaps.push(map)
+//
+// So an id that does not exist is a crash — not at load, but later, when the player navigates
+// between levels. The board is already on screen and working by then.
+
+const translateStub: any = { getLangs: () => [], setTranslation: () => { } };
+const scoreStub: any = { createEmptyScoreEntry: () => [], calculateScore: () => { } };
+const tiffStub: any = {
+	getOverlayGameBoard: (id: any, url: string, t: any) => of({ id, gameBoardType: t, urlToData: url, fields: [] }),
+	getSvgBackground: () => of('data:'),
+	getSvgGameBoard: (id: any, url: string, t: any) => of({ id, gameBoardType: t, urlToData: url, fields: [] }),
+};
+
+const settingsWith = (consequenceProductionTypes: number[]) => ({
+	title: { en: 'T' }, mapMode: 'svg', elementSize: 1,
+	gameBoardColumns: 4, gameBoardRows: 4, infiniteLevels: true,
+	productionTypes: [{ id: 1, name: { en: 'A' }, fieldColor: '#f00', urlToIcon: '', maxElements: 0 }],
+	customColors: [{ id: 'cc', colors: [{ number: 0, color: '#000000' }] }],
+	maps: [
+		{ id: '-3', gameBoardType: 'Drawing', urlToData: 'drawing.tif', productionTypes: [] },
+		{ id: '-2', gameBoardType: 'Background', urlToData: 'bg.tif', customColorId: 'cc', productionTypes: [] },
+		{ id: '11', gameBoardType: 'Consequence', urlToData: 'c11.tif', productionTypes: consequenceProductionTypes },
+	],
+});
+
+const resultFor = (round: number): CalculationResult => ({
+	results: [
+		{ name: `HH_r${round}.tif`, id: '11', score: 0.1, url: `http://gs/wcs?coverageId=ws_round${round}:HH` },
+		{ name: `S_r${round}.png`, id: '-1', score: undefined as any, url: `http://calc/S_r${round}.png` }
+	]
+});
+
+describe('GameService with a map referencing an unknown production type', () => {
+	let alerts: string[];
+	let errors: string[];
+	beforeEach(() => {
+		alerts = []; errors = [];
+		vi.spyOn(window, 'alert').mockImplementation((m?: any) => { alerts.push(String(m)); });
+		vi.spyOn(console, 'error').mockImplementation((...a: any[]) => { errors.push(a.map(String).join(' ')); });
+	});
+	afterEach(() => vi.restoreAllMocks());
+
+	const twoLevels = (ptIds: number[]) => {
+		const service = new GameService(tiffStub, scoreStub, translateStub, {} as any);
+		service.loadSettings(JSON.parse(JSON.stringify(settingsWith(ptIds))));
+		service.initialiseSVGMode();
+		service.prepareNextLevel(resultFor(1), 40);   // level 2 exists and is current
+		return service;
+	};
+
+	// The control. Everything below must be the difference the bad id makes, not the harness.
+	it('navigates back and forth normally when the ids all resolve', async () => {
+		const service = twoLevels([1]);
+
+		service.goToPreviousLevel();
+		service.goToNextLevel();
+
+		expect(errors).toEqual([]);
+		expect((await firstValueFrom(service.currentLevelObs))!.levelNumber).toBe(2);
+	});
+
+	it('does not crash navigating to the previous level', () => {
+		const service = twoLevels([99]);
+
+		expect(() => service.goToPreviousLevel()).not.toThrow();
+	});
+
+	it('does not crash navigating forward again', () => {
+		const service = twoLevels([99]);
+		service.goToPreviousLevel();
+
+		expect(() => service.goToNextLevel()).not.toThrow();
+	});
+
+	// Going back alone does not reach it: level 1 has no consequence boards, so the loop body
+	// never runs. It is stepping back and then FORWARD that rebuilds level 2's lists, which is
+	// why this hid — the crash needed two navigations, not one.
+	it('says which id is unresolved rather than failing silently', () => {
+		const service = twoLevels([99]);
+
+		service.goToPreviousLevel();
+		service.goToNextLevel();
+
+		expect(errors.join(' ')).toContain('99');
+		expect(errors.join(' ')).toContain('does not define');
+	});
+
+	it('names a board whose id is not in the game data at all', () => {
+		const service = twoLevels([1]);
+		// The other assertion in that helper: a level showing a board id `maps` does not contain.
+		(service as any).settings.value.maps = (service as any).settings.value.maps
+			.filter((m: any) => m.id !== '11');
+
+		service.goToPreviousLevel();
+		service.goToNextLevel();
+
+		expect(errors.join(' ')).toContain('no map with id "11"');
+	});
+});

--- a/v2/src/app/services/game.service.ts
+++ b/v2/src/app/services/game.service.ts
@@ -144,19 +144,55 @@ export class GameService {
 			let lvl = this.levels.find(o => o.levelNumber == (this.currentLevel.value!.levelNumber + 1))!;
 			const currentPt = this.productionTypes.value;
 
-			currentPt.forEach(pt => { pt.consequenceMaps = []; });
-
-			lvl.gameBoards.filter(c => c.gameBoardType == GameBoardType.ConsequenceMap).forEach(map => {
-				const mapSettings = this.settings.value.maps.find(c => c.id == map.id)!;
-				mapSettings.productionTypes.forEach(ptId => {
-					currentPt.find(c => c.id == ptId)!.consequenceMaps.push(map);
-				});
-			});
+			this.rebuildConsequenceMaps(lvl, currentPt);
 
 			this.currentLevel.next(lvl);
 			this.productionTypes.next(currentPt);
 			this.selectedFields.next(lvl.selectedFields);
 		}
+	}
+
+	/**
+	 * Rebuild each production type's consequence-map list for the level being shown.
+	 *
+	 * Both call sites used to assert their lookups non-null:
+	 *
+	 *     const mapSettings = this.settings.value.maps.find(c => c.id == map.id)!;
+	 *     mapSettings.productionTypes.forEach(ptId =>
+	 *         currentPt.find(c => c.id == ptId)!.consequenceMaps.push(map));
+	 *
+	 * Both ids come out of the deployment's own data.json, where a map's `productionTypes`
+	 * cross-references the top-level `productionTypes` and nothing checks that they line up. An
+	 * id that does not resolve threw "Cannot read properties of undefined (reading
+	 * 'consequenceMaps')" — and not at load, but the first time the player stepped back a level
+	 * and forward again, on a board that had been working until then.
+	 *
+	 * An unresolved id means one board is missing from one production type's list. That is worth
+	 * saying, and it is not worth taking the game down for.
+	 */
+	private rebuildConsequenceMaps(level: Level, productionTypes: ProductionType[]) {
+		productionTypes.forEach(pt => { pt.consequenceMaps = []; });
+
+		level.gameBoards.filter(c => c.gameBoardType == GameBoardType.ConsequenceMap).forEach(map => {
+			const mapSettings = this.settings.value.maps.find(c => c.id == map.id);
+			if (!mapSettings) {
+				console.error(
+					`The game data has no map with id "${map.id}", but level ${level.levelNumber} ` +
+					`is showing a consequence board with that id. Its production types cannot be ` +
+					`resolved; the board will not appear under any of them.`);
+				return;
+			}
+			mapSettings.productionTypes.forEach(ptId => {
+				const pt = productionTypes.find(c => c.id == ptId);
+				if (!pt) {
+					console.error(
+						`Map "${map.id}" lists production type ${ptId}, which the game data does ` +
+						`not define. Known ids: [${productionTypes.map(p => p.id).join(', ') || 'none'}].`);
+					return;
+				}
+				pt.consequenceMaps.push(map);
+			});
+		});
 	}
 
 	goToPreviousLevel() {
@@ -167,15 +203,7 @@ export class GameService {
 			let lvl = this.levels.find(o => o.levelNumber == this.currentLevel.value!.levelNumber - 1)!;
 			const currentPt = this.productionTypes.value;
 
-			currentPt.forEach(pt => { pt.consequenceMaps = []; });
-
-			lvl.gameBoards.filter(c => c.gameBoardType == GameBoardType.ConsequenceMap).forEach(map => {
-				const mapSettings = this.settings.value.maps.find(c => c.id == map.id)!;
-				mapSettings.productionTypes.forEach(ptId => {
-					const pt = currentPt.find(c => c.id == ptId)!;
-					pt.consequenceMaps.push(map);
-				});
-			});
+			this.rebuildConsequenceMaps(lvl, currentPt);
 
 			this.currentLevel.next(lvl);
 			this.selectedFields.next(lvl.selectedFields);


### PR DESCRIPTION
A deployment writes its own `data.json`, and the ids in it are **cross-references**: a map's `productionTypes` lists ids that must exist in the top-level `productionTypes`. Nothing checks that, and both places it's dereferenced asserted non-null:

```ts
const mapSettings = this.settings.value.maps.find(c => c.id == map.id)!;
mapSettings.productionTypes.forEach(ptId =>
    currentPt.find(c => c.id == ptId)!.consequenceMaps.push(map));
```

An id that doesn't resolve threw:

```
Cannot read properties of undefined (reading 'consequenceMaps')
```

Not at load — on a board that had been working, the first time the player stepped **back** a level and then **forward** again.

## Why the two-step matters

`goToPreviousLevel` alone never reaches it: level 1 has no consequence boards, so the loop body doesn't run. It's going forward again that rebuilds level 2's lists.

My own first test asserted the message on `goToPreviousLevel` and failed for exactly that reason. The all-ids-resolve control is what showed why — without it I'd have concluded the guard didn't work.

## The fix

`goToNextLevel` and `goToPreviousLevel` had the same block duplicated; it's now one method. An unresolved id means one board is missing from one production type's list — worth saying, not worth taking the game down for:

```
Map "11" lists production type 99, which the game data does not define. Known ids: [1].
The game data has no map with id "11", but level 2 is showing a consequence board with that id.
```

## Verified

Mutation with both assertions restored: the crash returns and all three assertions fail, while the control passes throughout.

293 unit, 12 e2e, both browser rounds against the live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE