### PR TITLE
fix(ui): an unrecognised gameBoardType or gradient no longer passes in silence

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -29,7 +29,7 @@ Verified working
    * - Path
      - How it was checked
    * - Static / grid game
-     - 363 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
+     - 374 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
        SEO 100. The board renders 2,436 fields; the e2e suite asserts that rather than
        just asserting the component mounted.
    * - No external runtime deps

--- a/v2/src/app/shared/models/settings.data-errors.spec.ts
+++ b/v2/src/app/shared/models/settings.data-errors.spec.ts
@@ -1,4 +1,5 @@
 import { Settings } from './settings';
+import gradients from '../helpers/gradients';
 
 // Every deployment writes its own data.json by hand, so a field being absent is an ordinary
 // mistake. What it used to produce was "Cannot read properties of undefined (reading 'map')" —
@@ -80,6 +81,63 @@ describe('Settings with missing text', () => {
 
 	it('says nothing when every label is present', () => {
 		new Settings(translateStub(), full());
+
+		expect(errors).toEqual([]);
+	});
+});
+
+// gameBoardType and gradient are strings a deployment types by hand, and both converters used
+// to accept anything: the switch defaulted every typo to a Suitability map, and the gradient
+// converter was a bare cast. Measured before the fix — "Consequense" and "Backgrund" both came
+// back as SuitabilityMap(0), and "blu"/"BLUE" were stored unchanged and looked up as undefined.
+describe('Settings with an unrecognised gameBoardType or gradient', () => {
+	let errors: string[];
+	beforeEach(() => {
+		errors = [];
+		vi.spyOn(console, 'error').mockImplementation((...a: any[]) => { errors.push(a.map(String).join(' ')); });
+	});
+	afterEach(() => vi.restoreAllMocks());
+
+	const withMap = (gameBoardType: string, gradient?: string) => new Settings(translateStub([]), {
+		title: { en: 'T' }, mapMode: 'svg', elementSize: 1, gameBoardColumns: 4, gameBoardRows: 4,
+		productionTypes: [], customColors: [],
+		maps: [{ id: 'm', name: { en: 'M' }, gameBoardType, gradient, urlToData: 'x.tif', productionTypes: [] }],
+	});
+
+	// Controls: the four real values must stay silent, or every deployment gets noise.
+	for (const t of ['Suitability', 'Consequence', 'Drawing', 'Background']) {
+		it(`accepts ${t} without comment`, () => {
+			withMap(t, 'blue');
+			expect(errors).toEqual([]);
+		});
+	}
+
+	for (const t of ['Consequense', 'Backgrund', 'suitability', '']) {
+		it(`names ${JSON.stringify(t)} rather than silently calling it a Suitability map`, () => {
+			withMap(t, 'blue');
+			expect(errors.join(' ')).toContain('gameBoardType');
+			expect(errors.join(' ')).toContain(JSON.stringify(t));
+		});
+	}
+
+	it('names an unknown gradient and falls back to one that exists', () => {
+		const s = withMap('Suitability', 'blu');
+
+		expect(errors.join(' ')).toContain('"blu"');
+		// The fallback has to be real: gradients.get() is dereferenced without a guard, so
+		// passing the bad name on would crash rather than merely look wrong.
+		expect(gradients.get(s.maps[0].gradient as any)).toBeTruthy();
+	});
+
+	it('is case sensitive about gradients, and says so', () => {
+		const s = withMap('Suitability', 'BLUE');
+
+		expect(errors.join(' ')).toContain('lower case');
+		expect(gradients.get(s.maps[0].gradient as any)).toBeTruthy();
+	});
+
+	it('says nothing when a map simply has no gradient', () => {
+		withMap('Suitability', undefined);
 
 		expect(errors).toEqual([]);
 	});

--- a/v2/src/app/shared/models/settings.ts
+++ b/v2/src/app/shared/models/settings.ts
@@ -152,13 +152,49 @@ export class Settings {
 	}
 }
 
+/**
+ * A deployment writes these strings by hand, and both converters used to accept anything.
+ *
+ * convertGameBoardType's `default` turned every typo into a Suitability map — measured:
+ * "Consequense" and "Backgrund" both became SuitabilityMap, so a mistyped consequence map
+ * rendered as a suitability one and a mistyped background left the game with none.
+ * convertGradient was a bare cast, so "blu" and "BLUE" were stored unchanged and then looked up
+ * as undefined, giving a blank board or "Cannot read properties of undefined (reading 'colors')".
+ *
+ * The fallbacks stay — refusing to start over one mistyped map would be worse — but they no
+ * longer happen in silence.
+ */
 const convertGameBoardType = (type: string) => {
 	switch (type) {
 		case "Suitability": return GameBoardType.SuitabilityMap;
 		case "Consequence": return GameBoardType.ConsequenceMap;
 		case "Drawing": return GameBoardType.DrawingMap;
 		case "Background": return GameBoardType.BackgroundMap;
-		default: return GameBoardType.SuitabilityMap;
+		default:
+			console.error(
+				`The game data has a map with gameBoardType ${JSON.stringify(type)}, which is not ` +
+				`one of Suitability, Consequence, Drawing, Background. Treating it as a ` +
+				`Suitability map, which is very likely not what was meant.`);
+			return GameBoardType.SuitabilityMap;
 	}
 };
-const convertGradient = (gradientName: string) => gradientName as unknown as DefaultGradients;
+
+const convertGradient = (gradientName: string) => {
+	const known = Object.values(DefaultGradients) as string[];
+	if (known.includes(gradientName)) return gradientName as DefaultGradients;
+	// An absent gradient is normal — a map may use customColors instead — so only a value that
+	// was given and is wrong is worth reporting.
+	if (gradientName !== undefined && gradientName !== null && gradientName !== '') {
+		console.error(
+			`The game data asks for gradient ${JSON.stringify(gradientName)}, which does not ` +
+			`exist. Known gradients: ${known.join(', ')} (lower case). Falling back to ` +
+			`${DefaultGradients.Blue}.`);
+		// Actually fall back, rather than passing the bad name on. gradients.get() would return
+		// undefined, and getGridGameBoard dereferences it — `gradients.get(x)!.colors[i]` — so
+		// the alternative to a wrong-but-working gradient is a crash.
+		return DefaultGradients.Blue;
+	}
+	// Absent: left as-is. A map may legitimately have no gradient and use customColors instead,
+	// and arrayToImage branches on that.
+	return gradientName as unknown as DefaultGradients;
+};


### PR DESCRIPTION
Both are strings a deployment types by hand, and both converters accepted anything.

## `convertGameBoardType`'s `default` turned every typo into a Suitability map

Measured:

```
"Suitability"   -> 0 SuitabilityMap
"Consequence"   -> 1 ConsequenceMap
"Background"    -> 3 BackgroundMap
"Consequense"   -> 0     a mistyped consequence map renders as a suitability one
"Backgrund"     -> 0     and the game is left with no background map at all
"suitability"   -> 0     right by accident; the switch is case sensitive
```

## `convertGradient` was a bare cast

```ts
const convertGradient = (gradientName: string) => gradientName as unknown as DefaultGradients;
```

So `"blu"` and `"BLUE"` were stored unchanged and looked up as `undefined` — a blank board, or `Cannot read properties of undefined (reading 'colors')` from `getGridGameBoard`, which dereferences the lookup without a guard.

## The fallbacks stay; the silence doesn't

Refusing to start over one mistyped map would be worse. But the gradient one now **actually falls back** — my first version logged *"Falling back to blue"* while returning the bad name unchanged. The message would have been a lie, and the crash it describes avoiding would still have happened.

## Verified

Eleven new specs, **six of them controls**: the four real `gameBoardType` values and a map with no gradient must stay silent, or every correct deployment gets noise.

Mutation with the silent default and the bare cast restored → the six typo specs fail, the controls pass.

374 unit, 12 e2e, both browser rounds against the live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE