### PR TITLE
fix(ui): the background map's transparency no longer discards shorthand colours

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -29,7 +29,7 @@ Verified working
    * - Path
      - How it was checked
    * - Static / grid game
-     - 348 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
+     - 356 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
        SEO 100. The board renders 2,436 fields; the e2e suite asserts that rather than
        just asserting the component mounted.
    * - No external runtime deps

--- a/v2/src/app/shared/helpers/gradients.spec.ts
+++ b/v2/src/app/shared/helpers/gradients.spec.ts
@@ -130,3 +130,44 @@ describe('CustomColors.colorToRgb', () => {
 		expect(c.colorToRgb(undefined)).toEqual([255, 255, 255, 0]);
 	});
 });
+
+// game.service calls this on every SVG level build, to render the background map at 25%
+// opacity. It sliced by index like colorToRgb did, so a shorthand colour came out with five
+// hex digits — not a colour at all, and the intended one lost.
+describe('CustomColors.addTransparencyToColors', () => {
+	const withColor = (v: string) => {
+		const c = new CustomColors('x');
+		c.set(1, v);
+		c.addTransparencyToColors('3F');   // the 25% opacity game.service asks for
+		return c;
+	};
+
+	it('appends the alpha to #RRGGBB', () => {
+		expect(withColor('#40916c').get(1)).toBe('#40916c3F');
+	});
+
+	it('replaces an alpha that is already there', () => {
+		expect(withColor('#b2b2b2c0').get(1)).toBe('#b2b2b23F');
+	});
+
+	// The regression: this used to give #FFF3F, which colorToRgb reads as fully transparent.
+	// Compared case-insensitively — hex colours are, and the expansion keeps the input's case.
+	it('expands shorthand rather than producing five hex digits', () => {
+		expect(withColor('#FFF').get(1).toLowerCase()).toBe('#ffffff3f');
+		expect(withColor('#f0fa').get(1).toLowerCase()).toBe('#ff00ff3f');
+	});
+
+	// The property that matters: whatever comes out has to survive the trip to pixels with the
+	// requested alpha, for every form the data files use.
+	for (const v of ['#40916c', '#b2b2b2c0', '#FFF', '#f0fa']) {
+		it(`${v} still paints with the requested alpha`, () => {
+			const rgba = withColor(v).getRgb(1)!;
+			expect(rgba.every((x: number) => Number.isInteger(x))).toBe(true);
+			expect(rgba[3]).toBe(0x3F);
+		});
+	}
+
+	it('leaves a colour it cannot parse alone rather than mangling it', () => {
+		expect(withColor('rebeccapurple').get(1)).toBe('rebeccapurple');
+	});
+});

--- a/v2/src/app/shared/helpers/gradients.ts
+++ b/v2/src/app/shared/helpers/gradients.ts
@@ -100,6 +100,21 @@ export enum DefaultGradients {
 	Yellow = 'yellow'
 }
 
+/**
+ * Expand a CSS hex colour to its 6- or 8-digit form, or null if it is not one.
+ *
+ * Shared because this class slices hex by index in two places, and both got it wrong for the
+ * shorthand forms. #RGB and #RGBA mean each digit doubled; 5 and 7 digits are not colours.
+ */
+export function expandHexColor(value: string | undefined): string | null {
+	const m = /^#([0-9a-fA-F]{3,8})$/.exec(value?.trim() ?? '');
+	if (!m) return null;
+	const digits = m[1].length === 3 || m[1].length === 4
+		? m[1].split('').map(c => c + c).join('')
+		: m[1];
+	return digits.length === 6 || digits.length === 8 ? digits : null;
+}
+
 export class CustomColors {
 	private colors = new Map<number, string>();
 	id: string;
@@ -118,9 +133,23 @@ export class CustomColors {
 		this.colors.set(key, value);
 	}
 
+	/**
+	 * Replace every colour's alpha with the given one, for the semi-transparent background map.
+	 *
+	 * This was `value.slice(0, 7) + transparencyHex`, which is right only for #RRGGBB and
+	 * #RRGGBBAA. Measured with "3F", the 25% opacity game.service asks for:
+	 *
+	 *   #40916c     #40916c3F   [64, 145, 108, 63]
+	 *   #b2b2b2c0   #b2b2b23F   [178, 178, 178, 63]    existing alpha correctly replaced
+	 *   #FFF        #FFF3F      [255, 255, 255, 0]     5 digits: the colour is lost entirely
+	 *
+	 * A colour that cannot be parsed is left alone rather than turned into something that is
+	 * not a colour at all.
+	 */
 	addTransparencyToColors(transparencyHex: string) {
 		this.colors.forEach((value, key) => {
-			this.colors.set(key, value.slice(0, 7) + transparencyHex);
+			const digits = expandHexColor(value);
+			if (digits) this.colors.set(key, `#${digits.slice(0, 6)}${transparencyHex}`);
 		});
 	}
 
@@ -149,13 +178,8 @@ export class CustomColors {
 	 */
 	colorToRgb(hex: string | undefined) {
 		const transparent = [255, 255, 255, 0];
-		if (!hex) return transparent;
-		const m = /^#([0-9a-fA-F]{3,8})$/.exec(hex.trim());
-		if (!m) return transparent;
-		let digits = m[1];
-		// #RGB and #RGBA are shorthand for each digit doubled.
-		if (digits.length === 3 || digits.length === 4) digits = digits.split('').map(c => c + c).join('');
-		if (digits.length !== 6 && digits.length !== 8) return transparent;   // 5 or 7: not a colour
+		const digits = expandHexColor(hex);
+		if (!digits) return transparent;
 		const pair = (i: number) => parseInt(digits.slice(i, i + 2), 16);
 		return [pair(0), pair(2), pair(4), digits.length === 8 ? pair(6) : 255];
 	}


### PR DESCRIPTION
Follow-on to #150 — the same index-slicing, in the other method of the same class.

`addTransparencyToColors` runs on **every SVG level build**, rendering the background map at 25% opacity (`game.service.ts:285`). Measured with the `"3F"` it's actually called with:

| colour | result | |
|---|---|---|
| `#40916c` | `#40916c3F` → `[64, 145, 108, 63]` | ✓ |
| `#b2b2b2c0` | `#b2b2b23F` → `[178, 178, 178, 63]` | ✓ existing alpha correctly replaced |
| `#FFF` | `#FFF3F` → `[255, 255, 255, 0]` | **five digits — the colour is lost entirely** |

After #150 that at least failed *safely* (transparent rather than a wrong colour), but the intended colour was still gone.

The rules for what a hex colour is now live in **one** exported function both callers use — this class had them written out twice and got them wrong twice.

## Two corrections I made to myself

**I said this method had no callers.** Wrong — I'd grepped for the wrong names (`setTransparency`, `transparencyHex`). It's called from `game.service.ts:285`, which is why it's worth fixing rather than deleting. Found by grepping properly before acting on the claim.

**My first test was wrong, not the code.** I expected `"#ffffff3F"`; the expansion preserves the input's case and gave `"#FFFFFF3F"`. The assertion is now case-insensitive, which is what CSS means anyway.

## Verified

Mutation on this method alone: the shorthand and non-hex specs fail while `#RRGGBB` and `#RRGGBBAA` — the two forms the data files actually use — keep passing.

356 unit, 12 e2e, both browser rounds against the live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE