### PR TITLE
ci: re-derive the verification doc's file references and e2e count

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,53 @@ jobs:
           fi
           echo "documented count matches the suite"
 
+      - name: Every file the verification doc points at must exist
+        run: |
+          # Same failure mode as the test count, different shape: verification-status.rst names
+          # ~16 files as evidence, and a rename leaves the doc pointing at nothing while every
+          # other check stays green. Nothing re-derived these, so this does.
+          cd "${GITHUB_WORKSPACE}"
+          paths=$(grep -oE ':file:`[^`]+`' docs/verification-status.rst \
+                  | sed -E 's/^:file:`//; s/`$//' | sort -u)
+          # Presence first: an empty list would validate nothing and report success.
+          n=$(printf '%s\n' "$paths" | grep -c . || true)
+          echo "$n paths referenced"
+          if [ "$n" -lt 5 ]; then
+            echo "::error file=docs/verification-status.rst::found only $n :file: references; this check is not looking at the right thing"
+            exit 1
+          fi
+          bad=0
+          for p in $paths; do
+            # Absolute paths are system files being described (/etc/hosts), not repo paths.
+            case "$p" in /*) continue ;; esac
+            if [ ! -e "$p" ]; then
+              echo "::error file=docs/verification-status.rst::references $p, which does not exist"
+              bad=1
+            fi
+          done
+          [ "$bad" = 0 ] && echo "every referenced path exists"
+          exit $bad
+
       - name: E2E (Playwright)
-        run: npm run e2e
+        run: |
+          set -o pipefail
+          npm run e2e 2>&1 | tee /tmp/e2e.log
+
+      - name: The documented e2e count is current
+        run: |
+          # The doc claims an e2e count beside the unit one, and only the unit one was checked.
+          actual=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/e2e.log | grep -oE '[0-9]+ passed' | grep -oE '[0-9]+' | tail -1)
+          claimed=$(grep -oE '^\s+- [0-9]+ unit tests, [0-9]+ Playwright e2e' "${GITHUB_WORKSPACE}/docs/verification-status.rst" \
+                    | grep -oE '[0-9]+ Playwright' | grep -oE '[0-9]+')
+          echo "suite reports: ${actual:-<none>}   docs claim: ${claimed:-<none>}"
+          if [ -z "$actual" ] || [ -z "$claimed" ]; then
+            echo "::error::could not read one of the e2e counts (suite='${actual}', docs='${claimed}')"; exit 1
+          fi
+          if [ "$actual" != "$claimed" ]; then
+            echo "::error file=docs/verification-status.rst::says $claimed Playwright e2e, the suite runs $actual — update it"
+            exit 1
+          fi
+          echo "documented e2e count matches the suite"
 
       - name: Upload Playwright report on failure
         if: failure()

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -182,7 +182,7 @@ None of these are defects to fix here — they are things a deployment must supp
    cluster served a frontend image seven merges old while every check passed, because the pod
    had been started before those merges. ``kind.sh deploy`` does ``rollout restart``, which
    re-pulls under ``imagePullPolicy: Always``, and re-deploying moved the running digest from
-   ``45f92893`` to ``e1fd8573``. :file:`ingress-test.sh` now prints the spec image and the
+   ``45f92893`` to ``e1fd8573``. :file:`deploy/k8s/ingress-test.sh` now prints the spec image and the
    running **digest** for both deployments, so its output records what it tested.
 
    Verified from a **cold start**, which is the claim :file:`deploy/k8s/README.md` makes: the


### PR DESCRIPTION
`docs/verification-status.rst` has a whole section warning about *"stated facts nothing re-derives"* — and then carried two of them itself.

CI already re-measures the unit-test count, after that claim drifted from 135 to 255. It did **not** check:

- the ~16 files the doc names as evidence — a rename leaves the doc pointing at nothing while every other check stays green
- the **e2e** count, sitting in the same sentence as the unit one

## The path check found one on its first run

Line 185 said `` :file:`ingress-test.sh` `` where the file is `deploy/k8s/ingress-test.sh`, so it didn't resolve from the repository root. Fixed.

## Both assert presence before absence

The path check refuses to pass on fewer than five references — an empty list would validate nothing and report success. Absolute paths are skipped, since `/etc/hosts` is a system file being *described*, not a repo path.

## The mutation had to be verified to have applied

My first attempt renamed a path the doc doesn't reference, so the "broken" copy was byte-identical to the real one and passed. That's the same not-really-testing-anything shape the doc's own vacuity section is about — arrived at while adding a check against it.

| state | result |
|---|---|
| real doc | **PASS** (14 paths) |
| a reference renamed away | **FAIL**, naming the missing path |
| a doc with no references | **FAIL** (only 0 references) |

## Also

The e2e step now tees its output with `set -o pipefail`, so the pipeline reports the suite's status and not `tee`'s — the trap already documented on the unit step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE