### PR TITLE
fix(ui): consequence-map opacity no longer breaks non-#RRGGBB field colours

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -29,7 +29,7 @@ Verified working
    * - Path
      - How it was checked
    * - Static / grid game
-     - 327 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
+     - 333 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
        SEO 100. The board renders 2,436 fields; the e2e suite asserts that rather than
        just asserting the component mounted.
    * - No external runtime deps

--- a/v2/src/app/field/svg-field/svg-field.component.spec.ts
+++ b/v2/src/app/field/svg-field/svg-field.component.spec.ts
@@ -251,3 +251,49 @@ describe('SvgFieldComponent subscription lifetime', () => {
 		expect(observers()).toBe(before);
 	});
 });
+
+// hasOpacity renders a placed field semi-transparently on a consequence map. The colour came
+// from `fieldColor + '7D'`, which only works for exactly #RRGGBB — and this repository's own
+// data files use two of the forms it breaks. An invalid CSS colour is not an error: the browser
+// drops the declaration and the field renders with no fill at all.
+describe('SvgFieldComponent consequence-map opacity', () => {
+	// A real browser is the authority on which hex forms are valid, so this asserts against the
+	// same jsdom CSS parser the app runs against rather than against my reading of the spec.
+	const acceptedByCss = (value: string) => {
+		const el = document.createElement('div');
+		el.style.fill = '';
+		el.style.fill = value;
+		return el.style.fill !== '';
+	};
+
+	const place = (fieldColor: string, hasOpacity: boolean) => {
+		const { c } = build();
+		c.hasOpacity = hasOpacity;
+		c.field = { id: 1, editable: true, assigned: false } as any;
+		c.clickable = true;
+		c.setColor({ id: 1, fieldColor } as any);
+		return c.fillColor;
+	};
+
+	// Every form that appears in src/assets/data.json or dataGridExample.json.
+	for (const fieldColor of ['#40916c', '#FFF', '#b2b2b2c0', '#f0f']) {
+		it(`produces a colour a browser accepts for ${fieldColor}`, () => {
+			const withAlpha = place(fieldColor, true);
+
+			expect(acceptedByCss(withAlpha)).toBe(true);
+			// ...and it must actually be translucent, not merely valid.
+			const el = document.createElement('div');
+			el.style.fill = withAlpha;
+			expect(el.style.fill).toContain('rgba');
+		});
+	}
+
+	it('leaves the colour alone when opacity is off', () => {
+		expect(place('#40916c', false)).toBe('#40916c');
+	});
+
+	it('does not mangle a colour that is not hex', () => {
+		// Named colours and rgb() are valid CSS a deployment may legitimately use.
+		expect(place('rebeccapurple', true)).toBe('rebeccapurple');
+	});
+});

--- a/v2/src/app/field/svg-field/svg-field.component.ts
+++ b/v2/src/app/field/svg-field/svg-field.component.ts
@@ -39,10 +39,38 @@ export class SvgFieldComponent extends FieldBaseComponent implements OnInit {
 		});
 	}
 
+	/**
+	 * Apply the consequence-map alpha to a deployment-supplied colour.
+	 *
+	 * This used to be `fieldColor + '7D'`, which only works for exactly `#RRGGBB`. CSS hex
+	 * colours are 3, 4, 6 or 8 digits, so concatenation produces an invalid one for the other
+	 * forms and the browser drops the declaration — the field renders with no fill at all.
+	 * Measured, and both broken forms are in this repository's own data files:
+	 *
+	 *   #40916c   + 7D = #40916c7D     rgba(64, 145, 108, 0.49)   data.json
+	 *   #FFF      + 7D = #FFF7D        REJECTED                   dataGridExample.json
+	 *   #b2b2b2c0 + 7D = #b2b2b2c07D   REJECTED                   data.json customColors
+	 *
+	 * So expand shorthand and replace any alpha already there, rather than appending to it.
+	 * Anything that is not a hex colour is returned untouched: named colours and rgb() are valid
+	 * CSS the game may legitimately be given, and mangling them would be worse than not applying
+	 * the alpha.
+	 */
+	private withConsequenceAlpha(color: string): string {
+		const m = /^#([0-9a-fA-F]{3,8})$/.exec(color?.trim() ?? '');
+		if (!m) return color;
+		let hex = m[1];
+		if (hex.length === 3 || hex.length === 4) hex = hex.split('').map(c => c + c).join('');
+		if (hex.length !== 6 && hex.length !== 8) return color;   // 5 or 7 digits: not a colour
+		return `#${hex.slice(0, 6)}7D`;
+	}
+
 	setColor(productionType: ProductionType | null = null) {
 		if (!this._field) return;
 		if (productionType && this.clickable) {
-			this.fillColor = `${productionType.fieldColor}${this.hasOpacity ? '7D' : ''}`;
+			this.fillColor = this.hasOpacity
+				? this.withConsequenceAlpha(productionType.fieldColor)
+				: productionType.fieldColor;
 		} else if(productionType) {
 			this.fillColor = `url(#pattern_${productionType.id}_${this.gameBoardId})`;
 		} else {


### PR DESCRIPTION
A placed field is drawn semi-transparently on a consequence map, and the colour was built by string concatenation:

```ts
this.fillColor = `${productionType.fieldColor}${this.hasOpacity ? '7D' : ''}`;
```

That only produces a valid colour for exactly `#RRGGBB`. CSS hex colours are **3, 4, 6 or 8** digits — so the other forms yield an invalid one, and an invalid CSS colour is not an error: the browser drops the declaration and the field renders with **no fill at all**.

## Both broken forms are in this repository's own data files

Measured against the same CSS parser the app runs against, not against my reading of the spec:

| input | result | where it appears |
|---|---|---|
| `#40916c` + `7D` = `#40916c7D` | `rgba(64, 145, 108, 0.49)` | `data.json` |
| `#FFF` + `7D` = `#FFF7D` | **REJECTED** | `dataGridExample.json` |
| `#b2b2b2c0` + `7D` = `#b2b2b2c07D` | **REJECTED** | `data.json` `customColors` |

## Now

Shorthand is expanded and an existing alpha replaced rather than appended to. Anything that isn't a hex colour is returned untouched — named colours and `rgb()` are valid CSS a deployment may legitimately use, and mangling them would be worse than not applying the alpha.

## Verified

The specs assert against jsdom's CSS parser rather than string-matching, so they test what a browser accepts rather than what I think it accepts. Mutation with the concatenation restored:

| | |
|---|---|
| `#FFF`, `#b2b2b2c0`, `#f0f` | **fail** |
| `#40916c` — the one that always worked | passes |

333 unit, 12 e2e, both browser rounds against the live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE