### PR TITLE
fix(k8s): the calculation container runs as a non-root user

### DIFF
--- a/deploy/k8s/base/calculation-deployment.yaml
+++ b/deploy/k8s/base/calculation-deployment.yaml
@@ -21,6 +21,13 @@ spec:
       volumes:
         - name: app-data
           emptyDir: {}
+      securityContext:
+        # /app/data is a mount, so its ownership comes from the volume, not the image.
+        # calculator.r does setwd() there and writes seven rasters plus the spider plot, and a
+        # bare emptyDir is created root-owned — the calculation would start and then fail on its
+        # first write. fsGroup 0 matches the image's `useradd --gid 0` and makes the kubelet set
+        # group ownership on the volume.
+        fsGroup: 0
       containers:
         - name: esgame-calculation
           image: esgame-calculation # rewritten by kustomization.yaml images:
@@ -84,6 +91,17 @@ spec:
             allowPrivilegeEscalation: false
             seccompProfile:
               type: RuntimeDefault
+            # tools/R/Dockerfile now runs as uid 10001. runAsNonRoot is the assertion the
+            # kubelet enforces at admission — it does not change the user, it refuses to start a
+            # container whose image resolves to uid 0, so it only means anything once the image
+            # cooperates. runAsUser repeats the number so the manifest is explicit rather than
+            # relying on whatever the image happens to say.
+            #
+            # Only this container. The frontend binds :80 and would need CAP_NET_BIND_SERVICE or
+            # a different base image; GeoServer is upstream. Both measured as uid 0 and left
+            # alone deliberately — see docs/verification-status.rst.
+            runAsNonRoot: true
+            runAsUser: 10001
           resources:
             limits:
               cpu: "2"

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -396,19 +396,33 @@ Container security context — *added 2026-07-31*, partial on purpose
    ``seccompProfile: RuntimeDefault``. Verified on a live cluster: all three roll out, 16/16 in
    :file:`deploy/k8s/ingress-test.sh`, both browser rounds pass.
 
-   ``runAsNonRoot`` and ``readOnlyRootFilesystem`` are deliberately **not** set. All three
-   images run as uid 0 — measured, not assumed:
+   **The calculation container now runs as uid 10001** (*2026-07-31*). It was the tractable one
+   of the three: it listens on 8000, above the privileged range, so nothing needs
+   ``CAP_NET_BIND_SERVICE``, and the only path it writes is ``/app/data`` — a mount, so its
+   ownership comes from ``fsGroup`` rather than from the image. ``tools/R/Dockerfile`` adds the
+   user; the Deployment asserts ``runAsNonRoot`` with ``runAsUser: 10001``, which is what the
+   kubelet enforces at admission.
+
+   Verified on both consumers, including the paths that would have failed silently: an esgame
+   round and both browser specs; a PLACES round through its ingress with a **PVC** rather than
+   an emptyDir; and PLACES' ``load-geodata`` init container on its **fetch** path — the first
+   attempt took the "geodata already present" branch and never ran ``apk add curl``, which is
+   the step that needs root. The init container has no ``securityContext`` of its own, so it
+   still runs as root and that step still works.
+
+   ``runAsNonRoot`` for the other two, and ``readOnlyRootFilesystem`` anywhere, are deliberately
+   **not** set. Both remaining images run as uid 0 — measured, not assumed:
 
    .. code-block:: text
 
-      localhost:5001/esgame:local               runs as uid 0
-      localhost:5001/esgame-calculation:local   runs as uid 0
-      docker.osgeo.org/geoserver:2.28.4         runs as uid 0
+      localhost:5001/esgame:local               runs as uid 0   binds :80, needs a different base image
+      docker.osgeo.org/geoserver:2.28.4         runs as uid 0   upstream
 
-   so ``runAsNonRoot`` would break every one of them, and a read-only root filesystem would
-   break nginx's cache directory, GeoServer's data directory and the calculator's
-   :file:`/app/data`. Those need changes to the images — one of which is upstream — rather than
-   to a manifest, so a deployment that needs them should expect image work.
+   The frontend binds :80, which a non-root process cannot do without ``CAP_NET_BIND_SERVICE``,
+   so it needs an unprivileged base image and a port move that carries the Service ``targetPort``
+   and the readiness probe with it. GeoServer is upstream. A read-only root filesystem would
+   additionally break nginx's cache directory and GeoServer's data directory. Those are image
+   changes, not manifest changes, so a deployment that needs them should expect image work.
 
 The layout needs about 620px, and scrolls sideways below that
    Measured against the live cluster at four widths, on ``/dynamic-game``:

--- a/tools/R/Dockerfile
+++ b/tools/R/Dockerfile
@@ -79,6 +79,23 @@ WORKDIR /app
 
 COPY . .
 
+# Run as a normal user, so the Deployment can set runAsNonRoot and the kubelet can enforce it.
+#
+# Two things make this container the tractable one of the three. It listens on 8000, above the
+# privileged range, so nothing needs CAP_NET_BIND_SERVICE to bind. And the only path it writes
+# is /app/data — calculator.r does setwd() there and writes seven rasters plus the spider plot —
+# which is an emptyDir in the base and a PVC in the places overlay, so it is a mount, not image
+# content: the directory has to exist and be owned here, and the volume inherits that ownership
+# via fsGroup.
+#
+# 10001 rather than a name so the manifests can assert runAsUser numerically. A named user alone
+# would leave runAsNonRoot unable to tell what the image resolves to in some runtimes.
+RUN useradd --system --uid 10001 --gid 0 --no-create-home --shell /usr/sbin/nologin esgame \
+ && mkdir -p /app/data \
+ && chown -R 10001:0 /app \
+ && chmod -R g=u /app
+USER 10001
+
 EXPOSE 8000
 
 CMD ["/app/calculator.r"]


### PR DESCRIPTION
The tractable one of the three: it listens on **8000** (above the privileged range, so no `CAP_NET_BIND_SERVICE`), and the only path it writes is `/app/data` — a **mount**, so ownership comes from `fsGroup`, not from the image.

`tools/R/Dockerfile` adds uid 10001 and owns `/app`. The Deployment asserts:

```yaml
securityContext:          # pod
  fsGroup: 0
securityContext:          # container
  runAsNonRoot: true
  runAsUser: 10001
```

`runAsNonRoot` changes nothing by itself — it's the assertion the kubelet enforces at admission, refusing to start a container whose image resolves to uid 0. It only means anything once the image cooperates. `fsGroup: 0` matches the image's `--gid 0`; without it the calculation starts and then fails on its first `writeRaster`.

## Verified on both consumers, not just esgame

places pulls this base at `?ref=master` and inherits it automatically:

| | |
|---|---|
| esgame | 16/16 ingress checks, both browser rounds, pod `uid=10001 gid=0` |
| places | 465 ids, 6 scores, 6/6 coverages through its ingress — with a **PVC**, not an emptyDir |

## The path that would have broken silently took two attempts to test

places' `load-geodata` init container runs `apk add curl`, which needs root. My first run took its *"geodata already present in /data; nothing to fetch"* branch and **never reached that step**. Emptying the volume forced the real fetch: the init container has no `securityContext` of its own, so it still runs as root and still works.

## One of my own checks lied first

My readiness loop reported success on the first *failure*: `$(curl -w '%{http_code}' ... || echo 000)` — curl prints `000` **and** exits non-zero, so the value became `"000000"`, which isn't equal to `"000"`.

## Still deliberately untouched

The frontend (binds `:80`, needs an unprivileged base plus a port move carrying the Service `targetPort` and readiness probe) and GeoServer (upstream). Both measured as uid 0; recorded in `docs/verification-status.rst`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCgmjnnNFUjfJdusJQg2uE