### PR TITLE
docs: record the width the layout actually needs

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -410,6 +410,29 @@ Container security context — *added 2026-07-31*, partial on purpose
    :file:`/app/data`. Those need changes to the images — one of which is upstream — rather than
    to a manifest, so a deployment that needs them should expect image work.
 
+The layout needs about 620px, and scrolls sideways below that
+   Measured against the live cluster at four widths, on ``/dynamic-game``:
+
+   .. code-block:: text
+
+      phone          390px viewport | content 619px | overflow 229px | 3/6 production buttons clipped | Next Level clipped
+      small tablet   600px viewport | content 619px | overflow  19px | 0/6 clipped                    | Next Level visible
+      iPad           768px viewport | content 768px | overflow   0px | 0/6 clipped                    | Next Level visible
+      laptop        1024px viewport | content 1024px| overflow   0px | 0/6 clipped                    | Next Level visible
+
+   Nothing is unreachable. ``tro-svg-level`` sets ``overflow: auto``, so on a phone the content
+   scrolls horizontally and every control can be scrolled to — confirmed by clicking *Next
+   Level* at 390px, which succeeds once the browser scrolls it into view. It is the document
+   that does not scroll (``scrollWidth == clientWidth``), which is easy to mistake for the
+   button being clipped away entirely; it is the component that scrolls, not the page.
+
+   But a player on a phone has to discover that sideways scroll to advance a level, and three of
+   the six production types are off-screen until they do. Whether that matters is a product
+   decision — this is a 466-hexagon board built for workshops — so it is recorded rather than
+   redesigned. The three panels are ``flex: 0 1 25% / 0 0 50% / 0 1 25%``
+   (:file:`v2/src/app/level/level-base.component.scss`); making it reflow below ~620px means
+   choosing what the narrow layout should look like, not adjusting a number.
+
 No default IngressClass is assumed
    The three Ingresses set no ``ingressClassName``. If the cluster has no default
    ``IngressClass`` they apply cleanly and route nothing, with no error. Check


### PR DESCRIPTION
Measured on the live cluster at four viewport widths, on `/dynamic-game`:

```
phone          390px | content 619px | overflow 229px | 3/6 production buttons clipped | Next Level clipped
small tablet   600px | content 619px | overflow  19px | 0/6 clipped                    | Next Level visible
iPad           768px | content 768px | overflow   0px | 0/6 clipped                    | Next Level visible
laptop        1024px | content 1024px| overflow   0px | 0/6 clipped                    | Next Level visible
```

## Nothing is unreachable — and getting that right took a second measurement

The **document** doesn't scroll (`scrollWidth == clientWidth`), which reads exactly like the button being clipped away. The element that scrolls is `tro-svg-level`, which sets `overflow: auto` — so every control can be scrolled to, and clicking *Next Level* at 390px succeeds once the browser scrolls it into view.

My first reading was wrong, and the screenshot supported the wrong reading. The honest statement is weaker than "the button is unreachable".

## What is true

A player on a phone has to discover a sideways scroll to advance a level, with three of six production types off-screen until they do.

## Recorded, not redesigned

The three panels are `flex: 0 1 25% / 0 0 50% / 0 1 25%`. Making this reflow below ~620px means **deciding what the narrow layout should be** — for a 466-hexagon board built for workshops — not adjusting a number. That's a product decision, and there's no signal here about whether phones are a target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE