### PR TITLE
test(k8s): surface how much of the allocation the calculator could use

### DIFF
--- a/deploy/k8s/ingress-test.sh
+++ b/deploy/k8s/ingress-test.sh
@@ -175,9 +175,47 @@ echo "     WCS GetCoverage through the ingress: ${ok}/${tot}"
 check "coverage URLs use an ingress host"  "[ -n '${urls}' ] && ! grep -q 'esgame-geoserver-service' <<<'${urls}'"
 check "coverage URLs return GeoTIFFs"      "[ ${tot} -gt 0 ] && [ ${ok} = ${tot} ]"
 
+echo "==> how much of the allocation the calculator could actually use"
+# Everything above can pass on a round that ignored the allocation entirely. The committed
+# LU_and_NEW_hexa.tif numbers its hexagons 10-474 while the board numbers its own 100-46500, so
+# only 4 of 465 ids overlap: reclassify is very nearly a no-op and the same five scores come back
+# for ANY allocation. tools/R/coverage.R detects this and logs it — and nothing ever read that
+# log, so this script printed "PASS (455 ids, 5 scores, 5/5 coverages)" over a game that was
+# inert. See docs/verification-status.rst, "The committed base raster makes the game inert".
+cov=$("${K[@]}" logs deploy/esgame-calculation --tail=400 2>/dev/null \
+      | grep -F 'Allocation coverage:' | tail -1 || true)
+echo "     ${cov:-<no coverage line in the calculation log>}"
+# Presence first: the reporter being wired in at all is the thing worth failing on. If someone
+# removes the source() of coverage.R, every other check here still passes.
+check "the calculator reported coverage"   "[ -n '${cov}' ]"
+
+pct=$(sed -nE 's/.*\(([0-9]+)%\).*/\1/p' <<<"${cov}")
+# ...and this number is CIRCULAR here, so do not read it as evidence about the data. The payload
+# above is built from ids this script read out of the deployed raster, so it matches by
+# construction and reports ~100% however wrong the raster is for the actual game board.
+#
+# A real player does not do that. Measured on this same cluster, minutes apart:
+#
+#   ingress-test.sh (ids taken from the raster)   455 of 455  (100%)
+#   a browser playing a round (real board ids)      4 of 465  (1%)
+#
+# So the honest figure comes from v2/e2e-cluster, not from here. What this proves is that the
+# reporter is wired in and runs — which is worth proving, because nothing else here would notice
+# if it were removed.
+if [ -n "${pct}" ] && [ "${pct}" -lt 50 ]; then
+  echo "     !! ${pct}% of the allocation matched the base raster."
+  echo "     !! The scores above are very nearly independent of what was allocated."
+  echo "     !! This is EXPECTED with the raster committed to this repository, which is only"
+  echo "     !! good for exercising the plumbing. A deployment supplies the data-release raster."
+  inert=" — but only ${pct}% of the allocation was used"
+elif [ -n "${pct}" ]; then
+  echo "     (${pct}% — circular: this payload's ids came from that raster. See v2/e2e-cluster"
+  echo "      for the figure a real browser produces, which on this data is 1%.)"
+fi
+
 echo
 if [ "${fail}" = 0 ]; then
-  echo "ingress round-trip: PASS   (${n} ids, ${scored} scores, ${ok}/${tot} coverages, all via http://localhost:${PORT})"
+  echo "ingress round-trip: PASS   (${n} ids, ${scored} scores, ${ok}/${tot} coverages, all via http://localhost:${PORT})${inert:-}"
 else
   echo "ingress round-trip: FAIL"; exit 1
 fi

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -243,6 +243,24 @@ The committed base raster makes the game inert
    Nothing is broken in the code: a deployment is supposed to supply the real geodata,
    and the release copy shares the board's id space. But the committed asset is only good
    for exercising the plumbing, and a green round against it says nothing about the model.
+
+   **The synthetic allocation was hiding this, not merely failing to exercise it.**
+   :file:`deploy/k8s/ingress-test.sh` builds its payload from ids it reads out of the
+   *deployed raster*, so it matches by construction. Measured on one cluster, minutes apart:
+
+   .. code-block:: text
+
+      ingress-test.sh (ids taken from the raster)   455 of 455  (100%)
+      a browser playing a round (real board ids)      4 of 465  (1%)
+
+   Both runs are green, both return five finite scores, and one of them is a game that
+   ignored 99% of what the player did. Neither number was surfaced anywhere until
+   2026-07-31 — ``tools/R/coverage.R`` logged it and nothing read the log.
+
+   Both now report it. ``ingress-test.sh`` fails if the reporter is not wired in at all —
+   nothing else there would notice its removal — and says in the output that its own
+   percentage is circular. :file:`v2/e2e-cluster` prints the honest figure, since the
+   browser sends the ids the board actually uses.
    See :ref:`allocation-id-space`.
 
 The loading spinner does not clear when a level fails to build — *fixed 2026-07-31*

--- a/v2/e2e-cluster/browser-round.spec.ts
+++ b/v2/e2e-cluster/browser-round.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
+import { execFileSync } from 'node:child_process';
 
 // A real browser playing real rounds against the live cluster.
 //
@@ -67,6 +68,34 @@ async function placeAndSubmit(page: Page, count: number, offset = 0) {
 	await page.locator('button.btn-next').click();
 }
 
+/**
+ * How much of the allocation the calculator could actually use, from its own log.
+ *
+ * This is the honest version of a number ingress-test.sh also reports. That script builds its
+ * payload from ids it reads out of the deployed raster, so it matches by construction and says
+ * ~100% however wrong the raster is. The browser sends the ids the BOARD uses, which is the
+ * comparison that means something — and on the raster committed to this repository the two
+ * differ enormously: 100% there, 1% here.
+ *
+ * Returns null when kubectl is unavailable, so the spec still runs without it.
+ */
+function allocationCoverage(): { line: string, percent: number } | null {
+	let logs: string;
+	try {
+		logs = execFileSync('kubectl',
+			['--context', process.env.KIND_CONTEXT ?? 'kind-esgame',
+				'logs', 'deploy/esgame-calculation', '--tail=400'],
+			{ encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+	} catch {
+		return null;
+	}
+	const lines = logs.split('\n').filter(l => l.includes('Allocation coverage:'));
+	if (!lines.length) return null;
+	const line = lines[lines.length - 1];
+	const m = /\((\d+)%\)/.exec(line);
+	return { line, percent: m ? Number(m[1]) : NaN };
+}
+
 /** The coverage each WCS URL asks for — this is what changes between rounds. */
 function coverageIds(urls: string[]): string[] {
 	return urls.map(u => new URL(u).searchParams.get('coverageId') ?? u);
@@ -101,6 +130,23 @@ test('a browser plays a round end to end against the cluster', async ({ page }) 
 	const rows = await page.locator('tro-score-board table tr').count();
 	console.log(`  score board rows: ${rows}`);
 	expect(rows).toBeGreaterThan(1);
+
+	// How much of what the browser sent the calculator could use. Everything above passes on a
+	// round that ignored the allocation entirely — five finite scores come back either way.
+	const coverage = allocationCoverage();
+	if (coverage) {
+		console.log(`  ${coverage.line.trim()}`);
+		if (coverage.percent < 50) {
+			console.log(`  !! only ${coverage.percent}% of what the browser allocated was used, so`);
+			console.log(`  !! those scores barely depend on it. Expected with the raster committed`);
+			console.log(`  !! here; a deployment supplies the data-release one.`);
+		}
+		// The reporter must be running. Nothing else in this file would notice if it were not,
+		// and it is the only signal that a round was inert.
+		expect(Number.isNaN(coverage.percent)).toBe(false);
+	} else {
+		console.log('  (allocation coverage unavailable — kubectl not on PATH, or no log line)');
+	}
 
 	expect(t.errors).toEqual([]);
 });


### PR DESCRIPTION
`tools/R/coverage.R` has detected an inert round since it was written. **Nothing ever read its output.** So `ingress-test.sh` printed:

```
ingress round-trip: PASS   (455 ids, 5 scores, 5/5 coverages)
```

…over a game that ignored 99% of what was allocated — because five finite scores come back either way.

## Running it turned up something better than the reporting gap

The synthetic allocation was not merely *"not real play"*. **It was hiding this.** `ingress-test.sh` builds its payload from ids it reads out of the deployed raster, so it matches by construction. On one cluster, minutes apart:

| harness | coverage |
|---|---|
| `ingress-test.sh` — ids taken from the raster | **455 of 455 (100%)** |
| a browser playing a round — real board ids | **4 of 465 (1%)** |

Both green. Both five finite scores. One of them is a game that ignored 99% of the player's input.

## So

- `ingress-test.sh` now says **in its own output** that its percentage is circular, and points at `v2/e2e-cluster` for the honest one. What it *does* prove is that the reporter runs at all — worth a check, since removing the `source()` of `coverage.R` leaves every other assertion in that script passing.
- The browser spec prints the real figure:

```
  allocation sent by the browser: 465 hexagons
  INFO [...] Allocation coverage: 4 of 465 ids exist in LU_and_NEW_hexa.tif (1%).
  !! only 1% of what the browser allocated was used, so
  !! those scores barely depend on it. Expected with the raster committed
  !! here; a deployment supplies the data-release one.
```

It does **not** fail on a low number — 1% is correct and expected for the raster committed here, which exists to exercise the plumbing. It just can no longer be mistaken for a working model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE