### PR TITLE
fix(ui): gradient stops are read as colours however they were assigned

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -29,7 +29,7 @@ Verified working
    * - Path
      - How it was checked
    * - Static / grid game
-     - 356 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
+     - 363 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
        SEO 100. The board renders 2,436 fields; the e2e suite asserts that rather than
        just asserting the component mounted.
    * - No external runtime deps

--- a/v2/src/app/shared/helpers/gradients.spec.ts
+++ b/v2/src/app/shared/helpers/gradients.spec.ts
@@ -171,3 +171,46 @@ describe('CustomColors.addTransparencyToColors', () => {
 		expect(withColor('rebeccapurple').get(1)).toBe('rebeccapurple');
 	});
 });
+
+// startingColor and endingColor are public fields, so "they are always bare 6-digit hex" was
+// true only by inspecting every assignment. Nothing enforced it — and reading hex from fixed
+// offsets was the same mistake found in four separate places in this codebase on one day.
+// These drive Gradient directly, the way a seventh built-in or another caller would.
+describe('Gradient stops assigned in any hex form', () => {
+	const forms = [
+		['bare 6-digit', 'F8F27D', 'A80000'],
+		['#-prefixed', '#F8F27D', '#A80000'],
+		['#RGB shorthand', '#ff0', '#a00'],
+		['lower case', 'f8f27d', 'a80000'],
+	] as const;
+
+	// The reference: the form the built-ins are written in.
+	const reference = new Gradient('F8F27D', 'A80000', []).calculateColor(0.5);
+
+	for (const [name, start, end] of forms) {
+		it(`${name} produces a real colour`, () => {
+			const g = new Gradient(start, end, []);
+
+			expect(g.calculateColor(0.5)).not.toContain('NaN');
+			expect(g.calculateColorRGB(0.5).every((c: number) => Number.isInteger(c))).toBe(true);
+		});
+	}
+
+	it('#-prefixed gives the same colour as the bare form', () => {
+		expect(new Gradient('#F8F27D', '#A80000', []).calculateColor(0.5)).toBe(reference);
+	});
+
+	it('lower case gives the same colour as upper', () => {
+		expect(new Gradient('f8f27d', 'a80000', []).calculateColor(0.5)).toBe(reference);
+	});
+
+	// A stop assigned after construction is the applyGradientOverrides path, and any future one.
+	it('survives a stop assigned after construction', () => {
+		const g = new Gradient('F8F27D', 'A80000', []);
+
+		g.startingColor = '#0f0';
+
+		expect(g.calculateColor(0.5)).not.toContain('NaN');
+		expect(g.calculateColorRGB(0.5).every((c: number) => Number.isInteger(c))).toBe(true);
+	});
+});

--- a/v2/src/app/shared/helpers/gradients.ts
+++ b/v2/src/app/shared/helpers/gradients.ts
@@ -1,3 +1,18 @@
+/**
+ * Expand a CSS hex colour to its 6- or 8-digit form, or null if it is not one.
+ *
+ * Shared because this class slices hex by index in two places, and both got it wrong for the
+ * shorthand forms. #RGB and #RGBA mean each digit doubled; 5 and 7 digits are not colours.
+ */
+export function expandHexColor(value: string | undefined): string | null {
+	const m = /^#([0-9a-fA-F]{3,8})$/.exec(value?.trim() ?? '');
+	if (!m) return null;
+	const digits = m[1].length === 3 || m[1].length === 4
+		? m[1].split('').map(c => c + c).join('')
+		: m[1];
+	return digits.length === 6 || digits.length === 8 ? digits : null;
+}
+
 export class Gradient {
 	constructor(startingColor: string, endingColor: string, colors: string[]) {
 		this.startingColor = startingColor;
@@ -9,25 +24,45 @@ export class Gradient {
 	startingColor: string;
 	endingColor: string;
 
+	/**
+	 * The two stops, as bare 6-digit hex whatever form they were assigned in.
+	 *
+	 * Both are public fields, so "they are always bare hex" was true only by inspecting every
+	 * assignment: six built-ins written that way, and applyGradientOverrides normalising the
+	 * config path. Nothing enforced it, and the same mistake — reading hex from fixed offsets —
+	 * was found in four places in this codebase on one day. A seventh gradient written "#abcdef",
+	 * or a Gradient built anywhere else, would silently produce "NaN8814" again.
+	 *
+	 * Doing it here makes every assignment path safe, including ones not written yet.
+	 * applyGradientOverrides still validates, because it can say WHICH override was wrong.
+	 */
+	private stops(): { start: string, end: string } {
+		return {
+			start: expandHexColor(`#${this.startingColor.replace(/^#/, '')}`)?.slice(0, 6) ?? '000000',
+			end: expandHexColor(`#${this.endingColor.replace(/^#/, '')}`)?.slice(0, 6) ?? '000000',
+		};
+	}
+
+	private mix(ratio: number): number[] {
+		const { start, end } = this.stops();
+		const at = (i: number) => Math.ceil(
+			parseInt(start.substring(i, i + 2), 16) * ratio +
+			parseInt(end.substring(i, i + 2), 16) * (1 - ratio));
+		return [at(0), at(2), at(4)];
+	}
+
 	calculateColor(ratio: number) : string {
 		const hex = (x: number) => {
 			const strValue = x.toString(16);
 			return (strValue.length == 1) ? '0' + strValue : strValue;
 		};
 
-		let r = Math.ceil(parseInt(this.startingColor.substring(0, 2), 16) * ratio + parseInt(this.endingColor.substring(0, 2), 16) * (1 - ratio));
-		let g = Math.ceil(parseInt(this.startingColor.substring(2, 4), 16) * ratio + parseInt(this.endingColor.substring(2, 4), 16) * (1 - ratio));
-		let b = Math.ceil(parseInt(this.startingColor.substring(4, 6), 16) * ratio + parseInt(this.endingColor.substring(4, 6), 16) * (1 - ratio));
-
+		const [r, g, b] = this.mix(ratio);
 		return hex(r) + hex(g) + hex(b);
 	}
 
 	calculateColorRGB(ratio: number) : number[] {
-		let r = Math.ceil(parseInt(this.startingColor.substring(0, 2), 16) * ratio + parseInt(this.endingColor.substring(0, 2), 16) * (1 - ratio));
-		let g = Math.ceil(parseInt(this.startingColor.substring(2, 4), 16) * ratio + parseInt(this.endingColor.substring(2, 4), 16) * (1 - ratio));
-		let b = Math.ceil(parseInt(this.startingColor.substring(4, 6), 16) * ratio + parseInt(this.endingColor.substring(4, 6), 16) * (1 - ratio));
-
-		return [r, g, b];
+		return this.mix(ratio);
 	}
 }
 
@@ -98,21 +133,6 @@ export enum DefaultGradients {
 	Purple = 'purple',
 	Red = 'red',
 	Yellow = 'yellow'
-}
-
-/**
- * Expand a CSS hex colour to its 6- or 8-digit form, or null if it is not one.
- *
- * Shared because this class slices hex by index in two places, and both got it wrong for the
- * shorthand forms. #RGB and #RGBA mean each digit doubled; 5 and 7 digits are not colours.
- */
-export function expandHexColor(value: string | undefined): string | null {
-	const m = /^#([0-9a-fA-F]{3,8})$/.exec(value?.trim() ?? '');
-	if (!m) return null;
-	const digits = m[1].length === 3 || m[1].length === 4
-		? m[1].split('').map(c => c + c).join('')
-		: m[1];
-	return digits.length === 6 || digits.length === 8 ? digits : null;
 }
 
 export class CustomColors {


### PR DESCRIPTION
Closing the class rather than the fourth instance of it.

`startingColor` and `endingColor` are **public fields**, and `calculateColor` read them at fixed offsets. *"They are always bare 6-digit hex"* was true — but only by inspecting every assignment: six built-ins written that way, and `applyGradientOverrides` normalising the config path since #148.

**Nothing enforced it.** A seventh gradient written `"#abcdef"`, or a `Gradient` constructed anywhere else, silently produces `"NaN8814"` again.

## Not a hypothetical risk here

Reading hex from fixed offsets was found in **four separate places in this codebase today**:

| PR | where |
|---|---|
| #148 | gradient stops |
| #149 | consequence-map opacity |
| #150 | `colorToRgb` → canvas pixels |
| #151 | `addTransparencyToColors` |

All four were safe-by-inspection until they weren't.

## The fix

The stops are expanded through the same `expandHexColor` the rest of the file uses, so every assignment path is covered — including ones not written yet. `applyGradientOverrides` still validates, because it's the only caller that can say *which* override was wrong.

## Verified

Mutation reading the stops raw again:

| | |
|---|---|
| `#`-prefixed, `#RGB` shorthand, assigned-after-construction | **fail** |
| bare 6-digit and lower-case — the forms that always worked | pass |

363 unit, 12 e2e, both browser rounds against the live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE