### PR TITLE
fix(k8s): readOnlyRootFilesystem on the frontend and the calculation

### DIFF
--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -214,12 +214,21 @@ jobs:
           #
           # Both images roll on `master`. Assert that, and assert the workflows that produce
           # them still emit a branch tag, so this does not quietly stop meaning anything.
+          #
+          # DISTINCT images, not references. The frontend image is named twice now — once by the
+          # seed-assets init container and once by the container it seeds for — and counting
+          # references made that read as "a third image appeared". What this check is actually
+          # about is which images exist and what tag they carry; how many containers pull one is
+          # not its business. The count guard stays, so a manifest that stops referencing an
+          # image entirely still fails here rather than passing on an empty list.
           bad=0
-          imgs=$(grep -oP '^\s+image:\s*\Kghcr\.io/\S+' rendered.yaml || true)
+          refs=$(grep -oP '^\s+image:\s*\Kghcr\.io/\S+' rendered.yaml || true)
+          imgs=$(printf '%s\n' "$refs" | grep -c . >/dev/null && printf '%s\n' "$refs" | sort -u || true)
           n=$(printf '%s\n' "$imgs" | grep -c . || true)
+          echo "$(printf '%s\n' "$refs" | grep -c . || echo 0) reference(s) -> $n distinct:"
           echo "$imgs"
           if [ "$n" -ne 2 ]; then
-            echo "::error::expected 2 ghcr images in the render, found $n"; exit 1
+            echo "::error::expected 2 distinct ghcr images in the render, found $n"; exit 1
           fi
           for i in $imgs; do
             case "$i" in

--- a/deploy/k8s/base/angular-deployment.yaml
+++ b/deploy/k8s/base/angular-deployment.yaml
@@ -16,6 +16,54 @@ spec:
       labels:
         app: esgame-angular
     spec:
+      volumes:
+        # nginx's pid file and its proxy/client/fastcgi/uwsgi/scgi temp paths all live under /tmp
+        # in the unprivileged image, so a read-only root needs exactly this one writable.
+        - name: tmp
+          emptyDir: {}
+        # And this one, because the entrypoint rewrites assets/config.json IN PLACE to inject
+        # CALC_URL. Seeded below — an emptyDir starts empty, unlike a docker named volume, which
+        # auto-populates from the image and makes this look unnecessary when tested with docker.
+        - name: assets
+          emptyDir: {}
+      initContainers:
+        # Copies the image's own assets into the emptyDir that will shadow them. Same image, so it
+        # copies whatever that image ships — which is how a downstream overlay (places bakes its
+        # own data.json, config.json and rasters) keeps working without knowing this exists.
+        - name: seed-assets
+          image: esgame-angular # rewritten by kustomization.yaml images:
+          imagePullPolicy: Always
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              # -R, not -a: -a tries to preserve ownership and timestamps on the emptyDir root,
+              # which uid 101 does not own, and prints three "Operation not permitted" lines that
+              # read like failures while the copy succeeds. Nothing here needs either preserved.
+              cp -R /usr/share/nginx/html/assets/. /seed/
+              # Presence, not exit status: cp can copy nothing and succeed. config.json is what the
+              # entrypoint rewrites, so its absence is the failure that would otherwise surface as
+              # a served 404 with the pod reporting healthy.
+              [ -s /seed/config.json ] || { echo "!! assets/config.json missing after seed" >&2; exit 1; }
+              echo ">> seeded $(find /seed -type f | wc -l) asset file(s)"
+          volumeMounts:
+            - name: assets
+              mountPath: /seed
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 101
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            limits:
+              cpu: 250m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
       containers:
         - name: esgame-angular
           image: esgame-angular # rewritten by kustomization.yaml images:
@@ -36,17 +84,24 @@ spec:
               port: 8080
             initialDelaySeconds: 5
             periodSeconds: 15
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: assets
+              mountPath: /usr/share/nginx/html/assets
           # runAsUser 101 is the `nginx` user in nginxinc/nginx-unprivileged, which v2/Dockerfile
           # now builds on. runAsNonRoot is the half the kubelet enforces at admission: it refuses
           # to start the pod if the image's uid is 0, so a base-image regression fails loudly here
           # instead of quietly restoring root. That is why both are set and not just runAsUser.
           #
-          # readOnlyRootFilesystem is still not set. nginx writes its pid and temp paths under
-          # /tmp in this image, but the entrypoint rewrites assets/config.json in place under
-          # /usr/share/nginx/html, so it would need an emptyDir there and a copy on start.
+          # readOnlyRootFilesystem needs the two mounts above and nothing else — measured by
+          # running the published image with `--read-only` and reading what it failed on, twice:
+          #   no writable paths   mktemp: : Read-only file system
+          #   /tmp only           mv: can't remove '.../assets/config.json': Read-only file system
           securityContext:
             runAsNonRoot: true
             runAsUser: 101
+            readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             seccompProfile:
               type: RuntimeDefault

--- a/deploy/k8s/base/calculation-deployment.yaml
+++ b/deploy/k8s/base/calculation-deployment.yaml
@@ -21,6 +21,11 @@ spec:
       volumes:
         - name: app-data
           emptyDir: {}
+        # R puts tempdir() under TMPDIR (/tmp by default) and writes there throughout a round —
+        # raster's own temp files among them. The only path a read-only root needs beyond the
+        # /app/data mount below; measured by running the published image with `--read-only`.
+        - name: tmp
+          emptyDir: {}
       securityContext:
         # /app/data is a mount, so its ownership comes from the volume, not the image.
         # calculator.r does setwd() there and writes seven rasters plus the spider plot, and a
@@ -63,6 +68,8 @@ spec:
           volumeMounts:
             - name: app-data
               mountPath: /app/data
+            - name: tmp
+              mountPath: /tmp
           # Without this the pod is "ready" the instant the container starts, and the Service
           # sends it traffic while plumber is still binding — about 12 seconds. That is not
           # hypothetical: a POST straight after a rollout returned 503 from the ingress, and it
@@ -80,12 +87,16 @@ spec:
             failureThreshold: 12
           # allowPrivilegeEscalation stops a setuid binary gaining privileges the container did
           # not start with, and RuntimeDefault applies the container runtime's seccomp filter.
-          # Neither needs anything from the image. readOnlyRootFilesystem is still not set —
-          # R writes to its library and temp paths outside the /app/data mount. Verified on a
-          # live cluster — all three roll out, 16/16 in ingress-test.sh, and both browser rounds
-          # pass.
+          # Neither needs anything from the image.
+          #
+          # readOnlyRootFilesystem holds because both paths this writes are mounts: /app/data,
+          # where calculator.r does setwd() and writes its rasters and the spider plot, and /tmp,
+          # which is where R puts tempdir(). An earlier comment here said R "writes to its library
+          # and temp paths outside the /app/data mount" — the library is read at run time, not
+          # written to, and the temp paths are now mounted.
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             seccompProfile:
               type: RuntimeDefault
             # tools/R/Dockerfile now runs as uid 10001. runAsNonRoot is the assertion the

--- a/deploy/k8s/base/geoserver-deployment.yaml
+++ b/deploy/k8s/base/geoserver-deployment.yaml
@@ -65,9 +65,25 @@ spec:
             failureThreshold: 30
           # The safe subset only, and this is now the one container it is still true of.
           # docker.osgeo.org/geoserver runs as uid 0 — measured, not assumed — so runAsNonRoot
-          # would refuse to start it, and readOnlyRootFilesystem would break its data directory.
-          # Both are upstream image concerns, not manifest ones. The other two containers do set
-          # runAsNonRoot: the calculation image runs as uid 10001, the frontend as uid 101.
+          # would refuse to start it. The other two containers do set it: the calculation image
+          # runs as uid 10001, the frontend as uid 101.
+          #
+          # readOnlyRootFilesystem is refused here on evidence rather than caution. Run with
+          # --read-only it does NOT fail; Tomcat binds and reports "Server startup in 6409 ms"
+          # while:
+          #
+          #   /opt/startup.sh: line 14: /usr/local/tomcat/conf/server.xml: Read-only file system
+          #   /opt/startup.sh: line 44: .../conf/healthcheck_url.txt: Read-only file system
+          #   sed: couldn't open temporary file /usr/local/tomcat/conf/sedpbEUk0: Read-only ...
+          #   java.io.FileNotFoundException: /usr/local/tomcat/logs/catalina.<date>.log
+          #
+          # The startup script REWRITES its own server.xml, and a read-only root drops those edits
+          # silently — a server that starts having ignored its configuration is worse than one
+          # that refuses to. Making it work means seeding emptyDirs over /usr/local/tomcat/conf,
+          # /logs, /work and /temp from the image, i.e. pinning this manifest to the internals of
+          # an upstream image whose next patch release can move them, with that same silent
+          # failure as the penalty. Not worth it for the one container here that holds no secrets
+          # of its own beyond the admin Secret already mounted.
           #
           # These two need nothing from the image: allowPrivilegeEscalation stops a setuid binary
           # gaining privileges the container did not start with, and RuntimeDefault applies the

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -9,7 +9,7 @@ time precisely because nothing had ever run them, and the failures were silent �
 that logged ``done`` having registered nothing, an e2e suite passing against a board that
 never rendered, a schema check reporting 10/10 valid on manifests the API server rejected.
 
-Last updated: **2026-08-05**.
+Last updated: **2026-08-06**.
 
 .. note::
 
@@ -391,7 +391,7 @@ Readiness probes — *added 2026-07-31*
    the first attempt failed with *"stopped after 10 redirects"* and timed the rollout out.
    ``/geoserver/index.html`` answers 200 directly.
 
-Container security context — *added 2026-07-31*, *extended 2026-08-05*, still partial on purpose
+Container security context — *added 2026-07-31*, extended *2026-08-05* and *2026-08-06*, still partial on purpose
    All three containers now set ``allowPrivilegeEscalation: false`` and
    ``seccompProfile: RuntimeDefault``. Verified on a live cluster: all three roll out, 16/16 in
    :file:`deploy/k8s/ingress-test.sh`, both browser rounds pass.
@@ -455,19 +455,68 @@ Container security context — *added 2026-07-31*, *extended 2026-08-05*, still 
       gone red. They shipped as two, in that order. Any deployment tracking ``:master`` sees the
       same ordering: pull the image, then apply the manifests.
 
-   ``runAsNonRoot`` for GeoServer, and ``readOnlyRootFilesystem`` anywhere, are still deliberately
-   **not** set:
+   **``readOnlyRootFilesystem`` on the frontend and the calculation** (*2026-08-06*). Neither
+   needed an image change — both are manifest-only, because every path either writes at run time
+   is now a mount:
 
    .. code-block:: text
 
-      esgame frontend image                     runs as uid 101     was uid 0 until 2026-08-05
-      localhost:5001/esgame-calculation:local   runs as uid 10001
-      docker.osgeo.org/geoserver:2.28.4         runs as uid 0       upstream
+      esgame frontend       uid 101     readOnlyRootFilesystem   /tmp + /usr/share/nginx/html/assets
+      esgame calculation    uid 10001   readOnlyRootFilesystem   /tmp + /app/data
+      geoserver 2.28.4      uid 0       (refused, see below)     upstream
 
-   GeoServer is upstream. A read-only root filesystem would break its data directory, R's library
-   and temp paths, and — for the frontend — the ``assets/config.json`` rewrite above, which would
-   need an ``emptyDir`` and a copy-on-start. Those are image and manifest changes together, so a
-   deployment that needs them should expect work.
+   The writable set was **measured, not guessed** — each image run with ``--read-only`` and the
+   first thing it failed on read off the log, then the mount added and the run repeated:
+
+   .. code-block:: text
+
+      frontend, nothing writable   mktemp: : Read-only file system
+      frontend, /tmp only          mv: can't remove '.../assets/config.json': Read-only file system
+      frontend, /tmp + assets      serves, CALC_URL injected, .tif 200
+      calculation, nothing         Fatal error: creating temporary file for '-e' failed   (exit 2)
+      calculation, /tmp + /app/data  starts, plumber binds
+
+   The frontend's second mount is the ``assets/config.json`` rewrite. An ``emptyDir`` starts
+   **empty**, so an init container seeds it from the image — the same image, which is how a
+   downstream overlay that bakes its own assets (PLACES does) keeps working without knowing this
+   exists. It copies with ``cp -R`` rather than ``cp -a``, which tries to preserve ownership on a
+   mount root uid 101 does not own and prints three "Operation not permitted" lines while
+   succeeding.
+
+   .. warning::
+
+      **Do not test this with docker named volumes.** A docker volume auto-populates from the
+      image when first mounted and empty; a Kubernetes ``emptyDir`` does not. Mounting one over
+      the assets directory therefore *looks* like it needs no seeding at all — it served the app,
+      the config and a real ``.tif`` — and the same manifest on a cluster would have served
+      nothing. The init container exists because of the difference.
+
+   That init container asserts ``[ -s /seed/config.json ]`` rather than trusting ``cp``'s exit
+   status, and the guard was confirmed able to fail: copying from an empty directory returns 0,
+   and the check then exits 1 naming the missing file. Without it a seed that copied nothing would
+   surface as a 404 from a pod reporting healthy.
+
+   Verified on the live cluster against the published images: both roll out, the root filesystem
+   really is read-only (``touch`` → ``Read-only file system``), the init container reports
+   ``seeded 54 asset file(s)``, 16/16 in :file:`deploy/k8s/ingress-test.sh` with a real round
+   (200 in 16s, five finite scores, 5/5 coverages), and both browser specs pass.
+
+   **GeoServer is refused on evidence, not caution.** Run with ``--read-only`` it does not fail —
+   Tomcat binds and logs ``Server startup in 6409 ms`` — while:
+
+   .. code-block:: text
+
+      /opt/startup.sh: line 14: /usr/local/tomcat/conf/server.xml: Read-only file system
+      /opt/startup.sh: line 44: .../conf/healthcheck_url.txt: Read-only file system
+      sed: couldn't open temporary file /usr/local/tomcat/conf/sedpbEUk0: Read-only file system
+      java.io.FileNotFoundException: /usr/local/tomcat/logs/catalina.<date>.log
+
+   The startup script rewrites its own ``server.xml``, and a read-only root drops those edits
+   silently. A server that starts having ignored its own configuration is worse than one that
+   refuses to start. Making it work means seeding ``emptyDir``\ s over ``/usr/local/tomcat/conf``,
+   ``/logs``, ``/work`` and ``/temp`` from the image — pinning the manifest to the internals of an
+   upstream image whose next patch release can move them, with that same silent failure as the
+   penalty. ``runAsNonRoot`` is out for the same upstream reason: it runs as uid 0.
 
    **This breaks anything that maps a host port to container :80, and PLACES is one.** Its
    ``deploy/compose/docker-compose.places.yml`` publishes ``${PLACES_FRONTEND_PORT:-81}:80``


### PR DESCRIPTION
The last container-hardening item. Neither container needed an image change — every path they write at run time is now a mount, so this is manifest-only.

```
frontend      uid 101     readOnlyRootFilesystem   /tmp + /usr/share/nginx/html/assets
calculation   uid 10001   readOnlyRootFilesystem   /tmp + /app/data
geoserver     uid 0       refused, with evidence   upstream
```

## The writable set was measured, not guessed

Each image run with `--read-only`, the first thing it failed on read off the log, the mount added, the run repeated:

```
frontend, nothing writable      mktemp: : Read-only file system
frontend, /tmp only             mv: can't remove '.../assets/config.json': Read-only file system
frontend, /tmp + assets         serves, CALC_URL injected, .tif 200
calculation, nothing            Fatal error: creating temporary file for '-e' failed   (exit 2)
calculation, /tmp + /app/data   starts, plumber binds
```

Those first and third lines are also the mutations proving both mounts are load-bearing rather than decorative. The old comment claiming R *"writes to its library and temp paths outside the /app/data mount"* was half wrong — the library is read, not written.

## ⚠️ Do not test this shape with docker named volumes

A docker named volume **auto-populates from the image** when first mounted and empty. A Kubernetes `emptyDir` does not.

Mounting one over the assets directory therefore looks like it needs no seeding at all — it served the app, the config *and* a real `.tif` — and the same manifest on a cluster would have served nothing. I hit this while probing and nearly drew the wrong conclusion from it. The init container exists because of that difference.

## The seed, and a guard that can fail

The frontend's second mount is the `assets/config.json` rewrite, so an init container seeds the emptyDir from the image — the *same* image, which is how a downstream overlay that bakes its own assets (PLACES does) keeps working without knowing this exists.

It asserts `[ -s /seed/config.json ]` rather than trusting `cp`'s exit status. Confirmed able to fail, per this repo's standing rule about checks that can't:

```
cp exit status: 0 (success)          # copied from an empty directory
!! assets/config.json missing after seed
exit=1
```

Without it, a seed that copied nothing would surface as a 404 from a pod reporting healthy.

`cp -R`, not `cp -a` — `-a` tries to preserve ownership on a mount root uid 101 doesn't own and prints three `Operation not permitted` lines while succeeding.

## GeoServer is refused on evidence, not caution

Run `--read-only` it **does not fail**. Tomcat binds and logs `Server startup in 6409 ms`, while:

```
/opt/startup.sh: line 14: /usr/local/tomcat/conf/server.xml: Read-only file system
/opt/startup.sh: line 44: .../conf/healthcheck_url.txt: Read-only file system
sed: couldn't open temporary file /usr/local/tomcat/conf/sedpbEUk0: Read-only file system
java.io.FileNotFoundException: /usr/local/tomcat/logs/catalina.<date>.log
```

The startup script rewrites its own `server.xml`, and a read-only root drops those edits silently. A server that starts having ignored its configuration is worse than one that refuses to start. Making it work means seeding emptyDirs over `/usr/local/tomcat/conf`, `/logs`, `/work` and `/temp` from the image — pinning this manifest to internals an upstream patch release can move, with that same silent failure as the penalty.

## Verified on the live cluster, against the published images

```
both deployments roll out
touch /usr/share/nginx/html/probe  ->  Read-only file system
init container: >> seeded 54 asset file(s)
ingress round-trip: PASS  (455 ids, 5 scores, 5/5 coverages)   POST /esgame -> 200 in 16s
browser specs: 2 passed  (465 hexagons, two rounds in separate workspaces)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AnDjKpsry35P8YQHkVr8p