### PR TITLE
fix(image): the frontend runs as a non-root user

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -46,3 +46,58 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: The published image must actually serve the app
+        # This workflow used to stop at the push, which proves bytes were uploaded and nothing
+        # more — the calculation image's workflow has probed its own artefact since #155 and this
+        # one did not. Every failure mode below is one a build can pass through green:
+        #
+        #   * the runtime stage runs as root again      -> the kubelet refuses the pod at
+        #     admission (runAsNonRoot), on a cluster, nowhere near the change
+        #   * the listen port and EXPOSE drift apart    -> the Service's targetPort points at
+        #     nothing and the readiness probe never passes
+        #   * CALC_URL injection cannot write           -> the entrypoint exits and takes the
+        #     container with it, but ONLY when CALC_URL is set, which is why it is set here.
+        #     A probe without it never touches the write path at all.
+        run: |
+          set -euo pipefail
+          tag=$(printf '%s\n' '${{ steps.meta.outputs.tags }}' | head -1)
+          echo "probing ${tag}"
+          docker run -d --name esgame -p 8080:8080 -e CALC_URL=http://calc.example:8000 "${tag}"
+
+          for i in $(seq 1 30); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8080/ || true)
+            if [ "${code}" != 000 ]; then ok=1; echo "answered ${code} after ${i} attempts"; break; fi
+            sleep 2
+          done
+          if [ "${ok:-0}" != 1 ]; then
+            echo "::error::the published image never served on :8080"
+            docker logs esgame || true
+            exit 1
+          fi
+
+          # Not "some uid that isn't 0" — the number the Deployment asserts with runAsUser.
+          uid=$(docker exec esgame id -u)
+          echo "runs as uid ${uid}"
+          if [ "${uid}" != 101 ]; then
+            echo "::error::image runs as uid ${uid}; deploy/k8s/base/angular-deployment.yaml pins runAsUser: 101"
+            exit 1
+          fi
+
+          # 200 is not enough: nginx answers its own 404 page with one. Require the app.
+          curl -sf http://127.0.0.1:8080/ -o index.html
+          if ! grep -q '<app-root' index.html; then
+            echo "::error::served something on :8080, but it is not the app"
+            head -c 400 index.html; exit 1
+          fi
+
+          # The entrypoint rewrote this, as uid 101, in a directory it had to own.
+          got=$(curl -sf http://127.0.0.1:8080/assets/config.json | tr -d ' \n\t' | grep -o '"calcUrl":"[^"]*"')
+          echo "config.json -> ${got}"
+          if [ "${got}" != '"calcUrl":"http://calc.example:8000"' ]; then
+            echo "::error::CALC_URL was not injected into assets/config.json"
+            docker logs esgame || true
+            exit 1
+          fi
+          docker rm -f esgame >/dev/null
+          echo "published image serves the app on :8080 as uid ${uid}, with CALC_URL applied"

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -222,9 +222,9 @@ The shared image
 * **Build stage** — ``node:26-alpine``; ``npm ci`` from the lockfile, then
   ``npm run build -- --base-href / --configuration production``. The image serves from
   the domain root; a reverse proxy maps host/path to the container.
-* **Runtime stage** — ``nginx:alpine`` serving ``dist/tradeoff-v2/`` from
-  :file:`/usr/share/nginx/html`, with the tuned :file:`nginx.conf` and the config
-  entrypoint installed into :file:`/docker-entrypoint.d/`.
+* **Runtime stage** — ``nginxinc/nginx-unprivileged:alpine`` serving ``dist/tradeoff-v2/``
+  from :file:`/usr/share/nginx/html` on port 8080 as uid 101, with the tuned
+  :file:`nginx.conf` and the config entrypoint installed into :file:`/docker-entrypoint.d/`.
 
 This image is the single artifact that all three deployment shapes consume.
 
@@ -258,7 +258,7 @@ defines four services:
      - Port
      - Role
    * - ``frontend``
-     - ``81:80``
+     - ``81:8080``
      - A thin overlay built ``FROM`` the esgame image
        (``ESGAME_IMAGE``, default ``ghcr.io/mlacayoemery/esgame:master``), adding this
        example's SVG ``data.json`` (a generated 28×29 zone map + background).

--- a/docs/data-flow.rst
+++ b/docs/data-flow.rst
@@ -122,7 +122,7 @@ Example :file:`assets/config.json` (the dynamic example,
 ``CALC_URL`` injection (entrypoint)
 -----------------------------------
 
-:file:`v2/docker-entrypoint.sh` runs (as root) via nginx's
+:file:`v2/docker-entrypoint.sh` runs (as uid 101 — the image is unprivileged) via nginx's
 ``/docker-entrypoint.d/`` hook before nginx starts. If
 :file:`/usr/share/nginx/html/assets/config.json` exists **and** the environment
 variable ``CALC_URL`` is set (``-n "${CALC_URL+x}"``, so even an empty string counts),
@@ -605,7 +605,7 @@ Source: :file:`examples/esgame-dynamic/docker-compose.yml`
    * - ``frontend``
      - built from ``./frontend`` (``ESGAME_IMAGE``, default
        ``ghcr.io/mlacayoemery/esgame:master``)
-     - ``81:80``
+     - ``81:8080``
      - Bind-mounts ``./frontend/config.json`` →
        ``/usr/share/nginx/html/assets/config.json:ro``. ``depends_on: [calculator]``.
    * - ``calculator``

--- a/docs/dependency-review.rst
+++ b/docs/dependency-review.rst
@@ -131,8 +131,13 @@ rule but means two builds a month apart are not the same build.
    * - ``geopython/pygeoapi:latest``
      - Same shape. The pygeoapi example is read-only and config-driven, so drift
        shows up as a startup failure rather than silent misbehaviour.
-   * - ``nginx:alpine``
-     - Low risk; the runtime stage only serves static files.
+   * - ``nginxinc/nginx-unprivileged:alpine``
+     - Low risk; the runtime stage only serves static files. The same nginx build as
+       ``nginx:alpine`` (1.31.3 at review time) from the nginx project's own Docker Hub
+       org, packaged to run as uid 101 — which is what lets the Deployment assert
+       ``runAsNonRoot``. Both tags are rolling, so a base-image regression to uid 0 would
+       arrive without a code change here; the probe in
+       :file:`.github/workflows/image.yml` fails the publish if it does.
    * - :file:`docs/requirements.txt` (``sphinx>=7``, ``furo``, ``myst-parser``)
      - Fully unpinned, so docs builds always take the newest Sphinx (9.1.0 at
        review time). Good for freshness, and a Sphinx major could break the build

--- a/docs/guides/builder.rst
+++ b/docs/guides/builder.rst
@@ -216,15 +216,17 @@ Runtime stage
 
 .. code-block:: dockerfile
 
-   FROM nginx:alpine
+   FROM nginxinc/nginx-unprivileged:alpine
    COPY nginx.conf /etc/nginx/conf.d/default.conf
-   COPY --from=build /app/dist/tradeoff-v2/ /usr/share/nginx/html
-   COPY docker-entrypoint.sh /docker-entrypoint.d/40-esgame-config.sh
+   COPY --from=build --chown=101:101 /app/dist/tradeoff-v2/ /usr/share/nginx/html
+   COPY --chown=101:101 docker-entrypoint.sh /docker-entrypoint.d/40-esgame-config.sh
    RUN chmod +x /docker-entrypoint.d/40-esgame-config.sh
-   EXPOSE 80
+   EXPOSE 8080
 
 The build output is copied from the flat ``/app/dist/tradeoff-v2/`` directory into
-the nginx web root.
+the nginx web root. nginx runs as uid 101 here and listens on 8080; the ``--chown`` is what
+lets the entrypoint rewrite :file:`assets/config.json` in place. See
+:ref:`container-nonroot`.
 
 ``CALC_URL`` is runtime, not build
 ----------------------------------
@@ -502,7 +504,7 @@ same constraints are applied everywhere:
      - Angular 22 requires ``^22.22.3 || ^24.15.0 || >=26.0.0``. The image uses
        ``node:26-alpine``; CI and Pages both pin ``26.5.0``.
    * - Pinned image bases
-     - ``node:26-alpine``, ``nginx:alpine``, ``python:3.14-slim``, and
+     - ``node:26-alpine``, ``nginxinc/nginx-unprivileged:alpine``, ``python:3.14-slim``, and
        ``docker.osgeo.org/geoserver:2.28.4``; the example calculator pins
        ``fastapi==0.140.13`` and ``uvicorn[standard]==0.52.0``.
    * - Configuration-free build

--- a/docs/guides/deployer.rst
+++ b/docs/guides/deployer.rst
@@ -179,8 +179,9 @@ Path 2 — Single Docker container
 The production frontend image (built from :file:`esgame/v2/Dockerfile`) is a
 multi-stage build: it compiles the app with ``--base-href /`` (served from the
 domain root; a reverse proxy maps host/path to the container) and serves the
-output from ``nginx:alpine`` on port **80**. See :doc:`/reference/containers` for
-the full container reference.
+output from ``nginxinc/nginx-unprivileged:alpine`` on port **8080**, as uid 101. See
+:doc:`/reference/containers` for the full container reference — including why the port is 8080
+and not 80.
 
 Run the frontend
 ----------------
@@ -189,7 +190,7 @@ Pull or build the image, then run it. Assuming a published image:
 
 .. code-block:: console
 
-   $ docker run -d --name esgame -p 8080:80 ghcr.io/mlacayoemery/esgame:master
+   $ docker run -d --name esgame -p 8080:8080 ghcr.io/mlacayoemery/esgame:master
 
 The site is then reachable at ``http://localhost:8080/``. With no environment
 variables this serves the **grid** game (empty ``calcUrl``).
@@ -200,13 +201,13 @@ Pointing the frontend at a backend (``CALC_URL``)
 To run the **dynamic** mode you must inject a backend URL. The image's
 entrypoint :file:`esgame/v2/docker-entrypoint.sh` (installed as
 :file:`/docker-entrypoint.d/40-esgame-config.sh` and run by nginx's
-``/docker-entrypoint.d/`` hook as root before nginx starts) substitutes the
+``/docker-entrypoint.d/`` hook as uid 101 before nginx starts) substitutes the
 ``CALC_URL`` environment variable into ``calcUrl`` inside
 :file:`/usr/share/nginx/html/assets/config.json`:
 
 .. code-block:: console
 
-   $ docker run -d --name esgame -p 8080:80 \
+   $ docker run -d --name esgame -p 8080:8080 \
        -e CALC_URL=https://esgame-calculation.example.com \
        ghcr.io/mlacayoemery/esgame:master
 
@@ -289,7 +290,7 @@ make up the project ``esgame-dynamic-example``:
      - Host port
      - Role
    * - ``frontend``
-     - ``81:80``
+     - ``81:8080``
      - The esgame image ``+`` this example's SVG config and generated zone/
        background maps.
    * - ``calculator``

--- a/docs/reference/containers.rst
+++ b/docs/reference/containers.rst
@@ -58,17 +58,41 @@ Runtime stage
 
 .. code-block:: dockerfile
 
-   FROM nginx:alpine
+   FROM nginxinc/nginx-unprivileged:alpine
    COPY nginx.conf /etc/nginx/conf.d/default.conf
-   COPY --from=build /app/dist/tradeoff-v2/ /usr/share/nginx/html
-   COPY docker-entrypoint.sh /docker-entrypoint.d/40-esgame-config.sh
+   COPY --from=build --chown=101:101 /app/dist/tradeoff-v2/ /usr/share/nginx/html
+   COPY --chown=101:101 docker-entrypoint.sh /docker-entrypoint.d/40-esgame-config.sh
    RUN chmod +x /docker-entrypoint.d/40-esgame-config.sh
-   EXPOSE 80
+   EXPOSE 8080
 
-The runtime is plain ``nginx:alpine``. The tuned server config replaces the stock
-``default.conf``, the flat ``dist`` tree is copied into nginx's document root
-(:file:`/usr/share/nginx/html`), and the runtime-config script is installed as a
-``/docker-entrypoint.d`` hook (see :ref:`container-entrypoint`).
+The runtime is ``nginxinc/nginx-unprivileged:alpine`` — the same nginx build as
+``nginx:alpine`` (1.31.3 at time of writing), packaged to run as **uid 101** with its pid file
+and temp paths under :file:`/tmp`. The tuned server config replaces the stock ``default.conf``,
+the flat ``dist`` tree is copied into nginx's document root (:file:`/usr/share/nginx/html`), and
+the runtime-config script is installed as a ``/docker-entrypoint.d`` hook (see
+:ref:`container-entrypoint`).
+
+.. _container-nonroot:
+
+Why 8080, and why ``--chown``
+-----------------------------
+
+A non-root process cannot bind a port below 1024 without ``CAP_NET_BIND_SERVICE``, and handing
+that capability back would undo the point of running unprivileged — so the server listens on
+**8080**. Callers keep the port they already published: the Kubernetes Service still listens on
+80 and only its ``targetPort`` moved, and compose still maps host ``81``.
+
+``--chown=101:101`` on the ``dist`` copy is load-bearing, not tidiness. The entrypoint rewrites
+:file:`assets/config.json` **in place**, which needs write permission on the directory holding
+it. Without the flag the tree lands root-owned and the container exits 1 on start with
+``mv: can't rename '/tmp/tmp.XXXXXX': Permission denied`` — confirmed by mutation, by chowning
+the tree back to root in a derived image.
+
+That failure is loud, but it is also **conditional**: the entrypoint only rewrites the file when
+``CALC_URL`` is set. A backend-less deployment (GitHub Pages, the static compose stack) never
+takes that branch, so a regression here would leave those green and break only the deployments
+that configure a calculator. This is why the probe in :file:`.github/workflows/image.yml` sets
+``CALC_URL`` — a probe without one never touches the write path.
 
 Healthcheck
 -----------
@@ -76,7 +100,7 @@ Healthcheck
 .. code-block:: dockerfile
 
    HEALTHCHECK --interval=15s --timeout=3s --start-period=5s --retries=3 \
-     CMD wget -q -O /dev/null http://127.0.0.1/ || exit 1
+     CMD wget -q -O /dev/null http://127.0.0.1:8080/ || exit 1
 
 .. list-table:: Healthcheck parameters
    :header-rows: 1
@@ -98,7 +122,7 @@ Healthcheck
      - ``3``
      - Consecutive failures before the container is marked *unhealthy*.
 
-The probe deliberately uses ``http://127.0.0.1/`` rather than ``localhost`` so it does not
+The probe deliberately uses ``http://127.0.0.1:8080/`` rather than ``localhost`` so it does not
 resolve to IPv6 ``[::1]`` before nginx is reachable.
 
 
@@ -106,7 +130,7 @@ The nginx configuration
 =======================
 
 :file:`v2/nginx.conf` is installed as ``/etc/nginx/conf.d/default.conf``. It is a single
-``server`` block on port 80 (IPv4 and IPv6), with document root
+``server`` block on port 8080 (IPv4 and IPv6 — see :ref:`container-nonroot`), with document root
 :file:`/usr/share/nginx/html` and ``index index.html``.
 
 Compression
@@ -171,7 +195,8 @@ The runtime-config entrypoint hook
 
 :file:`v2/docker-entrypoint.sh` is installed into the image as
 ``/docker-entrypoint.d/40-esgame-config.sh``. The stock ``nginx`` entrypoint runs every
-executable script in ``/docker-entrypoint.d/`` (in lexical order, as root) **before** nginx
+executable script in ``/docker-entrypoint.d/`` (in lexical order, as uid 101 in this image)
+**before** nginx
 starts; the ``40-`` prefix slots this hook into that sequence.
 
 Its single job is to inject the calculation backend URL into the served
@@ -201,7 +226,7 @@ The exact mechanism:
      # '#' delimiter avoids clashing with the '/' in URLs.
      sed "s#\"calcUrl\"[[:space:]]*:[[:space:]]*\"[^\"]*\"#\"calcUrl\": \"${CALC_URL}\"#" "$CONFIG" > "$tmp"
      mv "$tmp" "$CONFIG"
-     # mktemp creates a 0600 root-owned file; restore world-read so the nginx worker can serve it.
+     # mktemp creates a 0600 file; restore world-read so the nginx worker can serve it.
      chmod 644 "$CONFIG"
      echo "[esgame] runtime config: calcUrl=\"${CALC_URL}\""
    fi
@@ -218,8 +243,9 @@ Step by step:
    whitespace around the colon.
 #. The edit is written to a ``mktemp`` file and then ``mv``-ed over the original (atomic
    replace).
-#. ``mktemp`` produces a ``0600`` root-owned file, so the hook explicitly ``chmod 644``\ s
-   the result; otherwise the unprivileged nginx worker could not read it.
+#. ``mktemp`` produces a ``0600`` file, so the hook explicitly ``chmod 644``\ s the result;
+   otherwise the nginx worker could not read it. The ``mv`` in the previous step is also what
+   needs the document root to be writable by uid 101 — see :ref:`container-nonroot`.
 #. A confirmation line is printed to the container log.
 
 Because ``calcUrl`` flows through ``ConfigService`` and ``getGameData()`` in the app, the
@@ -257,7 +283,7 @@ Services
      - depends_on
    * - ``frontend``
      - build ``./frontend`` (arg ``ESGAME_IMAGE``, default ``ghcr.io/mlacayoemery/esgame:master``) → ``esgame-dynamic-example-frontend``
-     - ``81:80``
+     - ``81:8080``
      - ``./frontend/config.json`` → :file:`/usr/share/nginx/html/assets/config.json` ``:ro``
      - ``calculator``
    * - ``calculator``
@@ -311,7 +337,7 @@ This file is **bind-mounted** read-only over the baked-in config so that ``calcU
 ``defaultMode``, ``gridLineWidth``, ``gridLineColor`` and ``highlightWidth`` can be tweaked
 without rebuilding the image. Because ``calcUrl`` is set here, the ``CALC_URL`` entrypoint
 injection (see :ref:`container-entrypoint`) is not exercised in this stack. Note the host
-port mapping is ``81:80``, so the frontend is reached at ``http://localhost:81/``.
+port mapping is ``81:8080``, so the frontend is reached at ``http://localhost:81/``.
 
 calculator
 ~~~~~~~~~~

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -418,7 +418,7 @@ Container security context — *added 2026-07-31*, *extended 2026-08-05*, still 
    process in the container is root, it serves the app, a missing ``.tif`` still 404s and an
    unknown route still falls back to the app.
 
-   The load-bearing part is not the port. The entrypoint rewrites :file:`assets/config.json`
+   The load-bearing part is not the port. The entrypoint rewrites ``assets/config.json``
    **in place** and now does so as uid 101, so the document root must be owned by that uid —
    ``COPY --chown=101:101`` in :file:`v2/Dockerfile`. **Confirmed by mutation**: a derived image
    with the tree chowned back to root exits 1 on start with

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -9,7 +9,7 @@ time precisely because nothing had ever run them, and the failures were silent �
 that logged ``done`` having registered nothing, an e2e suite passing against a board that
 never rendered, a schema check reporting 10/10 valid on manifests the API server rejected.
 
-Last updated: **2026-07-30**.
+Last updated: **2026-08-05**.
 
 .. note::
 
@@ -391,7 +391,7 @@ Readiness probes — *added 2026-07-31*
    the first attempt failed with *"stopped after 10 redirects"* and timed the rollout out.
    ``/geoserver/index.html`` answers 200 directly.
 
-Container security context — *added 2026-07-31*, partial on purpose
+Container security context — *added 2026-07-31*, *extended 2026-08-05*, still partial on purpose
    All three containers now set ``allowPrivilegeEscalation: false`` and
    ``seccompProfile: RuntimeDefault``. Verified on a live cluster: all three roll out, 16/16 in
    :file:`deploy/k8s/ingress-test.sh`, both browser rounds pass.
@@ -410,19 +410,60 @@ Container security context — *added 2026-07-31*, partial on purpose
    the step that needs root. The init container has no ``securityContext`` of its own, so it
    still runs as root and that step still works.
 
-   ``runAsNonRoot`` for the other two, and ``readOnlyRootFilesystem`` anywhere, are deliberately
-   **not** set. Both remaining images run as uid 0 — measured, not assumed:
+   **The frontend image now runs as uid 101** (*2026-08-05*) — the image half of it.
+   :file:`v2/Dockerfile` builds on ``nginxinc/nginx-unprivileged:alpine`` (the same nginx 1.31.3
+   as ``nginx:alpine``, packaged for uid 101 with its pid and temp paths in :file:`/tmp`) and the
+   server block listens on 8080, since a non-root process cannot bind a privileged port without
+   ``CAP_NET_BIND_SERVICE``. Measured on the built image: ``id`` reports ``uid=101(nginx)``, no
+   process in the container is root, it serves the app, a missing ``.tif`` still 404s and an
+   unknown route still falls back to the app.
+
+   The load-bearing part is not the port. The entrypoint rewrites :file:`assets/config.json`
+   **in place** and now does so as uid 101, so the document root must be owned by that uid —
+   ``COPY --chown=101:101`` in :file:`v2/Dockerfile`. **Confirmed by mutation**: a derived image
+   with the tree chowned back to root exits 1 on start with
+   ``mv: can't rename '/tmp/tmp.XXXXXX': Permission denied``.
+
+   That failure is loud but **conditional** — the entrypoint only touches the file when
+   ``CALC_URL`` is set, so a backend-less deployment (Pages, the static compose stack) would stay
+   green while every deployment with a calculator broke. :file:`.github/workflows/image.yml` had
+   been pushing this image without ever starting it, so nothing would have caught that. It now
+   runs what it publishes and requires the app on 8080, ``uid == 101``, and a ``CALC_URL`` it can
+   see injected into the served config.
+
+   .. note::
+
+      **The manifests deliberately lag by one merge.** :file:`deploy/k8s/base` still declares
+      ``containerPort: 80`` and no ``runAsNonRoot``, because both images roll on ``:master`` and
+      the new one is not published until this merge completes. Landing them together was tried
+      and is wrong: the new manifests against the currently published image ``CrashLoopBackOff``
+      on a real cluster, with ``runAsUser: 101`` forcing the old nginx to bind :80 and fail.
+      They follow immediately once ghcr has the new image.
+
+   ``runAsNonRoot`` for GeoServer, and ``readOnlyRootFilesystem`` anywhere, are still deliberately
+   **not** set:
 
    .. code-block:: text
 
-      localhost:5001/esgame:local               runs as uid 0   binds :80, needs a different base image
-      docker.osgeo.org/geoserver:2.28.4         runs as uid 0   upstream
+      esgame frontend image                     runs as uid 101     was uid 0 until 2026-08-05
+      localhost:5001/esgame-calculation:local   runs as uid 10001
+      docker.osgeo.org/geoserver:2.28.4         runs as uid 0       upstream
 
-   The frontend binds :80, which a non-root process cannot do without ``CAP_NET_BIND_SERVICE``,
-   so it needs an unprivileged base image and a port move that carries the Service ``targetPort``
-   and the readiness probe with it. GeoServer is upstream. A read-only root filesystem would
-   additionally break nginx's cache directory and GeoServer's data directory. Those are image
-   changes, not manifest changes, so a deployment that needs them should expect image work.
+   GeoServer is upstream. A read-only root filesystem would break its data directory, R's library
+   and temp paths, and — for the frontend — the ``assets/config.json`` rewrite above, which would
+   need an ``emptyDir`` and a copy-on-start. Those are image and manifest changes together, so a
+   deployment that needs them should expect work.
+
+   **This breaks anything that maps a host port to container :80, and PLACES is one.** Its
+   ``deploy/compose/docker-compose.places.yml`` publishes ``${PLACES_FRONTEND_PORT:-81}:80``
+   against a thin image built ``FROM ghcr.io/mlacayoemery/esgame:master``, so the next publish of
+   that rolling tag leaves it mapping a port nothing listens on. It needs ``:8080`` on that line
+   and in ``test/smoke.sh``'s ``docker run``. Its k8s overlay needs nothing — it inherits this
+   base, so the ``targetPort`` and probe move with it.
+
+   That is a break by design rather than a surprise: PLACES added ``test/smoke.sh`` precisely to
+   catch a change to the rolling esgame base, it runs the image and curls it, and it fails on
+   exactly this. The guard works; the fix belongs in that repository.
 
 The layout needs about 620px, and scrolls sideways below that
    Measured against the live cluster at four widths, on ``/dynamic-game``:

--- a/examples/esgame-dynamic/docker-compose.pygeoapi.yml
+++ b/examples/esgame-dynamic/docker-compose.pygeoapi.yml
@@ -34,7 +34,8 @@ services:
     volumes:
       - ./frontend/config.json:/usr/share/nginx/html/assets/config.json:ro
     ports:
-      - "81:80"
+      # 8080 container-side: the upstream esgame image runs nginx unprivileged (v2/Dockerfile).
+      - "81:8080"
     depends_on: [calculator]
 
   calculator:

--- a/examples/esgame-dynamic/docker-compose.yml
+++ b/examples/esgame-dynamic/docker-compose.yml
@@ -31,7 +31,8 @@ services:
     volumes:
       - ./frontend/config.json:/usr/share/nginx/html/assets/config.json:ro
     ports:
-      - "81:80"
+      # 8080 container-side: the upstream esgame image runs nginx unprivileged (v2/Dockerfile).
+      - "81:8080"
     depends_on: [calculator]
 
   calculator:

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -13,20 +13,28 @@ COPY . .
 RUN npm run build -- --base-href / --configuration production
 
 # ---- Runtime stage ----
-FROM nginx:alpine
+# The same nginx build as nginx:alpine (1.31.3 at time of writing), packaged to run as uid 101
+# with its pid file and temp paths under /tmp. It listens on 8080 rather than 80: a non-root
+# process cannot bind a privileged port without CAP_NET_BIND_SERVICE, and the point of running
+# unprivileged is not to hand the capability back. Callers keep their published port: the k8s
+# Service still listens on 80 (only its targetPort moved) and compose still maps host 81.
+FROM nginxinc/nginx-unprivileged:alpine
 
 # Tuned config: gzip, long-cache hashed assets, no-cache runtime config, SPA fallback
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
-COPY --from=build /app/dist/tradeoff-v2/ /usr/share/nginx/html
+# --chown because the entrypoint below rewrites assets/config.json in place, as uid 101.
+# Without it the tree lands root-owned and the rewrite fails on a directory it cannot write —
+# and it fails *late*, at container start, not at build time.
+COPY --from=build --chown=101:101 /app/dist/tradeoff-v2/ /usr/share/nginx/html
 
 # Injects runtime configuration (e.g. CALC_URL) into assets/config.json before nginx starts,
 # so one image serves any backend/dataset without a rebuild. Runs via nginx's /docker-entrypoint.d hook.
-COPY docker-entrypoint.sh /docker-entrypoint.d/40-esgame-config.sh
+COPY --chown=101:101 docker-entrypoint.sh /docker-entrypoint.d/40-esgame-config.sh
 RUN chmod +x /docker-entrypoint.d/40-esgame-config.sh
 
-EXPOSE 80
+EXPOSE 8080
 
 # Use 127.0.0.1 (not localhost) so the probe doesn't resolve to IPv6 [::1] before nginx is reachable.
 HEALTHCHECK --interval=15s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget -q -O /dev/null http://127.0.0.1/ || exit 1
+  CMD wget -q -O /dev/null http://127.0.0.1:8080/ || exit 1

--- a/v2/README.md
+++ b/v2/README.md
@@ -32,9 +32,9 @@ $ docker build -t tradeoffv2 .
 
 **Run**
 
-In this example the url to access the game will be `http://localhost:81/`. If you want to be able to access it on a different port you can change the 81 in the command below to the desired port.
+In this example the url to access the game will be `http://localhost:81/`. If you want to be able to access it on a different port you can change the 81 in the command below to the desired port. The container side is `8080`, not `80` — nginx runs unprivileged inside, as uid 101.
 ```
-$ docker run -p 81:80 tradeoffv2
+$ docker run -p 81:8080 tradeoffv2
 ```
 
 ## Configuration

--- a/v2/docker-compose.yml
+++ b/v2/docker-compose.yml
@@ -12,7 +12,8 @@ services:
     image: local/esgame-core
     container_name: esgame-core
     ports:
-      - "81:80"
+      # 8080 container-side: the image runs nginx unprivileged (v2/Dockerfile). Host port unchanged.
+      - "81:8080"
     # No CALC_URL set -> the image keeps its built-in assets/config.json (calcUrl ""),
     # i.e. the fully client-side grid game. The dynamic overlay sets CALC_URL.
     # url: http://localhost:81/

--- a/v2/docker-entrypoint.sh
+++ b/v2/docker-entrypoint.sh
@@ -4,7 +4,10 @@
 #
 #   CALC_URL  -> overrides "calcUrl" (the calculation backend; empty string = fully client-side)
 #
-# Runs automatically via nginx's /docker-entrypoint.d/ hook (as root, during container init).
+# Runs automatically via nginx's /docker-entrypoint.d/ hook during container init, as uid 101 —
+# the image is unprivileged, so this replaces a file it must already own. The Dockerfile's
+# `COPY --chown=101:101` of the dist tree is what makes that true; without it this fails here,
+# at start, rather than at build.
 set -e
 
 CONFIG=/usr/share/nginx/html/assets/config.json
@@ -14,7 +17,7 @@ if [ -f "$CONFIG" ] && [ -n "${CALC_URL+x}" ]; then
   # '#' delimiter avoids clashing with the '/' in URLs.
   sed "s#\"calcUrl\"[[:space:]]*:[[:space:]]*\"[^\"]*\"#\"calcUrl\": \"${CALC_URL}\"#" "$CONFIG" > "$tmp"
   mv "$tmp" "$CONFIG"
-  # mktemp creates a 0600 root-owned file; restore world-read so the nginx worker can serve it.
+  # mktemp creates a 0600 file; restore world-read so the nginx worker can serve it.
   chmod 644 "$CONFIG"
   echo "[esgame] runtime config: calcUrl=\"${CALC_URL}\""
 fi

--- a/v2/nginx.conf
+++ b/v2/nginx.conf
@@ -1,6 +1,8 @@
+# 8080, not 80: nginx runs as uid 101 here (see Dockerfile), and binding a privileged port
+# would need CAP_NET_BIND_SERVICE back.
 server {
-    listen       80;
-    listen       [::]:80;
+    listen       8080;
+    listen       [::]:8080;
     server_name  _;
     root         /usr/share/nginx/html;
     index        index.html;


### PR DESCRIPTION
The last container in this repository still running as **uid 0** that we control. GeoServer is upstream; the calculation container moved to uid 10001 in #165.

## The change

`v2/Dockerfile` builds on `nginxinc/nginx-unprivileged:alpine` — the same nginx 1.31.3 as `nginx:alpine`, packaged for uid 101 with its pid and temp paths in `/tmp`. The server block listens on **8080**, because a non-root process cannot bind a privileged port and handing back `CAP_NET_BIND_SERVICE` would undo the point of running unprivileged. Callers keep the port they publish — compose still maps host `81`.

## Measured, not read off the Dockerfile

```
uid=101(nginx) gid=101(nginx) groups=101(nginx)
USER     PID   COMMAND
nginx      1   nginx: master process nginx -g daemon off;
nginx     26   nginx: worker process

index: 200 text/html          missing tif: 404
real tif: 200 image/tiff      unknown route: 200 text/html   healthcheck: healthy
```

Not one process in the container is root, including the master.

## The load-bearing part is not the port

The entrypoint rewrites `assets/config.json` **in place**, and now does so as uid 101 — so the document root has to be owned by that uid. Hence `COPY --chown=101:101`.

**Confirmed by mutation.** A derived image with the tree chowned back to root:

```
/docker-entrypoint.sh: Launching /docker-entrypoint.d/40-esgame-config.sh
mv: can't rename '/tmp/tmp.KpegdL': Permission denied
container: exited exit=1
```

That failure is loud but **conditional** — the entrypoint only touches the file when `CALC_URL` is set. A backend-less deployment (Pages, the static compose stack) never takes that branch, so a regression here would leave those green and break only the deployments that configure a calculator.

## So `image.yml` now runs what it publishes

It pushed the frontend image without ever starting it — `image-calculation.yml` has probed its own artefact since #155, this one did not. It now requires the app on 8080, `uid == 101`, and a `CALC_URL` it can see injected into the served config. Each probe targets a failure mode a green build passes straight through; the `CALC_URL` one is set deliberately, since a probe without it never touches the write path at all.

The whole step was run verbatim against the built image before being committed.

## Why `deploy/k8s` is not in this PR

Both images roll on `:master`, so the new one does not exist until this merges. The new manifests against the **currently published** image were deployed to a real cluster to check rather than assume:

```
esgame-angular-6bc669cc8-6flss   0/1   CrashLoopBackOff   3 (18s ago)   91s
mv: can't rename '/tmp/tmp.MOAofi': Permission denied
```

`runAsUser: 101` forces the old nginx to bind `:80` and fail. `manifests.yml` deploys exactly that, so shipping both together would have gone red. The manifest half follows immediately once ghcr has this image.

## Downstream

PLACES maps `${PLACES_FRONTEND_PORT:-81}:80` onto this image and will break on the next publish. That is by design rather than a surprise: its `test/smoke.sh` exists to catch a change to this rolling base, runs the image and curls it, and fails on exactly this. Its fix is `:8080` there and in `deploy/compose/docker-compose.places.yml`; its k8s overlay needs nothing, since it inherits this base.

## Also verified

Docs build with `-W` clean, `check-references.py` clean, all four compose stacks parse, all three kustomize overlays render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AnDjKpsry35P8YQHkVr8p