### PR TITLE
docs: measure the cold-start path the README promises

### DIFF
--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -81,9 +81,17 @@ To exercise the whole stack — with an actual ingress controller rather than `p
 **Nothing to build.** Both images are published, so this pulls everything from ghcr:
 
 ```sh
-deploy/k8s/kind.sh up                                # cluster + ingress-nginx
-ESGAME_OVERLAY=published deploy/k8s/kind.sh deploy   # pull both images from ghcr
-deploy/k8s/ingress-test.sh                           # a real round through the ingress, by Host header
+deploy/k8s/kind.sh up                                # cluster + ingress-nginx        ~65s
+ESGAME_OVERLAY=published deploy/k8s/kind.sh deploy   # pull both images from ghcr     ~95s
+deploy/k8s/ingress-test.sh                           # a real round via Host header   ~35s
+```
+
+Measured 2026-07-31 from **no cluster and no local registry running** — the registry container
+was deliberately stopped first, so nothing local could satisfy a pull that is meant to come from
+ghcr. About three minutes from nothing to a stack serving real ingress traffic. Then, optionally:
+
+```sh
+cd v2 && npx playwright test --config e2e-cluster/browser-round.config.ts   # ~85s, two rounds
 ```
 
 That was not possible until `esgame-calculation` was published — the image existed nowhere, so

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -185,6 +185,13 @@ None of these are defects to fix here — they are things a deployment must supp
    ``45f92893`` to ``e1fd8573``. :file:`ingress-test.sh` now prints the spec image and the
    running **digest** for both deployments, so its output records what it tested.
 
+   Verified from a **cold start**, which is the claim :file:`deploy/k8s/README.md` makes: the
+   cluster deleted and the local registry container stopped first, so nothing local could satisfy
+   a pull meant to come from ghcr. ``kind.sh up`` 65s, ``ESGAME_OVERLAY=published kind.sh deploy``
+   95s, ``ingress-test.sh`` 35s — about three minutes from nothing to a stack serving real
+   ingress traffic, followed by both browser specs in 85s. The earlier check had only ever run
+   the published overlay against an already-running cluster.
+
    Verified as a cluster uses it, not only as CI built it: pulled anonymously from ghcr, then
    deployed to the kind cluster through the new ``overlays/published`` and put through a full
    round — 16/16 in ``ingress-test.sh`` and both browser specs in ``v2/e2e-cluster`` (465


### PR DESCRIPTION
`deploy/k8s/README.md` says the whole stack comes up with nothing built (#132). That had only ever been run **against an already-running cluster**, which doesn't test the claim — the images were already pulled, and the local registry container was still up and able to satisfy a pull that's meant to come from ghcr.

Run properly: cluster deleted, registry stopped.

| step | time | result |
|---|---|---|
| `kind.sh up` | 65s | ingress reachable on :8880 |
| `ESGAME_OVERLAY=published kind.sh deploy` | 95s | 3/3 services with endpoints |
| `ingress-test.sh` | 35s | **PASS** — 455 ids, 5 scores, 5/5 coverages |
| `v2/e2e-cluster` browser rounds | 85s | **2 passed** |

About three minutes from nothing to a stack serving real ingress traffic.

The digest reporting added in #144 confirmed it pulled fresh, too — the frontend came up on `d091f913…`, newer than the `e1fd8573…` from an hour earlier, because #144 and #145 had merged in between.

Timings are now in the README so the claim is checkable rather than adjectival.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE