### PR TITLE
fix(ui): the grid game's level building has the same id guards as navigation

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -29,7 +29,7 @@ Verified working
    * - Path
      - How it was checked
    * - Static / grid game
-     - 296 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
+     - 298 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
        SEO 100. The board renders 2,436 fields; the e2e suite asserts that rather than
        just asserting the component mounted.
    * - No external runtime deps

--- a/v2/src/app/services/game.service.bad-references.spec.ts
+++ b/v2/src/app/services/game.service.bad-references.spec.ts
@@ -109,3 +109,57 @@ describe('GameService with a map referencing an unknown production type', () => 
 		expect(errors.join(' ')).toContain('no map with id "11"');
 	});
 });
+
+// The grid game builds its levels through a different branch of prepareNextLevel, with the same
+// two unchecked lookups — and there they run while the level is being BUILT, inside a subscribe.
+// An unresolved id aborted the loop and rxjs rethrew it asynchronously, so the boards after it
+// were never attached to any production type and nothing said why.
+describe('GameService grid levels with unresolvable ids', () => {
+	let errors: string[];
+	beforeEach(() => {
+		errors = [];
+		vi.spyOn(window, 'alert').mockImplementation(() => { });
+		vi.spyOn(console, 'error').mockImplementation((...a: any[]) => { errors.push(a.map(String).join(' ')); });
+	});
+	afterEach(() => vi.restoreAllMocks());
+
+	const gridSettings = (consequenceProductionTypes: number[]) => ({
+		title: { en: 'T' }, mapMode: 'grid', elementSize: 1,
+		gameBoardColumns: 2, gameBoardRows: 2, infiniteLevels: true,
+		productionTypes: [{ id: 1, name: { en: 'A' }, fieldColor: '#f00', urlToIcon: '', maxElements: 0 }],
+		customColors: [{ id: 'cc', colors: [{ number: 0, color: '#000000' }] }],
+		maps: [
+			{ id: 's1', gameBoardType: 'Suitability', urlToData: 's1.tif', productionTypes: [1] },
+			{ id: 'c1', gameBoardType: 'Consequence', urlToData: 'c1.tif', productionTypes: consequenceProductionTypes },
+		],
+	});
+
+	const gridTiff: any = {
+		getGridGameBoard: (id: any, u: string, t: any) => of({ id, gameBoardType: t, urlToData: u, fields: [] }),
+		getOverlayGameBoard: (id: any, u: string, t: any) => of({ id, gameBoardType: t, urlToData: u, fields: [] }),
+		getSvgBackground: () => of('data:'),
+		getSvgGameBoard: (id: any, u: string, t: any) => of({ id, gameBoardType: t, urlToData: u, fields: [] }),
+	};
+
+	const gridService = (ptIds: number[]) => {
+		const service = new GameService(gridTiff, scoreStub, translateStub, {} as any);
+		service.loadSettings(JSON.parse(JSON.stringify(gridSettings(ptIds))));
+		service.initialiseGridMode();
+		return service;
+	};
+
+	it('builds a grid level normally when the ids resolve', () => {
+		const service = gridService([1]);
+
+		service.prepareNextLevel();
+
+		expect(errors).toEqual([]);
+	});
+
+	it('does not abort the level when a consequence map lists an unknown production type', () => {
+		const service = gridService([99]);
+
+		expect(() => service.prepareNextLevel()).not.toThrow();
+		expect(errors.join(' ')).toContain('99');
+	});
+});

--- a/v2/src/app/services/game.service.ts
+++ b/v2/src/app/services/game.service.ts
@@ -173,25 +173,38 @@ export class GameService {
 	private rebuildConsequenceMaps(level: Level, productionTypes: ProductionType[]) {
 		productionTypes.forEach(pt => { pt.consequenceMaps = []; });
 
-		level.gameBoards.filter(c => c.gameBoardType == GameBoardType.ConsequenceMap).forEach(map => {
-			const mapSettings = this.settings.value.maps.find(c => c.id == map.id);
-			if (!mapSettings) {
+		level.gameBoards
+			.filter(c => c.gameBoardType == GameBoardType.ConsequenceMap)
+			.forEach(map => this.attachConsequenceMap(map, productionTypes, level.levelNumber));
+	}
+
+	/**
+	 * Attach one consequence board to every production type the game data says shows it.
+	 *
+	 * Both ids are deployment-supplied and neither used to be checked; see
+	 * rebuildConsequenceMaps above for what that cost. An unresolved id means one board is
+	 * missing from one production type's list, which is worth reporting and not worth taking the
+	 * rest of the level down for — so this returns rather than throws.
+	 */
+	private attachConsequenceMap(map: GameBoard, productionTypes = this.productionTypes.value, levelNumber?: number) {
+		const mapSettings = this.settings.value.maps.find(c => c.id == map.id);
+		if (!mapSettings) {
+			console.error(
+				`The game data has no map with id "${map.id}", but ` +
+				`${levelNumber === undefined ? 'a level' : `level ${levelNumber}`} is showing a ` +
+				`consequence board with that id. Its production types cannot be resolved; the ` +
+				`board will not appear under any of them.`);
+			return;
+		}
+		mapSettings.productionTypes.forEach(ptId => {
+			const pt = productionTypes.find(c => c.id == ptId);
+			if (!pt) {
 				console.error(
-					`The game data has no map with id "${map.id}", but level ${level.levelNumber} ` +
-					`is showing a consequence board with that id. Its production types cannot be ` +
-					`resolved; the board will not appear under any of them.`);
+					`Map "${map.id}" lists production type ${ptId}, which the game data does ` +
+					`not define. Known ids: [${productionTypes.map(p => p.id).join(', ') || 'none'}].`);
 				return;
 			}
-			mapSettings.productionTypes.forEach(ptId => {
-				const pt = productionTypes.find(c => c.id == ptId);
-				if (!pt) {
-					console.error(
-						`Map "${map.id}" lists production type ${ptId}, which the game data does ` +
-						`not define. Known ids: [${productionTypes.map(p => p.id).join(', ') || 'none'}].`);
-					return;
-				}
-				pt.consequenceMaps.push(map);
-			});
+			pt.consequenceMaps.push(map);
 		});
 	}
 
@@ -235,13 +248,12 @@ export class GameService {
 
 			combineLatest(maps.map(m => this.getGridGameBoard(m))).subscribe((gameBoards) => {
 				level.gameBoards.push(...gameBoards);
-				gameBoards.forEach(c => {
-					let map = settings.maps.find(o => o.id == c.id);
-					map!.productionTypes.forEach(p => {
-						let productionType = this.productionTypes.value.find(o => o.id == p);
-						productionType!.consequenceMaps.push(c);
-					});
-				});
+				// Same two lookups, and the same lie, as the level-navigation path — both ids
+				// come out of the deployment's data.json and neither is checked. This one runs
+				// while BUILDING the level, inside a subscribe, so an unresolved id aborts the
+				// loop and rxjs rethrows asynchronously: the remaining boards never get attached
+				// to any production type and nothing reports why.
+				gameBoards.forEach(c => this.attachConsequenceMap(c));
 
 				this.selectedFields.value.forEach(o => o.updateScore());
 


### PR DESCRIPTION
Follow-on to #140, which guarded the level-*navigation* path. `prepareNextLevel`'s GRID branch carried the identical two unchecked lookups:

```ts
let map = settings.maps.find(o => o.id == c.id);
map!.productionTypes.forEach(p => {
    let productionType = this.productionTypes.value.find(o => o.id == p);
    productionType!.consequenceMaps.push(c);
});
```

Both ids come from the deployment's `data.json`. Here they run while the level is being **built**, inside a `subscribe` — so an unresolved id aborted the loop and rxjs rethrew asynchronously: every board after it was never attached to any production type, and nothing said why.

The per-board half of `rebuildConsequenceMaps` is now shared, so the grid and SVG paths report the same thing instead of one of them reporting nothing. The reporting itself was written and tested in #140; only this caller was still bypassing it.

## Verified on this path specifically

The suite passing at 296 proved only that I hadn't broken anything — it didn't show the grid branch was reached at all. So there are two new specs driving `initialiseGridMode` → `prepareNextLevel`, and a mutation restoring the asserted lookups:

| | |
|---|---|
| ids resolve (control) | passes throughout |
| unknown production type id | **fails** without the guard, passes with it |

298 unit, 12 e2e, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE