### PR TITLE
test(k8s): record which image build was actually under test

### DIFF
--- a/deploy/k8s/ingress-test.sh
+++ b/deploy/k8s/ingress-test.sh
@@ -213,6 +213,28 @@ elif [ -n "${pct}" ]; then
   echo "      for the figure a real browser produces, which on this data is 1%.)"
 fi
 
+echo "==> what was actually under test"
+# A green run says nothing about WHICH build was green. Both images roll on :master, so a pod
+# that started before the last publish keeps serving the old one — `kubectl apply` sees no change
+# in a rolling tag and does nothing. That happened during this script's own development: the
+# cluster served a frontend image seven merges old while every check here passed.
+#
+# kind.sh deploy does `rollout restart`, which re-pulls under imagePullPolicy: Always. This just
+# records the result, so the output says what it tested rather than leaving it to be assumed.
+for d in esgame-angular esgame-calculation; do
+  app=$("${K[@]}" get deploy "${d}" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)
+  running=$("${K[@]}" get pod -l "app=${d}" -o jsonpath='{.items[0].status.containerStatuses[0].imageID}' 2>/dev/null || true)
+  echo "     ${d}"
+  echo "       spec:    ${app:-<unknown>}"
+  echo "       running: ${running:-<unknown>}"
+done
+# Presence, not a comparison: the digest a rolling tag resolves to is only knowable by pulling,
+# which this script should not do. Asserting it is non-empty keeps the record honest — an empty
+# line here would mean the pod is not reporting an image at all.
+digests=$("${K[@]}" get pod -l 'app in (esgame-angular,esgame-calculation)' \
+  -o jsonpath='{range .items[*]}{.status.containerStatuses[0].imageID}{"\n"}{end}' 2>/dev/null | grep -c '@sha256:' || true)
+check "both pods report an image digest"    "[ '${digests}' = '2' ]"
+
 echo
 if [ "${fail}" = 0 ]; then
   echo "ingress round-trip: PASS   (${n} ids, ${scored} scores, ${ok}/${tot} coverages, all via http://localhost:${PORT})${inert:-}"

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -176,6 +176,15 @@ None of these are defects to fix here — they are things a deployment must supp
    both referenced an image that existed nowhere and the calculation pod was a permanent
    ``ErrImagePull`` — which is why every local test had to stand up its own registry first.
 
+   **A green cluster run does not say which build was green.** Both images roll on ``:master``,
+   so a pod started before the last publish keeps serving the old one — ``kubectl apply`` sees
+   no change in a rolling tag and does nothing. That happened here: for several hours the
+   cluster served a frontend image seven merges old while every check passed, because the pod
+   had been started before those merges. ``kind.sh deploy`` does ``rollout restart``, which
+   re-pulls under ``imagePullPolicy: Always``, and re-deploying moved the running digest from
+   ``45f92893`` to ``e1fd8573``. :file:`ingress-test.sh` now prints the spec image and the
+   running **digest** for both deployments, so its output records what it tested.
+
    Verified as a cluster uses it, not only as CI built it: pulled anonymously from ghcr, then
    deployed to the kind cluster through the new ``overlays/published`` and put through a full
    round — 16/16 in ``ingress-test.sh`` and both browser specs in ``v2/e2e-cluster`` (465


### PR DESCRIPTION
A green cluster run said nothing about **which build** was green. Both images roll on `:master`, so a pod started before the last publish keeps serving the old one — `kubectl apply` sees no change in a rolling tag and does nothing.

## This happened while doing this work

The cluster served a frontend image **seven merges old** for several hours, while `ingress-test.sh` and both browser specs passed against it. The pod predated those merges. Found by comparing the running pod's `imageID` against what ghcr had just published:

```
running:   ...@sha256:45f92893b213add1ec3cbb0902a239ae75a646b25361712ae99ec0a2d831fbd5
published: ...@sha256:e1fd8573e7d6a1fbac91c71f523a2c94ae8a4b673948a6ccfc749a29562b3940
```

The tooling was already right — `kind.sh deploy` does `rollout restart`, which re-pulls under `imagePullPolicy: Always`. Re-deploying moved the digest and every check passed again on the current image. What was missing is that **nothing said which image it was**.

## Now

```
==> what was actually under test
     esgame-angular
       spec:    ghcr.io/mlacayoemery/esgame:master
       running: ghcr.io/mlacayoemery/esgame@sha256:e1fd8573...
     esgame-calculation
       spec:    ghcr.io/mlacayoemery/esgame-calculation:master
       running: ghcr.io/mlacayoemery/esgame-calculation@sha256:73ba10bd...
  ok   both pods report an image digest
```

The assertion is a **presence** check, deliberately not a comparison: what digest a rolling tag resolves to is only knowable by pulling, which this script shouldn't do.

| state | result |
|---|---|
| both pods | digests=2 → PASS |
| one pod matched | digests=1 → FAIL |
| selector matching nothing | digests=0 → FAIL |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE