### PR TITLE
chore(deps): npm audit reaches 0 including dev, and none of it needed an override

### DIFF
--- a/docs/dependency-review.rst
+++ b/docs/dependency-review.rst
@@ -9,7 +9,7 @@ The working rule is: **take the newest release, and only stay back when another
 dependency forces it.** "That's what was there" is not a reason. Everything on
 this page is either already at its newest version or has a named blocker below.
 
-Last reviewed: **2026-07-30**.
+Last reviewed: **2026-08-06**.
 
 
 Current state
@@ -23,16 +23,20 @@ Current state
      - State
      - Notes
    * - ``npm audit`` (all)
-     - **3 moderate**
-     - All three are inside ``@angular/cli``'s own tree — see
-       `@modelcontextprotocol/sdk`_ below.
+     - **0**
+     - First time including dev. See `Cleared 2026-08-06`_ for what the three
+       standing findings turned out to need, which was less than the entry they
+       replaced assumed.
    * - ``npm audit`` (production)
      - **0**
      - Nothing shipped to the browser has an outstanding advisory.
    * - ``npm outdated``
      - **1 entry**
-     - Only ``typescript`` (capped, see `TypeScript`_). Angular is on 22.1.0 across
-       the board; nothing else is behind, and no package in the tree is deprecated.
+     - Only ``typescript`` (capped, see `TypeScript`_). Framework packages are at
+       22.1.0, which *is* their newest; the tooling releases faster, so
+       ``@angular/build`` and ``@angular/cli`` are 22.1.3 and ``@angular/cdk`` /
+       ``@angular/material`` 22.1.1. Nothing else is behind and no package in the
+       tree is deprecated.
 
 
 Blocked upgrades
@@ -54,36 +58,48 @@ range, then bump both together. Check with::
 
    npm view @angular/compiler-cli@latest peerDependencies.typescript
 
-.. _@modelcontextprotocol/sdk:
+.. _Cleared 2026-08-06:
 
-@modelcontextprotocol/sdk → @hono/node-server
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Cleared 2026-08-06 — three dev advisories, none of which needed an override
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-*Three moderate advisories, dev-only.*
+Three findings sat here, all dev-scope, all inside ``@angular/cli``'s or
+``@lhci/cli``'s tree:
 
-::
+.. list-table::
+   :header-rows: 1
+   :widths: 22 26 52
 
-   @angular/cli → @modelcontextprotocol/sdk → @hono/node-server (path traversal)
+   * - Package
+     - Path
+     - How it cleared
+   * - ``fast-uri``
+     - ``@angular/cli → @angular-devkit/core → ajv``
+     - ``ajv@8.20.0`` declares ``fast-uri: ^3.0.1`` and the fix is **3.1.5**, so the
+       patched version was inside the declared range the whole time — only the
+       lockfile pinned 3.1.4. ``npm update fast-uri``. No override, no CLI bump.
+   * - ``hono``
+     - ``@angular/cli → @modelcontextprotocol/sdk``
+     - Same shape: the ReDoS fix is 4.12.34, ``sdk`` declares ``hono: ^4.11.4``, and
+       it resolved to **4.13.0**. The ``@modelcontextprotocol/sdk`` and
+       ``@hono/node-server`` overrides had already done the structural half.
+   * - ``brace-expansion``
+     - ``@lhci/cli → chrome-launcher → … → minimatch``
+     - The held-forward override below was already there; it just named ``^5.0.8``
+       and the fix is **5.0.9**. One character.
 
-Nothing in this repository selects those versions; ``@angular/cli`` does, and it
-is already at its newest release.
+The entry this replaces assumed the blocker was Angular CLI's exact pin of
+``@modelcontextprotocol/sdk@1.29.0``, and said to wait for a CLI bump. That pin is
+real — ``@angular/cli@22.1.3`` still carries it, so the ``sdk`` override stays — but
+it was never what held ``fast-uri`` back, and waiting would not have cleared any of
+the three. **Check the range before concluding a transitive is blocked:** a range
+that already admits the patched version means the lockfile is stale, not that
+upstream is holding you.
 
-**Blocker:** Angular CLI's own dependency pin — ``@angular/cli`` depends on
-``@modelcontextprotocol/sdk`` at an exact ``1.29.0``, and that release declares
-``@hono/node-server: ^1.19.9``, which cannot resolve the patched 2.0.5.
-
-**To unblock:** the upstream half is already done. ``@modelcontextprotocol/sdk``
-1.30.0 widened its range to ``^1.19.9 || ^2.0.5``, so this clears by itself as soon
-as Angular CLI bumps to it — checked at 22.1.0, which still pins 1.29.0. Watch::
-
-   npm view @angular/cli@latest dependencies.@modelcontextprotocol/sdk
-
-An ``overrides`` entry forcing ``@hono/node-server@^2.0.5`` remains the fallback,
-but it would resolve a package outside its parent's declared range to silence a
-Windows-only path traversal in a ``serve-static`` path this repository never
-invokes — the CLI's MCP server is not part of any build, test or deploy step here.
-Waiting is the smaller risk. Nothing shipped to the browser is affected:
-``npm audit --omit=dev`` is 0.
+Verified after the change, because all three sit in the toolchain rather than in
+the app: ``npm audit`` **0 including dev** (production was already 0), 378 unit
+tests, 12 Playwright e2e, and Lighthouse CI green — that last one being the check
+that matters, since the ``brace-expansion`` chain is ``@lhci/cli``'s own.
 
 
 Held-forward with overrides
@@ -98,7 +114,7 @@ introduced. ``npm audit fix --force`` "solves" this by downgrading to
 Instead :file:`v2/package.json` pins those transitives forward::
 
    "overrides": {
-     "brace-expansion": "^5.0.8",
+     "brace-expansion": "^5.0.9",
      "minimatch":       "^10.2.6",
      "glob":            "^13.0.6",
      "rimraf":          "^6.1.3",

--- a/v2/package-lock.json
+++ b/v2/package-lock.json
@@ -8,12 +8,12 @@
       "name": "tradeoff-v2",
       "version": "2.0.0",
       "dependencies": {
-        "@angular/cdk": "22.1.0",
+        "@angular/cdk": "22.1.1",
         "@angular/common": "22.1.0",
         "@angular/compiler": "22.1.0",
         "@angular/core": "22.1.0",
         "@angular/forms": "22.1.0",
-        "@angular/material": "22.1.0",
+        "@angular/material": "22.1.1",
         "@angular/platform-browser": "22.1.0",
         "@angular/router": "22.1.0",
         "@ngx-translate/core": "^18.0.0",
@@ -25,8 +25,8 @@
         "zone.js": "0.16.2"
       },
       "devDependencies": {
-        "@angular/build": "22.1.2",
-        "@angular/cli": "22.1.2",
+        "@angular/build": "22.1.3",
+        "@angular/cli": "22.1.3",
         "@angular/compiler-cli": "22.1.0",
         "@lhci/cli": "^0.15.1",
         "@playwright/test": "^1.62.0",
@@ -50,13 +50,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.2201.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2201.2.tgz",
-      "integrity": "sha512-RRG3JA3hPH0ypbDIyquZt9DDTP5pOMPgqQ/iLSkok1MZdKiOgpk6FGfXCa1ei72SwlX7lnJdq94d6WWdqpbyKg==",
+      "version": "0.2201.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2201.3.tgz",
+      "integrity": "sha512-5WX6rooTQZCh+yE9k3O5hc7nnQtzy1nw6fQpaTuCzIgPG8teQuVtdxegBsM3OcjJac1r+qJLo+KmTRfnqcfsyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.1.2",
+        "@angular-devkit/core": "22.1.3",
         "rxjs": "7.8.2"
       },
       "bin": {
@@ -69,9 +69,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "22.1.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.1.2.tgz",
-      "integrity": "sha512-tF1oEE7KPs8I08HJQmH5e4GkLUB3+MXXy8t6gMJULaLFxZYP9K1oXRFLappMpdm9OIbEXOChk23hrho0By9aYg==",
+      "version": "22.1.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.1.3.tgz",
+      "integrity": "sha512-ASK8oZVElt/Zpz5FrzJjLnnUbzp/fW57eFFSRgpA+n9KRnuFi6YvNdSS3HkG5049Jcukce+PiMBdfzw/jBVkEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -97,13 +97,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "22.1.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.1.2.tgz",
-      "integrity": "sha512-Lw6NvW5rfMUl/2dsuWY8l6wlfWCuYBzCYSSqqliLPDco0doGzBliHwY9uxuzuUKZgOl5TvuVyvEo0t3o4Jj4GA==",
+      "version": "22.1.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.1.3.tgz",
+      "integrity": "sha512-ebY5bwZVB0onxxyTbJch//VidVVV8jo/F13n+TV5s/3ZywsC3/XZsfMHaxlFmpvP/G17+/C9JVoEXT+uwjT+/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.1.2",
+        "@angular-devkit/core": "22.1.3",
         "jsonc-parser": "3.3.1",
         "magic-string": "1.0.0",
         "ora": "9.4.1",
@@ -116,14 +116,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "22.1.2",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.1.2.tgz",
-      "integrity": "sha512-DE/3o17JTel4EBt2BA4DqJYeBBuz5Ef/kf1jL9YZTyJu4SrLr/HI79K14jFr0VRIxzcqG92FdIzfLDxbOesQsg==",
+      "version": "22.1.3",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.1.3.tgz",
+      "integrity": "sha512-Hjen3LcVZUCNZy+epgO+/PMUpD/L8Y4vODS+Q8F0Lkva7YWQwycbJtrEr6xvFfMxp6xexxxIwB9+5b8voKSihQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2201.2",
+        "@angular-devkit/architect": "0.2201.3",
         "@babel/core": "8.0.1",
         "@babel/helper-annotate-as-pure": "8.0.0",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -165,7 +165,7 @@
         "@angular/platform-browser": "^22.0.0",
         "@angular/platform-server": "^22.0.0",
         "@angular/service-worker": "^22.0.0",
-        "@angular/ssr": "^22.1.2",
+        "@angular/ssr": "^22.1.3",
         "istanbul-lib-instrument": "^6.0.0",
         "karma": "^6.4.0",
         "less": "^4.2.0",
@@ -240,9 +240,9 @@
       }
     },
     "node_modules/@angular/cdk": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-22.1.0.tgz",
-      "integrity": "sha512-yfQug47CZ+51mHy0ZLWzi6F/YHfsAF2Z7Jxo3JLM7Aj3Er47hHB8VnrNERwK5tBLs0bE5DoEIm59ga/MI3fVGg==",
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-22.1.1.tgz",
+      "integrity": "sha512-P8YuW/r5MS8aeKF0NruktKGHQShOMctvhs3H/51BOwJrMZi5qtWJ40t1yqTrNnewSJIKI0/AroUEmEOqA9Ml9Q==",
       "license": "MIT",
       "dependencies": {
         "parse5": "^8.0.0",
@@ -256,19 +256,19 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "22.1.2",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.1.2.tgz",
-      "integrity": "sha512-gzB+iuZzB507DAkZb9s5+Jw8QRzOBolUhHEuAKH74xF6oWlEP5JdexfTgti45SjXaKKqeYpODJFnUmSQQJRhxA==",
+      "version": "22.1.3",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.1.3.tgz",
+      "integrity": "sha512-GB1Pv8CXAHXE2/hqiwSGD6JRIyT4wswadjH1j3DH2+6os1zc7CBm28/YtlKPPIHZKVOZLDqV6uW+bRQTtdOw2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2201.2",
-        "@angular-devkit/core": "22.1.2",
-        "@angular-devkit/schematics": "22.1.2",
+        "@angular-devkit/architect": "0.2201.3",
+        "@angular-devkit/core": "22.1.3",
+        "@angular-devkit/schematics": "22.1.3",
         "@inquirer/prompts": "8.5.2",
         "@listr2/prompt-adapter-inquirer": "4.2.4",
         "@modelcontextprotocol/sdk": "1.29.0",
-        "@schematics/angular": "22.1.2",
+        "@schematics/angular": "22.1.3",
         "jsonc-parser": "3.3.1",
         "listr2": "10.2.2",
         "npm-package-arg": "14.0.0",
@@ -410,15 +410,15 @@
       }
     },
     "node_modules/@angular/material": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-22.1.0.tgz",
-      "integrity": "sha512-i3Os8JZg4DejgNTtw8GCLQbbZ8+lv8h/ym6PxRwmYNpegmyGiVSKAZ2JBkEs5f1pmMaTppuG3MF6mXei4xi6Wg==",
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-22.1.1.tgz",
+      "integrity": "sha512-wXNNstkLrUJwmP/cZl+C64chL5qH0WbnHIeYbiXrPwgriAD10prbVBoSq2CWbBrAhQ691pDdFKVSLG5tC224jg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/cdk": "22.1.0",
+        "@angular/cdk": "22.1.1",
         "@angular/common": "^22.0.0 || ^23.0.0",
         "@angular/core": "^22.0.0 || ^23.0.0",
         "@angular/forms": "^22.0.0 || ^23.0.0",
@@ -4173,14 +4173,14 @@
       "license": "MIT"
     },
     "node_modules/@schematics/angular": {
-      "version": "22.1.2",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.1.2.tgz",
-      "integrity": "sha512-52udja/QGSNH5geSnL4JWFOEfx8M7tqf7LNXz8byjki4VshVOkKHTawQcL4YbJfo3MfwwXm4AsoadMOk8EST2w==",
+      "version": "22.1.3",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.1.3.tgz",
+      "integrity": "sha512-5f5f0tKp3d25hjNGkvw2dtGgTN4wxPNhv1AXnhFkh+mLinQK9Qwzr2iEXDDrAuJEkvz1ACHq631IURWph0lqew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.1.2",
-        "@angular-devkit/schematics": "22.1.2",
+        "@angular-devkit/core": "22.1.3",
+        "@angular-devkit/schematics": "22.1.3",
         "jsonc-parser": "3.3.1",
         "typescript": "6.0.3"
       },
@@ -4917,9 +4917,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6319,9 +6319,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -6678,9 +6678,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.32",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/v2/package.json
+++ b/v2/package.json
@@ -12,12 +12,12 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/cdk": "22.1.0",
+    "@angular/cdk": "22.1.1",
     "@angular/common": "22.1.0",
     "@angular/compiler": "22.1.0",
     "@angular/core": "22.1.0",
     "@angular/forms": "22.1.0",
-    "@angular/material": "22.1.0",
+    "@angular/material": "22.1.1",
     "@angular/platform-browser": "22.1.0",
     "@angular/router": "22.1.0",
     "@ngx-translate/core": "^18.0.0",
@@ -29,8 +29,8 @@
     "zone.js": "0.16.2"
   },
   "devDependencies": {
-    "@angular/build": "22.1.2",
-    "@angular/cli": "22.1.2",
+    "@angular/build": "22.1.3",
+    "@angular/cli": "22.1.3",
     "@angular/compiler-cli": "22.1.0",
     "@lhci/cli": "^0.15.1",
     "@playwright/test": "^1.62.0",
@@ -39,7 +39,7 @@
     "vitest": "^4.1.10"
   },
   "overrides": {
-    "brace-expansion": "^5.0.8",
+    "brace-expansion": "^5.0.9",
     "minimatch": "^10.2.6",
     "glob": "^13.0.6",
     "rimraf": "^6.1.3",


### PR DESCRIPTION
You asked me to check whether a newer `@angular/cli` clears the `fast-uri` alert. It doesn't — 22.1.3 exists but carries the identical `ajv` range. The actual fix was smaller than the doc assumed, and it cleared two other advisories with it.

## Three findings, none actually blocked

| Package | Path | How it cleared |
|---|---|---|
| `fast-uri` | `@angular/cli → @angular-devkit/core → ajv` | `ajv@8.20.0` declares `fast-uri: ^3.0.1`; the fix is **3.1.5**. The patched version was inside the declared range all along — only the lockfile pinned 3.1.4. |
| `hono` | `@angular/cli → @modelcontextprotocol/sdk` | Same shape: `sdk` declares `hono: ^4.11.4`, ReDoS fixed in 4.12.34, resolved to **4.13.0**. |
| `brace-expansion` | `@lhci/cli → chrome-launcher → … → minimatch` | The held-forward override already existed and named `^5.0.8`. The fix is **5.0.9**. |

`dependency-review.rst` said to wait for Angular CLI to bump its exact pin of `@modelcontextprotocol/sdk@1.29.0`. That pin is real and 22.1.3 still carries it, so the `sdk` override stays — but it was never what held `fast-uri` back, and waiting would not have cleared any of the three.

The generalisable bit, now written into the doc: **check the range before concluding a transitive is blocked.** A range that already admits the patched version means the lockfile is stale, not that upstream is holding you.

Only two of the three were even visible — Dependabot auto-dismissed `hono` and `brace-expansion` as dev-scope, so `npm audit` was the thing that surfaced them.

## Also: tooling drift

The doc claimed *"Angular is on 22.1.0 across the board; nothing else is behind."* Not so — `@angular/build` and `@angular/cli` were 22.1.2 (now 22.1.3), `@angular/cdk` and `@angular/material` 22.1.0 (now 22.1.1). The **framework** packages are at 22.1.0, which is genuinely their newest; the tooling just ships faster. `npm outdated` is back to its one documented entry, the `typescript` cap.

## Verified, not assumed

All of this is toolchain rather than app code, and the `brace-expansion` chain is `@lhci/cli`'s own — so Lighthouse is the check that matters here:

```
npm audit        0 vulnerabilities, including dev   (production was already 0)
npm test         378 passed
npm run e2e      12 passed
npm run lhci     green — all budget assertions pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AnDjKpsry35P8YQHkVr8p