### PR TITLE
fix(k8s): the calculation Ingress cut every long round off at 60 seconds

### DIFF
--- a/deploy/k8s/base/calculation-ingress.yaml
+++ b/deploy/k8s/base/calculation-ingress.yaml
@@ -9,6 +9,19 @@ metadata:
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
     # The browser posts here cross-origin, so CORS must allow the frontend origin.
     nginx.ingress.kubernetes.io/enable-cors: "true"
+    # A round is a long-running computation, not a web request. ingress-nginx defaults
+    # proxy_read_timeout and proxy_send_timeout to 60s, and one POST /esgame with real geodata
+    # takes longer than that — measured at 60-75s in the PLACES stack. The calculator finishes,
+    # publishes every coverage to GeoServer and builds the URLs, and the client gets
+    #
+    #   504 Gateway Time-out ... <center>nginx</center>
+    #
+    # so the work is done and thrown away, and the log shows a completely successful round. Only
+    # a real ingress in front of a real round finds this: the compose stacks publish host ports
+    # with no proxy, and esgame's own committed raster makes rounds fast enough (~26s) to stay
+    # under the default.
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "900"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "900"
 spec:
   # An Ingress with no ingressClassName is only picked up if the cluster has an
   # IngressClass marked as default. Without one, this Ingress is silently ignored —

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -347,6 +347,26 @@ The committed base raster makes the game inert
    browser sends the ids the board actually uses.
    See :ref:`allocation-id-space`.
 
+The calculation Ingress had a 60-second timeout — *fixed 2026-07-31*
+   ingress-nginx defaults ``proxy_read_timeout`` and ``proxy_send_timeout`` to 60 seconds, and
+   the base set neither. A round is a long-running computation, not a web request: one
+   ``POST /esgame`` against real geodata takes 60-75 seconds, measured.
+
+   What the client got was
+
+   .. code-block:: text
+
+      504 Gateway Time-out ... <center>nginx</center>
+
+   while the calculator finished the round, published all six coverages to GeoServer and built
+   every URL. The work was done and thrown away, and the calculation log showed a completely
+   successful round — the failure was visible only to the client.
+
+   Only a real ingress in front of a real round finds this. The compose stacks publish host
+   ports with no proxy in the way, and esgame's own committed raster makes rounds fast enough
+   (~26s) to stay under the default, so it was PLACES that hit it: 62-66s, 504 every time.
+   With the annotations, the same round returns six real scores and 6/6 fetchable coverages.
+
 Readiness probes — *added 2026-07-31*
    ``esgame-calculation`` and ``esgame-geoserver`` had none, so Kubernetes called a pod ready
    the instant its container started and the Service routed to it while plumber was still


### PR DESCRIPTION
ingress-nginx defaults `proxy_read_timeout` and `proxy_send_timeout` to **60s**, and the base set neither. A round is a long-running computation, not a web request: one `POST /esgame` against real geodata takes **60–75 seconds**.

The client got:

```
504 Gateway Time-out ... <center>nginx</center>
```

…while the calculator **finished the round**, published all six coverages to GeoServer and constructed every URL. The work was done and thrown away, and the calculation log showed a completely successful round. The failure existed only on the client side.

## Why nothing caught it

| | why it couldn't see this |
|---|---|
| `test/stack.sh` (both repos) | compose publishes host ports — no proxy in the way |
| esgame's `ingress-test.sh` | esgame's committed raster makes rounds ~26s, under the default |

It was **PLACES** — whose raster is the real data release — that hit it, at 62–66s, while I was building its first ingress test.

## Measured both ways, same cluster, same payload

```
without the annotations   504 Gateway Time-out
with them                 66s, six real scores, 6/6 coverages fetchable
```

900s rather than something tighter, because the ceiling should mean *"this round is never coming back"*, not *"this round is slower than the one I measured"*.

esgame is unaffected and re-verified: 16/16 in `ingress-test.sh`, both browser rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE