### PR TITLE
fix(ui): a production type with no suitability map no longer empties the palette

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -29,7 +29,7 @@ Verified working
    * - Path
      - How it was checked
    * - Static / grid game
-     - 293 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
+     - 296 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
        SEO 100. The board renders 2,436 fields; the e2e suite asserts that rather than
        just asserting the component mounted.
    * - No external runtime deps

--- a/v2/src/app/services/game.service.bad-references.spec.ts
+++ b/v2/src/app/services/game.service.bad-references.spec.ts
@@ -27,6 +27,10 @@ const settingsWith = (consequenceProductionTypes: number[]) => ({
 	maps: [
 		{ id: '-3', gameBoardType: 'Drawing', urlToData: 'drawing.tif', productionTypes: [] },
 		{ id: '-2', gameBoardType: 'Background', urlToData: 'bg.tif', customColorId: 'cc', productionTypes: [] },
+		// Every production type is listed by a Suitability map — that is the board it is drawn
+		// against, and src/assets/data.json holds to it for all six of its types. Without this
+		// the fixture describes a data.json that cannot exist.
+		{ id: 's1', gameBoardType: 'Suitability', urlToData: 's1.tif', productionTypes: [1] },
 		{ id: '11', gameBoardType: 'Consequence', urlToData: 'c11.tif', productionTypes: consequenceProductionTypes },
 	],
 });

--- a/v2/src/app/services/game.service.production-type-maps.spec.ts
+++ b/v2/src/app/services/game.service.production-type-maps.spec.ts
@@ -1,0 +1,71 @@
+import { firstValueFrom, of } from 'rxjs';
+import { GameService } from './game.service';
+
+// Each production type is drawn against the suitability map that lists its id. Which map that is
+// came from a doubly-asserted lookup, so a production type no map lists was a crash — inside a
+// subscribe, where rxjs rethrows asynchronously. Nothing caught it, the caller saw no error, and
+// the loop stopped where it was: that production type and EVERY ONE AFTER IT vanished from the
+// palette, with a working-looking board.
+
+const translateStub: any = { getLangs: () => [], setTranslation: () => { } };
+const scoreStub: any = { createEmptyScoreEntry: () => [], calculateScore: () => { } };
+const tiffStub: any = {
+	getOverlayGameBoard: (id: any, u: string, t: any) => of({ id, gameBoardType: t, urlToData: u, fields: [] }),
+	getSvgBackground: () => of('data:'),
+	getSvgGameBoard: (id: any, u: string, t: any) => of({ id, gameBoardType: t, urlToData: u, fields: [] }),
+};
+
+const settings = (suitabilityMaps: { id: string, productionTypes: number[] }[]) => ({
+	title: { en: 'T' }, mapMode: 'svg', elementSize: 1, gameBoardColumns: 4, gameBoardRows: 4,
+	productionTypes: [1, 2, 3].map(id => ({
+		id, name: { en: `pt${id}` }, fieldColor: '#ff0000', urlToIcon: '', maxElements: 0
+	})),
+	customColors: [{ id: 'cc', colors: [{ number: 0, color: '#000000' }] }],
+	maps: [
+		{ id: '-3', gameBoardType: 'Drawing', urlToData: 'd.tif', productionTypes: [] },
+		{ id: '-2', gameBoardType: 'Background', urlToData: 'b.tif', customColorId: 'cc', productionTypes: [] },
+		...suitabilityMaps.map(m => ({ ...m, gameBoardType: 'Suitability', urlToData: `${m.id}.tif` })),
+	],
+});
+
+describe('GameService production types without a suitability map', () => {
+	let errors: string[];
+	beforeEach(() => {
+		errors = [];
+		vi.spyOn(window, 'alert').mockImplementation(() => { });
+		vi.spyOn(console, 'error').mockImplementation((...a: any[]) => { errors.push(a.map(String).join(' ')); });
+	});
+	afterEach(() => vi.restoreAllMocks());
+
+	const start = (maps: { id: string, productionTypes: number[] }[]) => {
+		const service = new GameService(tiffStub, scoreStub, translateStub, {} as any);
+		service.loadSettings(JSON.parse(JSON.stringify(settings(maps))));
+		service.initialiseSVGMode();
+		return service;
+	};
+
+	// The control: with every id covered, all three must appear. Everything below is the
+	// difference the missing map makes, not the harness dropping types on its own.
+	it('creates every production type when each is listed by a map', async () => {
+		const service = start([{ id: 's1', productionTypes: [1, 2, 3] }]);
+
+		expect((await firstValueFrom(service.productionTypesObs)).map(p => p.id)).toEqual([1, 2, 3]);
+		expect(errors).toEqual([]);
+	});
+
+	// The regression. Type 2 is listed by nothing; 1 and 3 are fine. Before the fix the loop
+	// stopped at 2 and 3 was lost with it.
+	it('keeps the production types that do have a map', async () => {
+		const service = start([{ id: 's1', productionTypes: [1] }, { id: 's3', productionTypes: [3] }]);
+
+		expect((await firstValueFrom(service.productionTypesObs)).map(p => p.id)).toEqual([1, 3]);
+	});
+
+	it('says which production type was left out, and why', async () => {
+		const service = start([{ id: 's1', productionTypes: [1] }, { id: 's3', productionTypes: [3] }]);
+		await firstValueFrom(service.productionTypesObs);
+
+		expect(errors.join(' ')).toContain('Production type 2');
+		expect(errors.join(' ')).toContain('SuitabilityMap');
+	});
+});

--- a/v2/src/app/services/game.service.ts
+++ b/v2/src/app/services/game.service.ts
@@ -345,9 +345,27 @@ export class GameService {
 				o.background2 = background;
 			});
 
+			// Each production type is shown against the suitability map that lists it, found by a
+			// doubly-asserted lookup:
+			//
+			//   gameBoards.find(g => g.id == otherMaps.find(m => m.productionTypes.includes(current.id))!.id)!
+			//
+			// A production type that NO suitability map lists — an ordinary data.json mistake —
+			// made the inner find() undefined and reading `.id` threw. This runs inside a
+			// subscribe, so rxjs rethrows asynchronously: nothing here caught it, the caller saw
+			// no error, and the loop simply stopped. The palette silently lost that production
+			// type AND every one after it. Measured: 1 of 2 created, plus an unhandled error.
 			for (let i = 0; i < settings.productionTypes.length; i++) {
 				const current = settings.productionTypes[i];
-				const gameBoard = gameBoards.find(g => g.id == otherMaps.find(m => m.productionTypes.includes(current.id))!.id)!;
+				const mapForType = otherMaps.find(m => m.productionTypes.includes(current.id));
+				const gameBoard = mapForType && gameBoards.find(g => g.id == mapForType.id);
+				if (!gameBoard) {
+					console.error(
+						`Production type ${current.id} is not listed by any ${GameBoardType[GameBoardType.SuitabilityMap]}, ` +
+						`so it has no board to be shown against and is being left out of the game. ` +
+						`Add its id to a map's "productionTypes" in the game data.`);
+					continue;   // keep going: one bad entry must not take the rest of the palette with it
+				}
 				const productionType = new ProductionType(current.id, current.fieldColor, gameBoard, current.urlToIcon, current.maxElements);
 				this.productionTypes.value.push(productionType);
 			}


### PR DESCRIPTION
Each production type is drawn against the suitability map that lists its id, found by a doubly-asserted lookup:

```ts
gameBoards.find(g => g.id == otherMaps.find(m => m.productionTypes.includes(current.id))!.id)!
```

A production type that **no** suitability map lists made the inner `find()` undefined, and reading `.id` threw.

This runs inside a `subscribe`, where rxjs rethrows **asynchronously**. So nothing caught it, the caller saw no error, and the loop stopped where it was — that production type *and every one after it* disappeared from the palette, on a board that otherwise looked fine.

## Measured, and that mattered here

A synchronous try/catch around `initialiseSVGMode` reports:

```
no sync throw | created 1 of 2
```

Only the second half of that is visible to a player, and it's the half a try/catch can't see. Had I stopped at "it doesn't throw" I'd have concluded there was no bug.

Now it names the production type and carries on, so one bad entry costs one entry.

## An existing test broke, and I checked which side was wrong

Its fixture had a production type listed only by a *consequence* map. Rather than adjust the guard to suit the fixture, I checked `src/assets/data.json`:

```
productionTypes: ['10','20','30','40','60','50']
covered by a Suitability map: ['10','20','30','40','50','60']   missing: []
```

All six. The contract is real and the fixture described a `data.json` that cannot exist — so the fixture was corrected.

## Verified

Mutation with the double assertion restored: both regressions fail, the all-types-covered control passes.

296 unit, 12 e2e, both browser rounds against the live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE