### PR TITLE
fix(k8s): the frontend Deployment asserts the non-root user its image now has

### DIFF
--- a/deploy/k8s/base/angular-deployment.yaml
+++ b/deploy/k8s/base/angular-deployment.yaml
@@ -28,24 +28,25 @@ spec:
                   name: esgame-config
                   key: CALC_URL
           ports:
-            - containerPort: 80
+            - containerPort: 8080
               protocol: TCP
           readinessProbe:
             httpGet:
               path: /
-              port: 80
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 15
-          # The safe subset only. All three images run as uid 0 — measured, not assumed — so
-          # runAsNonRoot would break every one of them and readOnlyRootFilesystem would break
-          # nginx's cache dir, GeoServer's data dir and the calculator's /app/data. Those need
-          # image changes, not a manifest change, and are deliberately not attempted here.
+          # runAsUser 101 is the `nginx` user in nginxinc/nginx-unprivileged, which v2/Dockerfile
+          # now builds on. runAsNonRoot is the half the kubelet enforces at admission: it refuses
+          # to start the pod if the image's uid is 0, so a base-image regression fails loudly here
+          # instead of quietly restoring root. That is why both are set and not just runAsUser.
           #
-          # These two do not: allowPrivilegeEscalation stops a setuid binary gaining privileges
-          # the container did not start with, and RuntimeDefault applies the container runtime's
-          # seccomp filter. Verified on a live cluster — all three roll out, 16/16 in
-          # ingress-test.sh, and both browser rounds pass.
+          # readOnlyRootFilesystem is still not set. nginx writes its pid and temp paths under
+          # /tmp in this image, but the entrypoint rewrites assets/config.json in place under
+          # /usr/share/nginx/html, so it would need an emptyDir there and a copy on start.
           securityContext:
+            runAsNonRoot: true
+            runAsUser: 101
             allowPrivilegeEscalation: false
             seccompProfile:
               type: RuntimeDefault

--- a/deploy/k8s/base/angular-service.yaml
+++ b/deploy/k8s/base/angular-service.yaml
@@ -9,6 +9,8 @@ spec:
   selector:
     app: esgame-angular
   ports:
+    # The Service keeps port 80 so the Ingress backend reference does not move; only the
+    # container side did, when the image went unprivileged (v2/Dockerfile).
     - port: 80
-      targetPort: 80
+      targetPort: 8080
       protocol: TCP

--- a/deploy/k8s/base/calculation-deployment.yaml
+++ b/deploy/k8s/base/calculation-deployment.yaml
@@ -78,15 +78,12 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
             failureThreshold: 12
-          # The safe subset only. All three images run as uid 0 — measured, not assumed — so
-          # runAsNonRoot would break every one of them and readOnlyRootFilesystem would break
-          # nginx's cache dir, GeoServer's data dir and the calculator's /app/data. Those need
-          # image changes, not a manifest change, and are deliberately not attempted here.
-          #
-          # These two do not: allowPrivilegeEscalation stops a setuid binary gaining privileges
-          # the container did not start with, and RuntimeDefault applies the container runtime's
-          # seccomp filter. Verified on a live cluster — all three roll out, 16/16 in
-          # ingress-test.sh, and both browser rounds pass.
+          # allowPrivilegeEscalation stops a setuid binary gaining privileges the container did
+          # not start with, and RuntimeDefault applies the container runtime's seccomp filter.
+          # Neither needs anything from the image. readOnlyRootFilesystem is still not set —
+          # R writes to its library and temp paths outside the /app/data mount. Verified on a
+          # live cluster — all three roll out, 16/16 in ingress-test.sh, and both browser rounds
+          # pass.
           securityContext:
             allowPrivilegeEscalation: false
             seccompProfile:
@@ -97,9 +94,9 @@ spec:
             # cooperates. runAsUser repeats the number so the manifest is explicit rather than
             # relying on whatever the image happens to say.
             #
-            # Only this container. The frontend binds :80 and would need CAP_NET_BIND_SERVICE or
-            # a different base image; GeoServer is upstream. Both measured as uid 0 and left
-            # alone deliberately — see docs/verification-status.rst.
+            # The frontend asserts the same thing with uid 101 since 2026-08-05, when its image
+            # moved to an unprivileged nginx on 8080. GeoServer is upstream and is now the only
+            # container here still measured as uid 0 — see docs/verification-status.rst.
             runAsNonRoot: true
             runAsUser: 10001
           resources:

--- a/deploy/k8s/base/geoserver-deployment.yaml
+++ b/deploy/k8s/base/geoserver-deployment.yaml
@@ -63,15 +63,16 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 10
             failureThreshold: 30
-          # The safe subset only. All three images run as uid 0 — measured, not assumed — so
-          # runAsNonRoot would break every one of them and readOnlyRootFilesystem would break
-          # nginx's cache dir, GeoServer's data dir and the calculator's /app/data. Those need
-          # image changes, not a manifest change, and are deliberately not attempted here.
+          # The safe subset only, and this is now the one container it is still true of.
+          # docker.osgeo.org/geoserver runs as uid 0 — measured, not assumed — so runAsNonRoot
+          # would refuse to start it, and readOnlyRootFilesystem would break its data directory.
+          # Both are upstream image concerns, not manifest ones. The other two containers do set
+          # runAsNonRoot: the calculation image runs as uid 10001, the frontend as uid 101.
           #
-          # These two do not: allowPrivilegeEscalation stops a setuid binary gaining privileges
-          # the container did not start with, and RuntimeDefault applies the container runtime's
-          # seccomp filter. Verified on a live cluster — all three roll out, 16/16 in
-          # ingress-test.sh, and both browser rounds pass.
+          # These two need nothing from the image: allowPrivilegeEscalation stops a setuid binary
+          # gaining privileges the container did not start with, and RuntimeDefault applies the
+          # container runtime's seccomp filter. Verified on a live cluster — all three roll out,
+          # 16/16 in ingress-test.sh, and both browser rounds pass.
           securityContext:
             allowPrivilegeEscalation: false
             seccompProfile:

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -410,7 +410,7 @@ Container security context — *added 2026-07-31*, *extended 2026-08-05*, still 
    the step that needs root. The init container has no ``securityContext`` of its own, so it
    still runs as root and that step still works.
 
-   **The frontend image now runs as uid 101** (*2026-08-05*) — the image half of it.
+   **The frontend now runs as uid 101** (*2026-08-05*), image and manifest.
    :file:`v2/Dockerfile` builds on ``nginxinc/nginx-unprivileged:alpine`` (the same nginx 1.31.3
    as ``nginx:alpine``, packaged for uid 101 with its pid and temp paths in :file:`/tmp`) and the
    server block listens on 8080, since a non-root process cannot bind a privileged port without
@@ -431,14 +431,29 @@ Container security context — *added 2026-07-31*, *extended 2026-08-05*, still 
    runs what it publishes and requires the app on 8080, ``uid == 101``, and a ``CALC_URL`` it can
    see injected into the served config.
 
+   :file:`deploy/k8s/base` carries the port move — ``containerPort`` and the readiness probe to
+   8080, the Service's ``targetPort`` to 8080 with ``port: 80`` left alone so no Ingress backend
+   reference moved — and asserts ``runAsNonRoot: true`` with ``runAsUser: 101``. ``runAsNonRoot``
+   is the half the kubelet enforces at admission: it refuses to start a pod whose image resolves
+   to uid 0, so a base-image regression fails there rather than quietly restoring root.
+
+   Measured against the **published** ghcr images through ``overlays/published``, which is what a
+   real deployment and :file:`.github/workflows/manifests.yml` both use — not a locally built
+   image: ``kubectl exec`` reports ``uid=101(nginx)``, 16/16 in
+   :file:`deploy/k8s/ingress-test.sh` (``POST /esgame`` → 200 in 16s, five finite scores, 5/5
+   coverages through the geoserver ingress), and both browser specs pass — 465 hexagons, 5
+   coverages, two rounds in separate workspaces.
+
    .. note::
 
-      **The manifests deliberately lag by one merge.** :file:`deploy/k8s/base` still declares
-      ``containerPort: 80`` and no ``runAsNonRoot``, because both images roll on ``:master`` and
-      the new one is not published until this merge completes. Landing them together was tried
-      and is wrong: the new manifests against the currently published image ``CrashLoopBackOff``
-      on a real cluster, with ``runAsUser: 101`` forcing the old nginx to bind :80 and fail.
-      They follow immediately once ghcr has the new image.
+      **The image and the manifests could not land together, and this is why.** Both roll on
+      ``:master``, so the new image does not exist until the image PR merges. Checked rather than
+      assumed: the new manifests applied against the *then-published* image put the pod into
+      ``CrashLoopBackOff`` — ``runAsUser: 101`` forces the old nginx to bind :80, and it fails
+      with ``mv: can't rename '/tmp/tmp.MOAofi': Permission denied`` before that. Since
+      :file:`.github/workflows/manifests.yml` deploys exactly that combination, one PR would have
+      gone red. They shipped as two, in that order. Any deployment tracking ``:master`` sees the
+      same ordering: pull the image, then apply the manifests.
 
    ``runAsNonRoot`` for GeoServer, and ``readOnlyRootFilesystem`` anywhere, are still deliberately
    **not** set:


### PR DESCRIPTION
The manifest half of #166. It could not ship with it — see below.

## The change

- `containerPort` and the readiness probe → **8080**
- Service `targetPort` → **8080**; `port: 80` left alone, so **no Ingress backend reference moved**
- `runAsNonRoot: true` + `runAsUser: 101`

`runAsNonRoot` is the half the kubelet enforces at admission: it refuses to start a pod whose image resolves to uid 0. So a base-image regression fails at admission rather than quietly restoring root — which is why both are set and not just `runAsUser`.

## Verified against the published images, not a local build

Through `overlays/published`, which is what a real deployment and `manifests.yml` both use:

```
spec:    ghcr.io/mlacayoemery/esgame:master
running: ghcr.io/mlacayoemery/esgame@sha256:159fc5287f78...
kubectl exec -> uid=101(nginx) gid=101(nginx)

ingress round-trip: PASS  (455 ids, 5 scores, 5/5 coverages, all via http://localhost:8880)
  POST /esgame via ingress -> 200 in 16s

browser specs: 2 passed
  allocation sent by the browser: 465 hexagons
  coverage URLs fetched by the browser: 5
  rounds posted: 1 then 2 — round 1 coverages after round 2: 200, 200, 200, 200, 200
```

## Why this is a second PR

Both images roll on `:master`, so the new one did not exist until #166 merged. These manifests applied against the *then-published* image:

```
esgame-angular-6bc669cc8-6flss   0/1   CrashLoopBackOff   3 (18s ago)   91s
mv: can't rename '/tmp/tmp.MOAofi': Permission denied
```

`runAsUser: 101` forces the old nginx to bind `:80` and fail. `manifests.yml` deploys exactly that combination, so shipping both together would have gone red. That was checked on a real cluster before splitting, not assumed.

Any deployment tracking `:master` faces the same ordering: pull the image, then apply the manifests.

## Two stale comments corrected along the way

The calculation and geoserver manifests both still said *"All three images run as uid 0 — measured, not assumed"*. That was true when written and was not re-derived when the calculation container moved to uid 10001 in #165 — the same drift shape the verification doc warns about. GeoServer is now the only container here still running as uid 0, and the comments say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AnDjKpsry35P8YQHkVr8p