### PR TITLE
fix(calculator): refuse a round that cannot be scored, with 400 and a reason

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -205,6 +205,27 @@ None of these are defects to fix here — they are things a deployment must supp
    mounted, rather than a dead process. A connection that is refused (``000``) is the
    failure the probe exists to catch.
 
+The calculator refuses a round it cannot score — *added 2026-07-31*
+   An allocation the calculator cannot use produced ``500
+   {"error":"500 - Internal server error"}`` — plumber's rendering of an Rcpp type error
+   several frames down (``Not compatible with requested type: [type=list; target=double]``).
+   ``coverage.R`` had already logged *"Allocation is empty; the round will score the base
+   raster unchanged"*, so the log said the round would proceed, it did not, and the status
+   said the server was broken when the request was.
+
+   Four shapes are now refused with **400** and a message naming the problem, measured against
+   the live cluster:
+
+   .. code-block:: text
+
+      no allocation field   400  Cannot score this round: the request has no 'allocation' field.
+      empty allocation      400  Cannot score this round: 'allocation' is empty.
+      id-keyed object       400  ...'allocation' is a list; it must be an array of {id, lulc} objects.
+      missing lulc column   400  ...'allocation' has columns [id]; it needs id and lulc.
+
+   A real round is unaffected: 16/16 in :file:`deploy/k8s/ingress-test.sh` and both browser
+   specs against the same rebuilt image.
+
 Placeholders must be replaced
    ``change-me-*.example.com`` hosts, ``CALC_URL``, and — in the places overlay —
    ``CHANGE-ME-registry/…`` image names. Keep hosts lowercase: an Ingress host must be a

--- a/tools/R/calculator.r
+++ b/tools/R/calculator.r
@@ -21,7 +21,7 @@ list()
 
 #* @post /esgame
 #* @serializer unboxedJSON
-esgame <- function(req, json_in='{}') {
+esgame <- function(req, res, json_in='{}') {
   geoserver_url <- Sys.getenv("GEOSERVER", "https://esgame-geoserver.azurewebsites.net/geoserver")
   #NEW CODE --> ALLOW TO SEND DATA IN BODY OF Request
   if (!(json_in == '' || json_in == '{}')) { 
@@ -37,6 +37,42 @@ esgame <- function(req, json_in='{}') {
     score_PD <- req$body$score
     map_AG <- req$body$allocation
   }
+
+  # Refuse an allocation that cannot be scored, rather than letting it reach reclassify().
+  #
+  # An empty one used to warn "the round will score the base raster unchanged" and then die
+  # several frames later with
+  #
+  #   Not compatible with requested type: [type=list; target=double]
+  #
+  # an Rcpp type error the caller never sees: plumber turns it into a bare
+  # {"error":"500 - Internal server error"}. So the log said the round would proceed, it did not,
+  # and the status said the server was broken when the request was.
+  #
+  # 400 is what this is. The frontend already reports any error to the player, and the image
+  # probe in .github/workflows/image-calculation.yml accepts any HTTP status — it is a
+  # connection that fails (000) that means the process died.
+  bad <- NULL
+  if (is.null(map_AG)) {
+    bad <- "the request has no 'allocation' field"
+  } else if (length(map_AG) == 0) {
+    bad <- "'allocation' is empty"
+  } else if (is.data.frame(map_AG) && !all(c("id", "lulc") %in% names(map_AG))) {
+    bad <- paste0("'allocation' has columns [", paste(names(map_AG), collapse = ", "),
+                  "]; it needs id and lulc")
+  } else if (!is.data.frame(map_AG)) {
+    # jsonlite turns [{id, lulc}, ...] into a data.frame. Anything else — an object keyed by id,
+    # or a bare array — does not, and reclassify wants a two-column matrix.
+    bad <- paste0("'allocation' is a ", class(map_AG)[1],
+                  "; it must be an array of {id, lulc} objects")
+  }
+  if (!is.null(bad)) {
+    logger::log_error("Refusing the round: {bad}.")
+    res$status <- 400
+    return(list(error = paste0("Cannot score this round: ", bad,
+                               ". Expected {\"allocation\": [{\"id\": <number>, \"lulc\": <number>}, ...]}.")))
+  }
+
   return(calculate(req, geoserver_url, game_id, round_id, score_PD, map_AG))
 }
 


### PR DESCRIPTION
An allocation the calculator cannot use gave the caller:

```
500 {"error":"500 - Internal server error"}
```

which is plumber's rendering of an Rcpp type error several frames down:

```
Not compatible with requested type: [type=list; target=double]
```

`coverage.R` had *already* logged `Allocation is empty; the round will score the base raster unchanged`. So the log said the round would proceed, it didn't, and the status said the **server** was broken when the **request** was.

## Four shapes refused before reaching `reclassify()`

Measured against the live cluster, not reasoned about:

```
no allocation field   400  Cannot score this round: the request has no 'allocation' field.
empty allocation      400  Cannot score this round: 'allocation' is empty.
id-keyed object       400  ...'allocation' is a list; it must be an array of {id, lulc} objects.
missing lulc column   400  ...'allocation' has columns [id]; it needs id and lulc.
```

That third shape is worth having: `jsonlite` turns `[{id, lulc}, ...]` into a data.frame, and an id-keyed object instead is the mistake documented in places' `test/stack.sh` as producing *"comparison of these types is not implemented"* and a 500.

## Why 400

The request is what's wrong. Nothing depends on the old status — the frontend reports any error to the player, and the image probe in `image-calculation.yml` accepts any HTTP status, since it's a **refused connection (000)** that means the process died.

## The case that must keep working

16/16 in `ingress-test.sh` and both browser specs, against the same rebuilt image.

A transient `503` during the rollout was chased down to the pod not yet being ready, rather than written off — it looked exactly like a broken endpoint, and assuming would have been the wrong call in either direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE