### PR TITLE
fix(k8s): give the calculation and geoserver pods readiness probes

### DIFF
--- a/deploy/k8s/base/calculation-deployment.yaml
+++ b/deploy/k8s/base/calculation-deployment.yaml
@@ -56,6 +56,21 @@ spec:
           volumeMounts:
             - name: app-data
               mountPath: /app/data
+          # Without this the pod is "ready" the instant the container starts, and the Service
+          # sends it traffic while plumber is still binding — about 12 seconds. That is not
+          # hypothetical: a POST straight after a rollout returned 503 from the ingress, and it
+          # looked exactly like a broken endpoint.
+          #
+          # tcpSocket, not httpGet, because nothing here answers 2xx-3xx: measured from inside
+          # the cluster, / is 404 and /esgame is 405 (it is POST-only). Only /__docs__/ returns
+          # 200, and depending on swagger being enabled would be a worse probe than checking the
+          # port accepts connections — which is precisely what was missing.
+          readinessProbe:
+            tcpSocket:
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 12
           resources:
             limits:
               cpu: "2"

--- a/deploy/k8s/base/geoserver-deployment.yaml
+++ b/deploy/k8s/base/geoserver-deployment.yaml
@@ -41,6 +41,28 @@ spec:
           ports:
             - containerPort: 8080
               protocol: TCP
+          # GeoServer reports the container up long before the web app and REST API are
+          # serving, so the Deployment went "available" while requests still failed —
+          # deploy/k8s/kind.sh carries a poll loop for exactly this.
+          #
+          # /geoserver/index.html, because it answers 200 directly. The other candidates were
+          # measured against a running pod and all fail as probes:
+          #
+          #   /geoserver/web/                302 -> Location: ./?0   relative, and it LOOPS
+          #   /geoserver/rest/about/...      401                     needs credentials
+          #   /                              404
+          #
+          # A Kubernetes httpGet probe FOLLOWS redirects and gives up after ten, so /geoserver/web/
+          # never succeeded — "Readiness probe failed: Get \"./\": stopped after 10 redirects", and
+          # the rollout timed out. Reading only the first response and seeing 302 in the 200-399
+          # success range is what made that look correct.
+          readinessProbe:
+            httpGet:
+              path: /geoserver/index.html
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 30
           resources:
             limits:
               cpu: "1"

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -347,6 +347,30 @@ The committed base raster makes the game inert
    browser sends the ids the board actually uses.
    See :ref:`allocation-id-space`.
 
+Readiness probes — *added 2026-07-31*
+   ``esgame-calculation`` and ``esgame-geoserver`` had none, so Kubernetes called a pod ready
+   the instant its container started and the Service routed to it while plumber was still
+   binding — about 12 seconds for the calculator, 30 for GeoServer.
+
+   Measured on the live cluster, timing from ``kubectl rollout status`` returning to the first
+   correct answer through the ingress:
+
+   .. code-block:: text
+
+      without a probe   8s   codes seen: 503, 502, 400
+      with a probe      2s   codes seen: 503, 400
+
+   The 502 is the one that matters: traffic reaching a pod that is not serving. The residual
+   ~1s of 503 is ingress-nginx's own endpoint sync and no probe removes it, so this is a
+   smaller claim than "the 503 window is gone".
+
+   Both probe targets were chosen by measurement rather than by convention. The calculator
+   answers 404 on ``/`` and 405 on ``/esgame`` (it is POST-only), so nothing there is a 2xx —
+   hence ``tcpSocket``. GeoServer's ``/geoserver/web/`` looked right at 302, but a Kubernetes
+   httpGet probe **follows** redirects and that one is relative (``Location: ./?0``) and loops:
+   the first attempt failed with *"stopped after 10 redirects"* and timed the rollout out.
+   ``/geoserver/index.html`` answers 200 directly.
+
 No default IngressClass is assumed
    The three Ingresses set no ``ingressClassName``. If the cluster has no default
    ``IngressClass`` they apply cleanly and route nothing, with no error. Check


### PR DESCRIPTION
Neither had one, so Kubernetes called the pod ready the instant its container started and the Service routed to it while the application was still coming up — ~12s for plumber, ~30s for GeoServer.

Not hypothetical: a POST immediately after a rollout returned 503 from the ingress earlier today and looked exactly like a broken endpoint.

## Measured on the live cluster

Timing from `kubectl rollout status` returning to the first **correct** answer through the ingress:

| | time | codes seen |
|---|---|---|
| without a probe | **8s** | 503, **502**, 400 |
| with a probe | **2s** | 503, 400 |

The **502** is the point: traffic reaching a pod that isn't serving.

The residual ~1s of 503 is ingress-nginx's own endpoint sync, which no readiness probe removes. So this is a **smaller claim than "the 503 window is gone"** — which is what I first assumed, and the measurement contradicted.

## Both targets chosen by measurement, and my first GeoServer attempt was wrong

**Calculator** answers `404` on `/` and `405` on `/esgame` (POST-only). Only `/__docs__/` gives 200, and depending on swagger being enabled is a worse probe than checking the port accepts connections → `tcpSocket`.

**GeoServer's** `/geoserver/web/` returns `302`, which is inside httpGet's 200–399 success range — so it looked correct. But a Kubernetes httpGet probe **follows redirects**, and that one is *relative* and loops:

```
Readiness probe failed: Get "./": stopped after 10 redirects
```

…and the rollout timed out. Reading only the first response is what made it look fine. `/geoserver/index.html` answers 200 directly.

## Verified after the fix

16/16 in `ingress-test.sh`, both browser rounds against the live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE