### PR TITLE
fix(ui): "custom" is a gradient marker, not a mistake

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -29,7 +29,7 @@ Verified working
    * - Path
      - How it was checked
    * - Static / grid game
-     - 374 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
+     - 378 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
        SEO 100. The board renders 2,436 fields; the e2e suite asserts that rather than
        just asserting the component mounted.
    * - No external runtime deps

--- a/v2/src/app/shared/models/settings.shipped-data.spec.ts
+++ b/v2/src/app/shared/models/settings.shipped-data.spec.ts
@@ -1,0 +1,51 @@
+import { Settings } from './settings';
+import dataJson from '../../../assets/data.json';
+import dataGridExampleJson from '../../../assets/dataGridExample.json';
+
+// The guards added on 2026-07-31 all report problems in a deployment's data file. Nothing loaded
+// THIS repository's own data files through them — so the first one to fire did so on a correct
+// configuration, and only because I happened to open the running game and read the console:
+//
+//   The game data asks for gradient "custom", which does not exist. Falling back to blue.
+//
+// "custom" is the marker a map uses to say its colours come from customColorId. A guard that
+// cries wolf on the shipped data is worse than no guard: it teaches people to ignore the ones
+// that matter.
+
+const translateStub = (langs: string[] = ['en']): any => ({
+	getLangs: () => langs,
+	setTranslation: () => { },
+});
+
+// Imported rather than hand-copied, so this tracks the real files.
+
+const dataFiles: [string, any][] = [
+	['data.json', dataJson],
+	['dataGridExample.json', dataGridExampleJson],
+];
+
+describe('the data files shipped in this repository', () => {
+	let errors: string[];
+	beforeEach(() => {
+		errors = [];
+		vi.spyOn(console, 'error').mockImplementation((...a: any[]) => { errors.push(a.map(String).join(' ')); });
+	});
+	afterEach(() => vi.restoreAllMocks());
+
+	for (const [name, data] of dataFiles) {
+		it(`${name} loads without a single complaint`, () => {
+			expect(() => new Settings(translateStub(), JSON.parse(JSON.stringify(data)))).not.toThrow();
+			expect(errors).toEqual([]);
+		});
+
+		it(`${name} keeps every map's gradient marker intact`, () => {
+			const s = new Settings(translateStub(), JSON.parse(JSON.stringify(data)));
+
+			// A map written `custom` must stay `custom` — defaulting it to a real gradient would
+			// make a custom-coloured map look like it asked for one.
+			data.maps.forEach((m: any, i: number) => {
+				if (m.gradient) expect(s.maps[i].gradient).toBe(m.gradient);
+			});
+		});
+	}
+});

--- a/v2/src/app/shared/models/settings.ts
+++ b/v2/src/app/shared/models/settings.ts
@@ -179,9 +179,24 @@ const convertGameBoardType = (type: string) => {
 	}
 };
 
+/**
+ * "custom" is not a gradient and not a mistake: it is the marker a map uses to say its colours
+ * come from `customColorId` instead. src/assets/data.json's Background map is written that way,
+ * and getSvgBackground passes `undefined` for the gradient and the CustomColors separately, so
+ * nothing ever looks it up.
+ *
+ * Reporting it was a false alarm on the game's own shipped data — every load of the dynamic
+ * game logged an error about a correct configuration. A guard that cries wolf on the common
+ * case is worse than no guard, because it teaches people to ignore the ones that matter.
+ */
+const CUSTOM_COLOURS_MARKER = 'custom';
+
 const convertGradient = (gradientName: string) => {
 	const known = Object.values(DefaultGradients) as string[];
 	if (known.includes(gradientName)) return gradientName as DefaultGradients;
+	// Passed through unchanged, not defaulted: a map marked `custom` must NOT end up looking
+	// like it asked for blue.
+	if (gradientName === CUSTOM_COLOURS_MARKER) return gradientName as unknown as DefaultGradients;
 	// An absent gradient is normal — a map may use customColors instead — so only a value that
 	// was given and is wrong is worth reporting.
 	if (gradientName !== undefined && gradientName !== null && gradientName !== '') {


### PR DESCRIPTION
The gradient guard added in #154 fired on **this repository's own shipped data**. Every load of the dynamic game logged:

```
The game data asks for gradient "custom", which does not exist. Known gradients: blue,
green, orange, purple, red, yellow (lower case). Falling back to blue.
```

`"custom"` is the marker a map uses to say its colours come from `customColorId` instead. `src/assets/data.json`'s Background map is written that way, and `getSvgBackground` passes `undefined` for the gradient and the `CustomColors` separately — nothing ever looks it up.

**The configuration was correct and the guard was wrong.**

## Two problems, not one

1. The message is noise on the common case. A guard that cries wolf teaches people to ignore the ones that matter — and I added nine such guards today.
2. #154's fallback returned **Blue**, so a map saying *"use my custom colours"* came out looking like it had asked for a gradient. It's now passed through unchanged.

## Found by looking, not by testing

I opened the running game and read the browser console. **The whole suite passed with the bug in it** — because nothing ever loaded *this* repository's data files through the guards written to check a *deployment's*.

That gap is the more useful half of this change:

```ts
// settings.shipped-data.spec.ts
it(`${name} loads without a single complaint`, ...)
it(`${name} keeps every map's gradient marker intact`, ...)
```

## Verified

- mutation: with the marker recognition removed, both `data.json` specs fail while `dataGridExample.json` — which has no custom marker — passes throughout
- measured where it was found, in a real browser against the cluster: **`PAGE ERRORS: none`**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE