### PR TITLE
fix(ui): a gradient override written as "#RRGGBB" no longer produces a wrong colour

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -29,7 +29,7 @@ Verified working
    * - Path
      - How it was checked
    * - Static / grid game
-     - 323 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
+     - 327 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
        SEO 100. The board renders 2,436 fields; the e2e suite asserts that rather than
        just asserting the component mounted.
    * - No external runtime deps

--- a/v2/src/app/shared/helpers/gradients.spec.ts
+++ b/v2/src/app/shared/helpers/gradients.spec.ts
@@ -30,3 +30,55 @@ describe('applyGradientOverrides', () => {
 		expect(gradients.get('green')!.startingColor).toBe('edf8e9');
 	});
 });
+
+// calculateColor slices its colours by index and parseInt's each pair, so a stop that is not
+// six bare hex digits does not fail — it produces a colour. "#F8F27D", the form every other
+// colour in this file and in data.json's fieldColor uses, gave calculateColor(0.5) = "NaN8814":
+// only the first channel lands on the "#", and the other two read shifted pairs, so the result
+// looks plausible and is wrong.
+describe('applyGradientOverrides with colours a deployment might reasonably write', () => {
+	let errors: string[];
+	beforeEach(() => {
+		errors = [];
+		vi.spyOn(console, 'error').mockImplementation((...a: any[]) => { errors.push(a.map(String).join(' ')); });
+	});
+	afterEach(() => { vi.restoreAllMocks(); applyGradientOverrides({}); });
+
+	it('accepts a #-prefixed colour and produces the same result as the bare form', () => {
+		applyGradientOverrides({ red: { start: '#F8F27D', end: '#A80000' } });
+		const withHash = gradients.get('red')!.calculateColor(0.5);
+		const rgbWithHash = gradients.get('red')!.calculateColorRGB(0.5);
+
+		applyGradientOverrides({ red: { start: 'F8F27D', end: 'A80000' } });
+		const bare = gradients.get('red')!.calculateColor(0.5);
+
+		expect(withHash).toBe(bare);
+		expect(withHash).not.toContain('NaN');
+		expect(rgbWithHash.every(c => Number.isInteger(c))).toBe(true);
+		expect(errors).toEqual([]);
+	});
+
+	it('expands three-digit shorthand', () => {
+		applyGradientOverrides({ red: { start: '#f00', end: '#00f' } });
+
+		expect(gradients.get('red')!.startingColor).toBe('ff0000');
+		expect(gradients.get('red')!.endingColor).toBe('0000ff');
+		expect(errors).toEqual([]);
+	});
+
+	it('keeps the built-in colour and says so when the override is not a colour', () => {
+		const before = gradients.get('red')!.startingColor;
+
+		applyGradientOverrides({ red: { start: 'nonsense' } });
+
+		expect(gradients.get('red')!.startingColor).toBe(before);
+		expect(gradients.get('red')!.calculateColor(0.5)).not.toContain('NaN');
+		expect(errors.join(' ')).toContain('gradientOverrides.red.start');
+	});
+
+	it('says nothing for a valid override', () => {
+		applyGradientOverrides({ red: { start: 'AABBCC', end: '#DDEEFF' } });
+
+		expect(errors).toEqual([]);
+	});
+});

--- a/v2/src/app/shared/helpers/gradients.ts
+++ b/v2/src/app/shared/helpers/gradients.ts
@@ -50,6 +50,30 @@ export interface GradientOverride { start?: string; end?: string; }
  * Always resets to the built-in defaults first, so loading a config without overrides restores them
  * and one config's override never leaks into the next.
  */
+/**
+ * Normalise a deployment-supplied stop colour to the bare 6-hex-digit form the maths expects.
+ *
+ * calculateColor slices the string by index and parseInt's each pair, so anything else produces
+ * a colour rather than an error. "#F8F27D" — the form every other colour in this file and in
+ * data.json's fieldColor uses — gives calculateColor(0.5) = "NaN8814" and
+ * calculateColorRGB(0.5) = [null, 136, 20]: not a failure, a plausible-looking wrong colour,
+ * because only the first channel lands on the "#" while the other two read shifted pairs.
+ * Junk gives "NaNNaNNaN". Measured, both of them.
+ *
+ * Returns null for anything that is not a colour, so the caller can keep the built-in default.
+ */
+function normaliseStop(value: string, gradient: string, which: 'start' | 'end'): string | null {
+	const bare = value.trim().replace(/^#/, '');
+	if (/^[0-9a-fA-F]{6}$/.test(bare)) return bare;
+	// Three-digit shorthand is valid CSS and an easy thing to write; expand rather than reject.
+	if (/^[0-9a-fA-F]{3}$/.test(bare)) return bare.split('').map(c => c + c).join('');
+	console.error(
+		`gradientOverrides.${gradient}.${which} is ${JSON.stringify(value)}, which is not a ` +
+		`6-digit hex colour. Keeping the built-in ${gradient} ${which} colour. ` +
+		`Both "#RRGGBB" and "RRGGBB" are accepted.`);
+	return null;
+}
+
 export function applyGradientOverrides(overrides: { [name: string]: GradientOverride } = {}) {
 	defaultGradientStops.forEach((d, name) => {
 		const g = gradients.get(name);
@@ -59,8 +83,8 @@ export function applyGradientOverrides(overrides: { [name: string]: GradientOver
 		const g = gradients.get(name);
 		const o = overrides[name];
 		if (g && o) {
-			if (o.start) g.startingColor = o.start;
-			if (o.end) g.endingColor = o.end;
+			if (o.start) g.startingColor = normaliseStop(o.start, name, 'start') ?? g.startingColor;
+			if (o.end) g.endingColor = normaliseStop(o.end, name, 'end') ?? g.endingColor;
 		}
 	});
 }


### PR DESCRIPTION
`gradientOverrides` is deployment-supplied, and `calculateColor` slices its stops **by index** and `parseInt`s each pair. So a stop that isn't six bare hex digits doesn't fail — it produces a colour.

Measured:

| override | `calculateColor(0.5)` | `calculateColorRGB(0.5)` |
|---|---|---|
| `"#F8F27D"` | **`NaN8814`** | **`[null, 136, 20]`** |
| `"F8F27D"` | `d0793f` | `[208, 121, 63]` |
| `"nonsense"` | `NaNNaNNaN` | — |

The first row is the dangerous one. It's not a clean failure: only the red channel lands on the `#`, while green and blue read *shifted pairs* — so the result looks like a colour and is the wrong one.

## `#RRGGBB` is the form to expect, not an exotic mistake

Every `colors[]` entry in this same file is written that way:

```ts
gradients.set('red', new Gradient("ffc0c0", "c90000", ['#d2b188', '#fee5d9', ...]));
//                                 ^^^^^^ no hash      ^^^^^^^^ hash
```

…and so is every `fieldColor` in `data.json`. The two conventions sit six lines apart.

## Now

`"#RRGGBB"` and `"RRGGBB"` both accepted, `"#RGB"` shorthand expanded, and anything else keeps the built-in colour and names the override it rejected.

## Verified

Mutation with the normalisation bypassed → the three new failure specs fail, the valid-override control passes. The **four pre-existing gradient specs were green throughout**, which is the check that this didn't change what already worked.

327 unit, 12 e2e, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE