### PR TITLE
fix(ui): Settings names the data.json field that is missing

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -29,7 +29,7 @@ Verified working
    * - Path
      - How it was checked
    * - Static / grid game
-     - 298 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
+     - 308 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
        SEO 100. The board renders 2,436 fields; the e2e suite asserts that rather than
        just asserting the component mounted.
    * - No external runtime deps

--- a/v2/src/app/shared/models/settings.data-errors.spec.ts
+++ b/v2/src/app/shared/models/settings.data-errors.spec.ts
@@ -1,0 +1,86 @@
+import { Settings } from './settings';
+
+// Every deployment writes its own data.json by hand, so a field being absent is an ordinary
+// mistake. What it used to produce was "Cannot read properties of undefined (reading 'map')" —
+// which names neither the field nor the file, and is identical for six different omissions.
+
+const translateStub = (langs: string[] = ['en']): any => ({
+	getLangs: () => langs,
+	setTranslation: () => { },
+});
+
+const full = () => ({
+	title: { en: 'T' }, mapMode: 'svg', elementSize: 1, gameBoardColumns: 4, gameBoardRows: 4,
+	basicInstructions: { en: 'b' }, advancedInstructions: { en: 'a' },
+	productionTypes: [{ id: 1, name: { en: 'A' }, fieldColor: '#f00', urlToIcon: '', maxElements: 0 }],
+	customColors: [],
+	maps: [{ id: 'm', name: { en: 'M' }, gameBoardType: 'Suitability', urlToData: 'x.tif', productionTypes: [1] }],
+});
+
+const without = (path: string) => {
+	const d: any = full();
+	if (path === 'maps[0].productionTypes') delete d.maps[0].productionTypes;
+	else delete d[path];
+	return d;
+};
+
+describe('Settings with a required field missing', () => {
+	// The control. Everything below has to be the difference the omission makes.
+	it('accepts a complete data file', () => {
+		expect(() => new Settings(translateStub(), full())).not.toThrow();
+	});
+
+	for (const [field, expected] of [
+		['productionTypes', 'productionTypes'],
+		['maps', 'maps'],
+		['maps[0].productionTypes', 'maps[0] (id "m").productionTypes'],
+	] as const) {
+		it(`names ${field}`, () => {
+			expect(() => new Settings(translateStub(), without(field)))
+				.toThrowError(new RegExp(expected.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+		});
+	}
+
+	it('reports every missing field at once, not just the first', () => {
+		const d: any = full();
+		delete d.productionTypes;
+		delete d.maps;
+
+		expect(() => new Settings(translateStub(), d)).toThrowError(/productionTypes.*maps|maps.*productionTypes/s);
+	});
+});
+
+// Missing TEXT is a different matter: a label with no translation is a blank label, not a dead
+// game. These used to take the whole app down with the same opaque message.
+describe('Settings with missing text', () => {
+	let errors: string[];
+	beforeEach(() => {
+		errors = [];
+		vi.spyOn(console, 'error').mockImplementation((...a: any[]) => { errors.push(a.map(String).join(' ')); });
+	});
+	afterEach(() => vi.restoreAllMocks());
+
+	for (const field of ['title', 'basicInstructions', 'advancedInstructions']) {
+		it(`renders without ${field} and says the label is blank`, () => {
+			const d: any = full();
+			delete d[field];
+
+			expect(() => new Settings(translateStub(), d)).not.toThrow();
+			expect(errors.join(' ')).toContain(field);
+		});
+	}
+
+	it('names a map whose own name is missing', () => {
+		const d: any = full();
+		delete d.maps[0].name;
+
+		expect(() => new Settings(translateStub(), d)).not.toThrow();
+		expect(errors.join(' ')).toContain('maps["m"].name');
+	});
+
+	it('says nothing when every label is present', () => {
+		new Settings(translateStub(), full());
+
+		expect(errors).toEqual([]);
+	});
+});

--- a/v2/src/app/shared/models/settings.ts
+++ b/v2/src/app/shared/models/settings.ts
@@ -54,8 +54,43 @@ export class Settings {
 		this.mapData(data);
 	}
 
+	/**
+	 * Fields this class dereferences, and therefore cannot do without.
+	 *
+	 * Omitting any of them used to give "Cannot read properties of undefined (reading 'map')" —
+	 * which names neither the field nor the file, and a deployment writes this file by hand. They
+	 * are collected and reported together rather than one per attempt, because a data.json being
+	 * written from scratch is usually missing more than one.
+	 *
+	 * `visualOptions` and `gradientOverrides` are deliberately absent: they already default via
+	 * `?? {}` just below, and are genuinely optional.
+	 */
+	private static missingRequired(data: any): string[] {
+		const missing: string[] = [];
+		const isArray = (v: any) => Array.isArray(v);
+		if (!isArray(data.productionTypes)) missing.push('productionTypes (an array)');
+		if (!isArray(data.maps)) missing.push('maps (an array)');
+		if (isArray(data.maps)) {
+			data.maps.forEach((m: any, i: number) => {
+				if (!isArray(m?.productionTypes)) {
+					missing.push(`maps[${i}]${m?.id ? ` (id "${m.id}")` : ''}.productionTypes (an array)`);
+				}
+			});
+		}
+		return missing;
+	}
+
 	mapData(data: any) {
 		if (!data) return;
+
+		const missing = Settings.missingRequired(data);
+		if (missing.length) {
+			throw new Error(
+				`The game data is missing ${missing.length === 1 ? 'a required field' : 'required fields'}: ` +
+				`${missing.join(', ')}. Every deployment supplies its own data file, so this is a ` +
+				`problem with that file rather than with the game.`);
+		}
+
 		this.elementSize = data.elementSize;
 		this.gameBoardColumns = data.gameBoardColumns;
 		this.gameBoardRows = data.gameBoardRows;
@@ -81,23 +116,39 @@ export class Settings {
 		this.visualOptions = { ...DEFAULT_VISUAL_OPTIONS, ...(data.visualOptions ?? {}) };
 		applyGradientOverrides(data.gradientOverrides ?? {});
 
-		this.translate.getLangs().forEach((lang) => {
+		// Every one of these was an unguarded index into an object the data file may not have,
+		// so a data.json with no `title` — or a map with no `name` — took the whole game down
+		// with "Cannot read properties of undefined (reading 'en')". A missing label is a missing
+		// label: report it and render the rest.
+		const langs = this.translate.getLangs();
+		const missingText: string[] = [];
+		const text = (obj: any, lang: string, what: string) => {
+			const v = obj?.[lang];
+			if (v === undefined) missingText.push(`${what} (${lang})`);
+			return v;
+		};
+		langs.forEach((lang) => {
 			this.maps.forEach(o => {
 				let translation = {} as any;
-				translation["map_name_" + o.id] = o.name[lang];
+				translation["map_name_" + o.id] = text(o.name, lang, `maps["${o.id}"].name`);
 				this.translate.setTranslation(lang, translation, true);
 			});
 			this.productionTypes.forEach(o => {
 				let translation = {} as any;
-				translation["production_type_" + o.id] = o.name[lang];
+				translation["production_type_" + o.id] = text(o.name, lang, `productionTypes[${o.id}].name`);
 				this.translate.setTranslation(lang, translation, true);
 			});
 			let translation = {} as any;
-			translation["basic_instructions"] = this.basicInstructions[lang];
-			translation["advanced_instructions"] = this.advancedInstructions[lang];
-			translation["title"] = data.title[lang];
+			translation["basic_instructions"] = text(this.basicInstructions, lang, 'basicInstructions');
+			translation["advanced_instructions"] = text(this.advancedInstructions, lang, 'advancedInstructions');
+			translation["title"] = text(data.title, lang, 'title');
 			this.translate.setTranslation(lang, translation, true);
 		});
+		if (missingText.length) {
+			console.error(
+				`The game data has no text for: ${missingText.join(', ')}. ` +
+				`Those labels will be blank.`);
+		}
 	}
 }
 


### PR DESCRIPTION
Every deployment writes its own `data.json` by hand, so an absent field is an ordinary mistake. `Settings` dereferenced six of them unguarded, and **all six produced the same message**:

```
productionTypes          Cannot read properties of undefined (reading 'map')
maps                     Cannot read properties of undefined (reading 'map')
maps[i].productionTypes  Cannot read properties of undefined (reading 'map')
title                    Cannot read properties of undefined (reading 'en')
basicInstructions        Cannot read properties of undefined (reading 'en')
advancedInstructions     Cannot read properties of undefined (reading 'en')
customColors             built ok
```

Measured by deleting each in turn, not read off the source — that last row is only visible by trying it.

## The two kinds are treated differently, because they are different

**A missing array is fatal.** Nothing can be built, so it throws — and reports every missing field at once rather than one per attempt, because a data file written from scratch is usually missing more than one:

```
The game data is missing required fields: productionTypes (an array), maps (an array).
Every deployment supplies its own data file, so this is a problem with that file rather
than with the game.
```

**A missing label is a blank label, not a dead game.** Those are logged and the rest renders:

```
The game data has no text for: maps["m"].name (en), title (en). Those labels will be blank.
```

## Smaller than it looks

The file already guarded `visualOptions` and `gradientOverrides` with `?? {}` — the awareness was there, applied unevenly.

## Verified

Ten new specs, including **two controls**: a complete file must throw nothing and log nothing. Mutation with the validation removed → all eight omission specs fail, both controls still pass.

308 unit, 12 e2e, both browser rounds against the live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE