### PR TITLE
fix(test): "index.html is really the app" passed on nginx's 404 page

### DIFF
--- a/deploy/k8s/ingress-test.sh
+++ b/deploy/k8s/ingress-test.sh
@@ -46,7 +46,11 @@ check "esgame.local serves the app"        "[ \"\$(code esgame.local /)\" = 200 
 # so the check failed precisely BECAUSE the pattern matched. Whether it bites depends on whether
 # curl finishes writing before grep exits, which is why it looked intermittent.
 body=$(ing esgame.local / || true)
-check "index.html is really the app"       "grep -qi '<app-root\|<title' <<<\"\${body}\""
+# `<app-root` only. The pattern used to be '<app-root\|<title', and ingress-nginx's own 404
+# page is "<html><head><title>404 Not Found</title>...", so the <title> alternative matched it:
+# with nothing serving esgame.local at all, this check reported the app was really being served.
+# Found by running the whole script against a deleted deployment.
+check "index.html is really the app"       "grep -qi '<app-root' <<<\"\${body}\""
 check "assets/config.json served"          "[ \"\$(code esgame.local /assets/config.json)\" = 200 ]"
 # The premise of the whole deployment: one image, retargeted by env var at container start.
 want=$("${K[@]}" get cm esgame-config -o jsonpath='{.data.CALC_URL}' 2>/dev/null || true)

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -452,7 +452,26 @@ The checks were audited for vacuity
 -----------------------------------
 
 A check that cannot fail is worse than no check: it reports success and stops anyone
-looking. On 2026-07-30 every check added that day was re-read for that shape — an
+looking.
+
+**2026-07-31, found by running a whole suite against a deleted deployment rather than one check
+against a missing file.** Two more of this shape, one in each repository:
+
+.. code-block:: text
+
+   grep -qi '<app-root\|<title'   ingress-nginx's 404 page is
+                                  "<html><head><title>404 Not Found</title>..." — the <title>
+                                  alternative matched it, so with NOTHING serving the host the
+                                  check reported the app was really being served
+   [ -n "$res" ]                  with nothing serving, the POST returns 145 bytes of nginx 404
+                                  HTML, which is very much "something"
+
+Both now require what only the real thing produces: ``<app-root``, and a response that parses as
+JSON with a non-empty results list. An earlier attempt at this test measured nothing — pointing
+the namespace variable at an empty namespace redirects the ``kubectl`` checks but not the HTTP
+ones, because ingress hosts are cluster-wide, so seven checks appeared to "pass on nothing"
+while in fact passing on the still-running real deployment. Deleting it is the only version of
+the test that means anything. On 2026-07-30 every check added that day was re-read for that shape — an
 assertion that also holds when the thing being examined is absent — and **seven were
 found, all written the same day**. Six in the first pass; the seventh turned up afterwards
 in :file:`deploy/k8s/ingress-test.sh`, which the first pass had skipped because the inotify


### PR DESCRIPTION
The pattern was `'<app-root\|<title'`, and ingress-nginx's own 404 page is:

```html
<html><head><title>404 Not Found</title></head>...
```

The `<title>` alternative matched it — so with **nothing serving `esgame.local` at all**, this check reported that the app really was being served.

## How it was found

By running the whole suite against a **deleted deployment** — the standing *"check it against an absent subject"* rule applied to the script rather than to one check at a time.

The same pattern was in places' new `ingress-test.sh`, fixed there too, along with a second one: `[ -n "$res" ]` for *"round returns something"*, which passed on 145 bytes of nginx 404 HTML. It now requires a response that parses as JSON with a non-empty `results` list.

## An earlier attempt at that test measured nothing

Pointing `PLACES_NAMESPACE` at an empty namespace redirects the `kubectl` checks but **not** the HTTP ones — ingress hosts are cluster-wide, so those kept hitting the real deployment. Seven checks appeared to "pass on nothing" while in fact passing on something. Deleting the namespace is the only version of the test that means anything.

## Verified

| | |
|---|---|
| `esgame-angular` scaled to zero | the check **fails** |
| restored | 16/16, 455 ids, 5 scores, 5/5 coverages |

Recorded in the vacuity section of `docs/verification-status.rst`, where the previous nine of this shape are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE