### PR TITLE
feat: tell the player when the model ignored their round

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -29,7 +29,7 @@ Verified working
    * - Path
      - How it was checked
    * - Static / grid game
-     - 378 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
+     - 385 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
        SEO 100. The board renders 2,436 fields; the e2e suite asserts that rather than
        just asserting the component mounted.
    * - No external runtime deps
@@ -346,6 +346,45 @@ The committed base raster makes the game inert
    percentage is circular. :file:`v2/e2e-cluster` prints the honest figure, since the
    browser sends the ids the board actually uses.
    See :ref:`allocation-id-space`.
+
+   **And the player is now told** (*2026-08-06*). Every reader of that number so far has been a
+   test or a log. The person the round actually misleads — someone running a workshop, watching
+   five finite scores that will be the same next round — had no way to know, short of reading the
+   calculator's stdout. ``/esgame`` returns the numbers alongside ``results``:
+
+   .. code-block:: text
+
+      { "results": [ … ], "allocationCoverage": { "allocated": 465, "matched": 4, "fraction": 0.0086 } }
+
+   and below 50% the game says so once per game, naming the figures rather than showing a generic
+   failure: *"Only 1% of this round reached the model (4 of 465 areas)."* Once per game, not once
+   per round — it is a deployment mismatch that cannot change between rounds, and a dialog that
+   repeats is a dialog people learn to dismiss unread.
+
+   ``results`` is unchanged and the new field is **optional**, so a calculator that does not send
+   it (PLACES carries its own ``calculation.r``) is not treated as having ignored the round. That
+   is asserted, not just intended — absent, malformed and high-coverage responses must all stay
+   silent, and each has a spec.
+
+   Measured on the live cluster, where the committed raster makes this real rather than contrived:
+
+   .. code-block:: text
+
+      calculator reported: 4 of 465 ids used (1%)
+      warning shown to the player: yes
+
+   Confirmed able to fail four ways: dropping the call, warning every round instead of once, and
+   treating an absent field as zero coverage each fail exactly one unit spec; and pointing the
+   browser spec at a phrase the app never says fails it with *"the player was not told the round
+   had been ignored"*.
+
+   .. note::
+
+      The first version of that browser assertion **skipped silently.** It sat inside the block
+      that reads the pod log via ``kubectl``, which degrades to a console note when ``kubectl`` is
+      absent — as it was on the very run meant to prove the warning. It passed, printed
+      ``(allocation coverage unavailable …)``, and asserted nothing. It now reads the response the
+      browser itself received and needs nothing but the browser.
 
 The calculation Ingress had a 60-second timeout — *fixed 2026-07-31*
    ingress-nginx defaults ``proxy_read_timeout`` and ``proxy_send_timeout`` to 60 seconds, and

--- a/tools/R/calculator.r
+++ b/tools/R/calculator.r
@@ -112,7 +112,10 @@ calculate<-function(req, geoserver_url, game_id, round_id,score_PD,map_AG) {
   # its hexagons 10-474 while the board numbers its own 100-46500 in hundreds — 4 ids in common
   # out of 465 — and the constant it returns was quoted in the docs as a working round.
   # Cheap to check, and the only thing that distinguishes "scored" from "ignored".
-  esgame_report_coverage(LU_hexa, map_AG)
+  # Kept, not just logged. The log line below is inside the container; the person who needs it is
+  # the one running the workshop, and until now the only way to learn a round had been ignored was
+  # to read the calculator's stdout. It goes back in the response — see the end of this function.
+  coverage_stats <- esgame_report_coverage(LU_hexa, map_AG)
   LU_complete<-reclassify(LU_hexa, map_AG, right=F) # no value can be 1!!!!
 
   #### Set parameters ####
@@ -460,5 +463,23 @@ calculate<-function(req, geoserver_url, game_id, round_id,score_PD,map_AG) {
   
   #DELETED CODE
   
-  return(list(results = calculated_rasters))
+  # `results` is unchanged: every existing client keys off it and none of them know about the
+  # field below. allocationCoverage is additive and optional by design — a client that ignores it
+  # behaves exactly as before, which is what keeps other calculators (places carries its own
+  # calculation.r) from having to ship this at the same time.
+  #
+  # Omitted entirely rather than sent as nulls when the diagnostic itself failed:
+  # esgame_report_coverage returns NULL in that case, and a client cannot tell "0% matched" from
+  # "could not measure" if both arrive as zeroes.
+  if (is.null(coverage_stats)) {
+    return(list(results = calculated_rasters))
+  }
+  return(list(
+    results = calculated_rasters,
+    allocationCoverage = list(
+      allocated = coverage_stats$allocated,
+      matched   = coverage_stats$matched,
+      fraction  = coverage_stats$fraction
+    )
+  ))
 }

--- a/v2/e2e-cluster/browser-round.spec.ts
+++ b/v2/e2e-cluster/browser-round.spec.ts
@@ -27,11 +27,22 @@ interface Traffic {
 	errors: string[];
 	posts: any[];
 	coverages: string[];
+	dialogs: string[];
+	replies: any[];
 }
 
 function watch(page: Page): Traffic {
-	const t: Traffic = { errors: [], posts: [], coverages: [] };
+	const t: Traffic = { errors: [], posts: [], coverages: [], dialogs: [], replies: [] };
 	page.on('pageerror', e => t.errors.push(e.message));
+	// Playwright dismisses dialogs automatically when nothing is listening, which is why the
+	// low-coverage warning could be added and every spec here still pass without seeing it.
+	// Record them, then dismiss exactly as the default would.
+	page.on('dialog', async d => { t.dialogs.push(d.message()); await d.dismiss(); });
+	page.on('response', async r => {
+		if (r.url().includes('esgame-calculation.local') && r.request().method() === 'POST') {
+			try { t.replies.push(await r.json()); } catch { /* not JSON; the assertions below will say so */ }
+		}
+	});
 	page.on('request', r => {
 		if (r.url().includes('esgame-calculation.local') && r.method() === 'POST') {
 			try { t.posts.push(r.postDataJSON()); } catch { t.posts.push(null); }
@@ -146,6 +157,29 @@ test('a browser plays a round end to end against the cluster', async ({ page }) 
 		expect(Number.isNaN(coverage.percent)).toBe(false);
 	} else {
 		console.log('  (allocation coverage unavailable — kubectl not on PATH, or no log line)');
+	}
+
+	// And the player was told. Deliberately NOT inside the kubectl block above: that one degrades
+	// to a console note when kubectl is absent, and the first version of this assertion sat inside
+	// it — so it skipped silently on the very run that was meant to prove it. This reads the
+	// response the browser itself received, which needs nothing but the browser.
+	expect(t.replies, 'no JSON reply from the calculation ingress').toHaveLength(1);
+	const reported = t.replies[0]?.allocationCoverage;
+	expect(reported, 'the calculator did not report allocationCoverage').toBeTruthy();
+	const percent = Math.round(100 * reported.fraction);
+	console.log(`  calculator reported: ${reported.matched} of ${reported.allocated} ids used (${percent}%)`);
+
+	// The committed raster shares 4 ids of 465 with the board, so this cluster always takes the
+	// low branch. That makes it the honest place to assert the warning rather than a contrived one.
+	if (reported.fraction < 0.5) {
+		const warning = t.dialogs.find(d => d.includes('reached the model'));
+		console.log(`  warning shown to the player: ${warning ? 'yes' : 'NO'}`);
+		expect(warning, 'the player was not told the round had been ignored').toBeTruthy();
+		expect(warning).toContain(`${percent}%`);
+		expect(warning).toContain(`${reported.matched} of ${reported.allocated}`);
+	} else {
+		console.log('  coverage is high, so no warning is expected');
+		expect(t.dialogs.filter(d => d.includes('reached the model'))).toHaveLength(0);
 	}
 
 	expect(t.errors).toEqual([]);

--- a/v2/src/app/services/game.service.allocation-coverage.spec.ts
+++ b/v2/src/app/services/game.service.allocation-coverage.spec.ts
@@ -1,0 +1,155 @@
+import { of } from 'rxjs';
+import { GameService } from './game.service';
+import { CalculationResult } from '../shared/models/calculation-result';
+
+// The round scores, and the scores may have nothing to do with what the player did.
+//
+// raster::reclassify() ignores any id that is not in the base raster — no warning, no error — so
+// an allocation in the wrong id space comes back 200, with a full set of consequence maps and five
+// finite scores that are IDENTICAL every round. The raster committed to this repository is exactly
+// that case against the real board: 4 ids in common out of 465, i.e. 1%.
+//
+// tools/R has measured this since 2026-07-31 and only logged it, which reaches whoever reads the
+// container's stdout — not the person running the workshop. The calculator now returns the numbers
+// and these specs cover what the game does with them.
+
+const settingsData = {
+	title: { en: 'T' },
+	mapMode: 'svg',
+	elementSize: 1,
+	gameBoardColumns: 4,
+	gameBoardRows: 4,
+	calcUrl: 'http://calc.example/esgame',
+	productionTypes: [],
+	customColors: [{ id: 'cc', colors: [{ number: 0, color: '#000000' }, { number: 1, color: '#ffffff' }] }],
+	maps: [
+		{ id: '-3', gameBoardType: 'Drawing', urlToData: 'drawing.tif', productionTypes: [] },
+		{ id: '-2', gameBoardType: 'Background', urlToData: 'bg.tif', customColorId: 'cc', productionTypes: [] },
+		{ id: '11', gameBoardType: 'Consequence', urlToData: 'c11.tif', productionTypes: [] }
+	]
+};
+
+const resultsOnly = [
+	{ name: 'HH.tif', id: '11', score: 0.1, url: 'http://gs/wcs?coverageId=ws:HH' },
+	{ name: 'S.png', id: '-1', score: 0, url: 'http://calc/images/S.png' }
+];
+
+const translateStub: any = { getLangs: () => [], setTranslation: () => { } };
+const scoreStub: any = { createEmptyScoreEntry: () => [], calculateScore: () => { } };
+
+/** A service wired to a calculator that answers with `response`, ready to play a round. */
+const makeService = (response: CalculationResult) => {
+	const tiffStub: any = {
+		getOverlayGameBoard: (id: any, url: string, t: any) => of({ id, gameBoardType: t, urlToData: url }),
+		getSvgBackground: () => of({ id: 'bg' }),
+		getSvgGameBoard: (id: any, url: string, t: any) => of({ id, gameBoardType: t, urlToData: url })
+	};
+	const apiStub: any = { postRequest: () => of(response) };
+	const service = new GameService(tiffStub, scoreStub, translateStub, apiStub);
+	service.loadSettings(JSON.parse(JSON.stringify(settingsData)));
+	service.initialiseSVGMode();
+	return service;
+};
+
+describe('GameService allocation coverage', () => {
+	let alertSpy: any;
+	beforeEach(() => {
+		// alert() is not implemented in jsdom and would log an error per call.
+		alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => { });
+		vi.spyOn(console, 'error').mockImplementation(() => { });
+	});
+	afterEach(() => vi.restoreAllMocks());
+
+	it('warns when most of the allocation never reached the model', () => {
+		// The real committed-raster case: 4 of 465.
+		const service = makeService({
+			results: resultsOnly,
+			allocationCoverage: { allocated: 465, matched: 4, fraction: 4 / 465 }
+		});
+
+		service.goToNextLevel();
+
+		expect(alertSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('says how much was ignored, rather than that something went wrong', () => {
+		const service = makeService({
+			results: resultsOnly,
+			allocationCoverage: { allocated: 465, matched: 4, fraction: 4 / 465 }
+		});
+
+		service.goToNextLevel();
+
+		// The numbers are the whole point — a generic "something went wrong" would send someone
+		// looking at the network tab instead of at which base map the backend mounted.
+		const message = alertSpy.mock.calls[0][0] as string;
+		expect(message).toContain('1%');
+		expect(message).toContain('4 of 465');
+	});
+
+	it('stays silent when the calculator does not report coverage', () => {
+		// Only esgame's own tools/R sends the field; places carries its own calculation.r. Absent
+		// must mean "not reported", never "nothing matched" — this is the assertion that stops a
+		// quiet backend being accused of ignoring the round.
+		const service = makeService({ results: resultsOnly });
+
+		service.goToNextLevel();
+
+		expect(alertSpy).not.toHaveBeenCalled();
+	});
+
+	it('stays silent on a round the model really used', () => {
+		const service = makeService({
+			results: resultsOnly,
+			allocationCoverage: { allocated: 455, matched: 455, fraction: 1 }
+		});
+
+		service.goToNextLevel();
+
+		expect(alertSpy).not.toHaveBeenCalled();
+	});
+
+	it('warns once per game, not once per round', () => {
+		// It is a deployment mismatch, not a per-round event: it cannot change between rounds, and
+		// repeating it every time is how people learn to dismiss a dialog without reading it.
+		const service = makeService({
+			results: resultsOnly,
+			allocationCoverage: { allocated: 465, matched: 4, fraction: 4 / 465 }
+		});
+
+		service.goToNextLevel();
+		service.goToNextLevel();
+		service.goToNextLevel();
+
+		expect(alertSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('owes the warning again after a new game is loaded', () => {
+		const service = makeService({
+			results: resultsOnly,
+			allocationCoverage: { allocated: 465, matched: 4, fraction: 4 / 465 }
+		});
+		service.goToNextLevel();
+		expect(alertSpy).toHaveBeenCalledTimes(1);
+
+		// A new game may be a new backend, so a still-set flag would hide a real mismatch.
+		service.loadSettings(JSON.parse(JSON.stringify(settingsData)));
+		service.initialiseSVGMode();
+		service.goToNextLevel();
+
+		expect(alertSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it('does not treat a malformed fraction as a failed round', () => {
+		// jsonlite can hand back a string, and NaN >= 0.5 is false — which would have made every
+		// round from a backend with a broken diagnostic look like an ignored one.
+		const service = makeService({
+			results: resultsOnly,
+			allocationCoverage: { allocated: 465, matched: 4, fraction: NaN }
+		});
+
+		service.goToNextLevel();
+
+		expect(alertSpy).not.toHaveBeenCalled();
+	});
+});

--- a/v2/src/app/services/game.service.ts
+++ b/v2/src/app/services/game.service.ts
@@ -32,6 +32,8 @@ export class GameService {
 	private levels: Level[] = [];
 	private gameId = uuid.v4();
 	private customColors: CustomColors[] = [];
+	// Once per game, not once per round — see warnIfAllocationWasIgnored.
+	private allocationWarningShown = false;
 
 	highlightFieldObs = this.highlightFields.asObservable();
 	currentLevelObs = this.currentLevel.asObservable();
@@ -119,6 +121,7 @@ export class GameService {
 				this.apiService.postRequest(this.settings.value.calcUrl, inputData).subscribe({
 					next: (res) => {
 						const convertedResult = res as CalculationResult;
+						this.warnIfAllocationWasIgnored(convertedResult);
 						this.prepareNextLevel(convertedResult, score);
 						this.loading(false);
 					},
@@ -440,6 +443,39 @@ export class GameService {
 	openHelp(close = false) { this.helpWindow.next(!close); }
 
 	/**
+	 * The round scored, and the scores may have almost nothing to do with what the player did.
+	 *
+	 * raster::reclassify() ignores any id that is not in the base raster — no warning, no error —
+	 * so an allocation in the wrong id space returns 200, a full set of consequence maps, and five
+	 * finite scores that are the SAME for every round. The raster committed to this repository is
+	 * exactly that case against the real board: 4 ids in common out of 465. The calculator has
+	 * measured this since 2026-07-31 and only ever logged it, which reaches whoever reads the
+	 * container's stdout and not the person running the workshop.
+	 *
+	 * Warn once per game, not once per round: this is a deployment mismatch that will not change
+	 * between rounds, so repeating it every time trains people to dismiss it.
+	 */
+	private warnIfAllocationWasIgnored(result: CalculationResult) {
+		// Absent means "this calculator does not report it", not "nothing matched" — only esgame's
+		// own tools/R sends the field. Saying a round was ignored because a backend is quiet would
+		// be worse than saying nothing.
+		const coverage = result?.allocationCoverage;
+		if (!coverage || this.allocationWarningShown) return;
+		if (typeof coverage.fraction !== 'number' || !isFinite(coverage.fraction)) return;
+		// Matches warn_below in tools/R/coverage.R. Both sides warn on the same round.
+		if (coverage.fraction >= 0.5) return;
+
+		this.allocationWarningShown = true;
+		const percent = Math.round(100 * coverage.fraction);
+		alert(
+			`Only ${percent}% of this round reached the model (${coverage.matched} of ${coverage.allocated} areas).\n\n` +
+			`The scores below barely depend on where things were placed, and will look much the ` +
+			`same every round. This usually means the calculation backend is using a different ` +
+			`base map than this board.`
+		);
+	}
+
+	/**
 	 * A level failed to build. Without this the loading spinner ran forever: prepareNextLevel
 	 * fetches every consequence map, and if one of them fails — a 404 for a raster that is not
 	 * in the build, say — the combineLatest errors, the subscribe body never runs, and nothing
@@ -474,6 +510,8 @@ export class GameService {
 
 
 	resetGame() {
+		// A new game may be a new backend, so the warning is owed again.
+		this.allocationWarningShown = false;
 		this.currentLevel.next(null);
 		this.highlightFields.next([]);
 		this.selectedFields.next([]);

--- a/v2/src/app/shared/models/calculation-result.ts
+++ b/v2/src/app/shared/models/calculation-result.ts
@@ -1,5 +1,25 @@
 export class CalculationResult {
 	results: Result[];
+	/**
+	 * How much of the allocation the calculator could actually use. Optional: only esgame's own
+	 * tools/R sends it, and a calculator that does not is not misbehaving — so absent must mean
+	 * "not reported", never "nothing matched".
+	 */
+	allocationCoverage?: AllocationCoverage;
+}
+
+/**
+ * reclassify() silently ignores any id that is not in the base raster, so an allocation in the
+ * wrong id space still returns 200 with finite scores that do not depend on it. These are the
+ * numbers that tell the two apart.
+ */
+export class AllocationCoverage {
+	/** Distinct ids the round sent. */
+	allocated: number;
+	/** How many of them exist in the base raster. */
+	matched: number;
+	/** matched / allocated, 0..1. */
+	fraction: number;
 }
 
 export class Result {


### PR DESCRIPTION
`raster::reclassify()` drops any id that is not in the base raster — no warning, no error — so an allocation in the wrong id space returns 200, a full set of consequence maps, and five finite scores that are **identical every round**. The raster committed to this repository is exactly that case against the real board: **4 ids in common out of 465**.

`coverage.R` has measured this since #150 and only ever logged it. Every reader of that number so far has been a test or a log. The person the round actually misleads — someone running a workshop, watching scores that will not move next round — had no way to know short of reading the calculator's stdout.

## The change

`/esgame` returns the numbers next to `results`:

```
{ "results": [ … ], "allocationCoverage": { "allocated": 465, "matched": 4, "fraction": 0.0086 } }
```

and below 50% the game says so, naming the figures rather than showing a generic failure:

> Only 1% of this round reached the model (4 of 465 areas).
>
> The scores below barely depend on where things were placed, and will look much the same every round. This usually means the calculation backend is using a different base map than this board.

**Once per game, not once per round.** It is a deployment mismatch that cannot change between rounds, and a dialog that repeats is one people learn to dismiss unread.

## What must stay silent

`results` is unchanged and the new field is **optional**, so a calculator that does not send it (PLACES carries its own `calculation.r`) is not accused of ignoring the round. Asserted, not merely intended — absent, malformed (`NaN`) and high-coverage responses each have a spec. The field is omitted entirely when the diagnostic itself failed, because a client cannot tell *"0% matched"* from *"could not measure"* if both arrive as zeroes.

## Measured, on the cluster, where this is real rather than contrived

Both branches of the R change, POSTed through the ingress:

```
board-space ids  (100, 200, …)   ->  allocated 59,  matched 4,   fraction 0.0678
raster-space ids (10 … 119)      ->  allocated 110, matched 107, fraction 0.9727
```

And in a real browser round against the live cluster:

```
allocation sent by the browser: 465 hexagons
calculator reported: 4 of 465 ids used (1%)
warning shown to the player: yes
```

`ingress-test.sh` still PASSes (its 455/455 is high, so no warning is expected there) and both browser specs pass.

## Confirmed able to fail

| Mutation | Result |
|---|---|
| drop the call | 4 unit specs fail |
| warn every round instead of once | `warns once per game, not once per round` fails |
| treat an absent field as zero coverage | `stays silent when the calculator does not report coverage` fails |
| point the browser spec at a phrase the app never says | fails with *"the player was not told the round had been ignored"* |

## One thing I got wrong first

That browser assertion **skipped silently** in its first form. I had put it inside the block that reads the pod log via `kubectl` — which degrades to a console note when `kubectl` is absent, as it was on the very run meant to prove the warning. It passed, printed `(allocation coverage unavailable …)`, and asserted nothing. Precisely the shape this repo's vacuity audit exists to catch, freshly reintroduced.

It now reads the response the browser itself received, so it needs nothing but the browser. The `kubectl` block still reports the log-side figure and is still allowed to degrade.

Unit tests 378 → 385; the documented count is updated with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AnDjKpsry35P8YQHkVr8p