### PR TITLE
fix(k8s): set the container security options that do not need image changes

### DIFF
--- a/deploy/k8s/base/angular-deployment.yaml
+++ b/deploy/k8s/base/angular-deployment.yaml
@@ -36,6 +36,19 @@ spec:
               port: 80
             initialDelaySeconds: 5
             periodSeconds: 15
+          # The safe subset only. All three images run as uid 0 — measured, not assumed — so
+          # runAsNonRoot would break every one of them and readOnlyRootFilesystem would break
+          # nginx's cache dir, GeoServer's data dir and the calculator's /app/data. Those need
+          # image changes, not a manifest change, and are deliberately not attempted here.
+          #
+          # These two do not: allowPrivilegeEscalation stops a setuid binary gaining privileges
+          # the container did not start with, and RuntimeDefault applies the container runtime's
+          # seccomp filter. Verified on a live cluster — all three roll out, 16/16 in
+          # ingress-test.sh, and both browser rounds pass.
+          securityContext:
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
           resources:
             limits:
               cpu: "1"

--- a/deploy/k8s/base/calculation-deployment.yaml
+++ b/deploy/k8s/base/calculation-deployment.yaml
@@ -71,6 +71,19 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
             failureThreshold: 12
+          # The safe subset only. All three images run as uid 0 — measured, not assumed — so
+          # runAsNonRoot would break every one of them and readOnlyRootFilesystem would break
+          # nginx's cache dir, GeoServer's data dir and the calculator's /app/data. Those need
+          # image changes, not a manifest change, and are deliberately not attempted here.
+          #
+          # These two do not: allowPrivilegeEscalation stops a setuid binary gaining privileges
+          # the container did not start with, and RuntimeDefault applies the container runtime's
+          # seccomp filter. Verified on a live cluster — all three roll out, 16/16 in
+          # ingress-test.sh, and both browser rounds pass.
+          securityContext:
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
           resources:
             limits:
               cpu: "2"

--- a/deploy/k8s/base/geoserver-deployment.yaml
+++ b/deploy/k8s/base/geoserver-deployment.yaml
@@ -63,6 +63,19 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 10
             failureThreshold: 30
+          # The safe subset only. All three images run as uid 0 — measured, not assumed — so
+          # runAsNonRoot would break every one of them and readOnlyRootFilesystem would break
+          # nginx's cache dir, GeoServer's data dir and the calculator's /app/data. Those need
+          # image changes, not a manifest change, and are deliberately not attempted here.
+          #
+          # These two do not: allowPrivilegeEscalation stops a setuid binary gaining privileges
+          # the container did not start with, and RuntimeDefault applies the container runtime's
+          # seccomp filter. Verified on a live cluster — all three roll out, 16/16 in
+          # ingress-test.sh, and both browser rounds pass.
+          securityContext:
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
           resources:
             limits:
               cpu: "1"

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -371,6 +371,25 @@ Readiness probes — *added 2026-07-31*
    the first attempt failed with *"stopped after 10 redirects"* and timed the rollout out.
    ``/geoserver/index.html`` answers 200 directly.
 
+Container security context — *added 2026-07-31*, partial on purpose
+   All three containers now set ``allowPrivilegeEscalation: false`` and
+   ``seccompProfile: RuntimeDefault``. Verified on a live cluster: all three roll out, 16/16 in
+   :file:`deploy/k8s/ingress-test.sh`, both browser rounds pass.
+
+   ``runAsNonRoot`` and ``readOnlyRootFilesystem`` are deliberately **not** set. All three
+   images run as uid 0 — measured, not assumed:
+
+   .. code-block:: text
+
+      localhost:5001/esgame:local               runs as uid 0
+      localhost:5001/esgame-calculation:local   runs as uid 0
+      docker.osgeo.org/geoserver:2.28.4         runs as uid 0
+
+   so ``runAsNonRoot`` would break every one of them, and a read-only root filesystem would
+   break nginx's cache directory, GeoServer's data directory and the calculator's
+   :file:`/app/data`. Those need changes to the images — one of which is upstream — rather than
+   to a manifest, so a deployment that needs them should expect image work.
+
 No default IngressClass is assumed
    The three Ingresses set no ``ingressClassName``. If the cluster has no default
    ``IngressClass`` they apply cleanly and route nothing, with no error. Check


### PR DESCRIPTION
None of the three deployments set a `securityContext` at all. Two options can be set **today**, without touching the images:

```yaml
securityContext:
  allowPrivilegeEscalation: false
  seccompProfile:
    type: RuntimeDefault
```

## Verified on a live cluster, not rendered and assumed

Applied to the running deployments first — all three rolled out, 16/16 in `ingress-test.sh`, both browser rounds passed. Then committed to the manifests and the whole thing re-deployed and re-run from them.

## What is deliberately NOT set, and why

`runAsNonRoot` and `readOnlyRootFilesystem`. The evidence says they'd break the stack — all three images run as uid 0, measured:

```
localhost:5001/esgame:local               uid 0
localhost:5001/esgame-calculation:local   uid 0
docker.osgeo.org/geoserver:2.28.4         uid 0
```

…and a read-only root filesystem would break nginx's cache directory, GeoServer's data directory and the calculator's `/app/data`.

Those need **image** changes — one of the images is upstream — not a manifest change. Setting the field and letting deployments discover the breakage would be worse than saying so, which is why `docs/verification-status.rst` records this as partial on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE