### PR TITLE
fix(ui): a shorthand custom colour no longer paints the wrong colour

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -29,7 +29,7 @@ Verified working
    * - Path
      - How it was checked
    * - Static / grid game
-     - 333 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
+     - 348 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
        SEO 100. The board renders 2,436 fields; the e2e suite asserts that rather than
        just asserting the component mounted.
    * - No external runtime deps

--- a/v2/src/app/shared/helpers/gradients.spec.ts
+++ b/v2/src/app/shared/helpers/gradients.spec.ts
@@ -1,4 +1,4 @@
-import gradients, { Gradient, applyGradientOverrides } from './gradients';
+import gradients, { CustomColors, Gradient, applyGradientOverrides } from './gradients';
 
 describe('Gradient.calculateColor', () => {
 	it('returns the start color at ratio 1 and the end color at ratio 0', () => {
@@ -80,5 +80,53 @@ describe('applyGradientOverrides with colours a deployment might reasonably writ
 		applyGradientOverrides({ red: { start: 'AABBCC', end: '#DDEEFF' } });
 
 		expect(errors).toEqual([]);
+	});
+});
+
+// colorToRgb turns a deployment-supplied colour into the pixels of the background map. It used
+// to slice by index assuming #RRGGBB, so every other CSS form was read from the wrong offsets
+// and produced a colour rather than an error — which the canvas then painted. NaN enters a
+// Uint8ClampedArray as 0, so nothing downstream noticed either.
+describe('CustomColors.colorToRgb', () => {
+	const c = new CustomColors('x');
+
+	it('reads #RRGGBB', () => {
+		expect(c.colorToRgb('#40916c')).toEqual([64, 145, 108, 255]);
+	});
+
+	it('reads #RRGGBBAA', () => {
+		expect(c.colorToRgb('#b2b2b2c0')).toEqual([178, 178, 178, 192]);
+	});
+
+	// The regression. #FFF is white; the old code read [255, 15, NaN, 255] — near-pure red.
+	it('expands #RGB shorthand instead of reading it from the wrong offsets', () => {
+		expect(c.colorToRgb('#FFF')).toEqual([255, 255, 255, 255]);
+		expect(c.colorToRgb('#f0f')).toEqual([255, 0, 255, 255]);
+	});
+
+	it('expands #RGBA shorthand', () => {
+		expect(c.colorToRgb('#f0fa')).toEqual([255, 0, 255, 170]);
+	});
+
+	// Every channel of every accepted form must be a real byte. This is the property that
+	// actually matters: a NaN here is silently painted as 0.
+	for (const v of ['#40916c', '#b2b2b2c0', '#FFF', '#f0fa', '#FFFFFF']) {
+		it(`gives four real bytes for ${v}`, () => {
+			const rgba = c.colorToRgb(v);
+			expect(rgba).toHaveLength(4);
+			expect(rgba.every((x: number) => Number.isInteger(x) && x >= 0 && x <= 255)).toBe(true);
+		});
+	}
+
+	// A named colour is valid CSS but cannot be resolved without a DOM. Refusing is honest;
+	// reading it by offset gave [235, 236, 202, NaN].
+	for (const v of ['rebeccapurple', '#12345', 'rgb(1,2,3)', '', 'not a colour']) {
+		it(`returns the transparent default rather than nonsense for ${JSON.stringify(v)}`, () => {
+			expect(c.colorToRgb(v)).toEqual([255, 255, 255, 0]);
+		});
+	}
+
+	it('returns the transparent default when the colour is unset', () => {
+		expect(c.colorToRgb(undefined)).toEqual([255, 255, 255, 0]);
 	});
 });

--- a/v2/src/app/shared/helpers/gradients.ts
+++ b/v2/src/app/shared/helpers/gradients.ts
@@ -128,16 +128,35 @@ export class CustomColors {
 		return this.colorToRgb(this.colors.get(i));
 	}
 
+	/**
+	 * Deployment-supplied colour to RGBA, for painting a raster into a canvas.
+	 *
+	 * This used to slice by index, assuming #RRGGBB or #RRGGBBAA. Every other CSS colour form is
+	 * then read from the wrong offsets and produces a colour rather than an error, which the
+	 * canvas paints. Measured, since the offsets do not misbehave in the way one would guess —
+	 * "#FFF".slice(3, 5) is "F", not "":
+	 *
+	 *   #FFF            [255, 15, NaN, 255]     white paints as near-pure red
+	 *   #f0fa           [240, 250, NaN, 255]
+	 *   rebeccapurple   [235, 236, 202, NaN]    a valid CSS colour, read as nonsense
+	 *
+	 * NaN then enters a Uint8ClampedArray as 0, so nothing downstream notices either.
+	 *
+	 * Now: 3, 4, 6 and 8 digit hex are all parsed, and anything else returns the same
+	 * transparent default an unknown value already did. Named colours and rgb() cannot be
+	 * resolved without a DOM, so refusing them is the honest answer — and it is a better one
+	 * than painting 235,236,202.
+	 */
 	colorToRgb(hex: string | undefined) {
-		if (!hex) return [255, 255, 255, 0];
-		const r = hex.slice(1, 3);
-		const g = hex.slice(3, 5);
-		const b = hex.slice(5, 7);
-		const a = hex.slice(7, 9);
-		if (a) {
-			return [parseInt(r, 16), parseInt(g, 16), parseInt(b, 16), parseInt(a, 16)];
-		}
-
-		return [parseInt(r, 16), parseInt(g, 16), parseInt(b, 16), 255];
+		const transparent = [255, 255, 255, 0];
+		if (!hex) return transparent;
+		const m = /^#([0-9a-fA-F]{3,8})$/.exec(hex.trim());
+		if (!m) return transparent;
+		let digits = m[1];
+		// #RGB and #RGBA are shorthand for each digit doubled.
+		if (digits.length === 3 || digits.length === 4) digits = digits.split('').map(c => c + c).join('');
+		if (digits.length !== 6 && digits.length !== 8) return transparent;   // 5 or 7: not a colour
+		const pair = (i: number) => parseInt(digits.slice(i, i + 2), 16);
+		return [pair(0), pair(2), pair(4), digits.length === 8 ? pair(6) : 255];
 	}
 }


### PR DESCRIPTION
`colorToRgb` turns a deployment-supplied colour into **the pixels of the background map**, and it sliced by index assuming `#RRGGBB` or `#RRGGBBAA`. Every other CSS form is read from the wrong offsets and produces a colour rather than an error — which the canvas then paints. `NaN` enters a `Uint8ClampedArray` as `0`, so nothing downstream notices either.

## Measured, and it doesn't misbehave the way you'd guess

I predicted the green channel would be `NaN` for `#FFF`. It's **15** — because `"#FFF".slice(3, 5)` is `"F"`, not `""`:

| colour | result | |
|---|---|---|
| `#40916c` | `[64, 145, 108, 255]` | ✓ |
| `#b2b2b2c0` | `[178, 178, 178, 192]` | ✓ |
| `#FFF` | `[255, 15, NaN, 255]` | **white paints as near-pure red** |
| `#f0fa` | `[240, 250, NaN, 255]` | |
| `rebeccapurple` | `[235, 236, 202, NaN]` | a valid CSS colour, read as nonsense |

## Now

3, 4, 6 and 8 digit hex all parsed; anything else returns the same transparent default an unset colour already did. Named colours and `rgb()` can't be resolved without a DOM, so refusing them is the honest answer — and a better one than painting `235,236,202`.

## The third of the same shape today

| PR | where | symptom |
|---|---|---|
| #148 | gradient stops | `"#F8F27D"` → `"NaN8814"` |
| #149 | consequence-map opacity | `#FFF` + `7D` → invalid, no fill |
| this | custom colours → canvas | `#FFF` → near-pure red |

All three sliced hex by index.

## Verified

Mutation with the index slicing restored: **eight** specs fail; `#RRGGBB` and `#RRGGBBAA` — the two forms that always worked — pass.

348 unit, 12 e2e, both browser rounds against the live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE