### PR TITLE
feat(ui): the level stacks into one column below 620px

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -29,7 +29,7 @@ Verified working
    * - Path
      - How it was checked
    * - Static / grid game
-     - 385 unit tests, 12 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
+     - 385 unit tests, 18 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
        SEO 100. The board renders 2,436 fields; the e2e suite asserts that rather than
        just asserting the component mounted.
    * - No external runtime deps
@@ -568,8 +568,8 @@ Container security context — *added 2026-07-31*, extended *2026-08-05* and *20
    catch a change to the rolling esgame base, it runs the image and curls it, and it fails on
    exactly this. The guard works; the fix belongs in that repository.
 
-The layout needs about 620px, and scrolls sideways below that
-   Measured against the live cluster at four widths, on ``/dynamic-game``:
+The layout needed about 620px, and now stacks below it — *fixed 2026-08-06*
+   Measured against the live cluster at four widths, on ``/dynamic-game``, **before the fix**:
 
    .. code-block:: text
 
@@ -584,12 +584,40 @@ The layout needs about 620px, and scrolls sideways below that
    that does not scroll (``scrollWidth == clientWidth``), which is easy to mistake for the
    button being clipped away entirely; it is the component that scrolls, not the page.
 
-   But a player on a phone has to discover that sideways scroll to advance a level, and three of
-   the six production types are off-screen until they do. Whether that matters is a product
-   decision — this is a 466-hexagon board built for workshops — so it is recorded rather than
-   redesigned. The three panels are ``flex: 0 1 25% / 0 0 50% / 0 1 25%``
-   (:file:`v2/src/app/level/level-base.component.scss`); making it reflow below ~620px means
-   choosing what the narrow layout should look like, not adjusting a number.
+   But a player on a phone had to discover that sideways scroll to advance a level, with three of
+   the six production types off-screen until they did. That was recorded rather than redesigned
+   because it was a product decision — this is a 466-hexagon board built for workshops — and
+   making it reflow means choosing what the narrow layout should be, not adjusting a number.
+
+   **The decision was taken on 2026-08-06: below 620px the panels stop being a row.** Production
+   types, board, scores and *Next Level* in one column, with the side maps above and below. The
+   board keeps its size and scrolls inside its own wrapper rather than taking the page with it.
+   The wide layout is untouched — ``25% / 50% / 25%`` is what a projector or a tablet gets, and
+   that is what the game was designed around.
+
+   One thing was load-bearing and not obvious. ``.panel`` carries ``padding: 0 15px``, so with the
+   default ``content-box`` a panel at ``width: 100%`` is 100% **plus 30px** — measured at 420px in
+   a 390px viewport, which put *Next Level* past the right edge while every other control looked
+   fine. ``box-sizing: border-box`` on the stacked panels is the fix.
+
+   Asserted rather than re-measured by hand, at the same four widths plus the grid game:
+   :file:`v2/e2e/narrow-layout.spec.ts`. Each width checks that the document does not scroll
+   sideways, that **every** production type is fully on screen, and that *Next Level* is. A
+   separate spec asserts the ``flex-direction`` itself in both directions — 1024px and 620px must
+   still be a row, 390px a column — because "everything fits" alone would be satisfied by stacking
+   at every width, quietly throwing the wide layout away.
+
+   Confirmed by mutation: with the media query removed the suite fails with
+   ``3 of 6 production types are off-screen at 390px`` and ``the narrow layout should be a
+   column`` — reproducing the measurement in the table above exactly, at the width it was taken.
+
+   .. note::
+
+      The first run of that spec reported *"no production types rendered; this test would be
+      checking nothing"* and the second measured a stale build. Both are the presence-first rule
+      earning its keep: the spec waited on the board, which becomes visible a beat before the
+      types populate, and ``npx playwright test`` does not rebuild — so an early measurement was
+      of the previous ``dist``. Neither would have been visible as anything but a green run.
 
 No default IngressClass is assumed
    The three Ingresses set no ``ingressClassName``. If the cluster has no default

--- a/v2/e2e/narrow-layout.spec.ts
+++ b/v2/e2e/narrow-layout.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect, Page } from '@playwright/test';
+
+// The board is 466 hexagons built for a workshop projector, and the level is three panels at
+// 25% / 50% / 25% of a row. That row needs about 620px. Below it, three of the six production
+// types were off-screen and Next Level with them.
+//
+// Nothing was ever unreachable — tro-svg-level sets overflow: auto, so the content scrolled
+// sideways and every control could be scrolled to. But it is the component that scrolls, not the
+// page, which is easy to mistake for the button being clipped away entirely: a player on a phone
+// had to discover a sideways scroll to advance a level.
+//
+// So below 620px the panels stop being a row. These are the widths that measurement was taken at
+// (docs/verification-status.rst), asserted rather than re-measured by hand.
+
+const WIDTHS = [
+	{ name: 'phone', width: 390, height: 844 },
+	{ name: 'small tablet', width: 600, height: 900 },
+	{ name: 'iPad', width: 768, height: 1024 },
+	{ name: 'laptop', width: 1024, height: 768 },
+];
+
+/** Is every part of the element inside the viewport, without scrolling anything? */
+async function fullyOnScreen(page: Page, selector: string, nth = 0) {
+	const box = await page.locator(selector).nth(nth).boundingBox();
+	if (!box) return false;
+	const view = page.viewportSize()!;
+	return box.x >= 0 && box.y >= 0 && box.x + box.width <= view.width + 1;
+}
+
+for (const { name, width, height } of WIDTHS) {
+	test(`the level fits at ${width}px (${name})`, async ({ page }) => {
+		await page.setViewportSize({ width, height });
+		await page.goto('/dynamic-game');
+		// Wait for the production types, not the board: the board becomes visible first and the
+		// types populate a beat later, which made the count guard below fire on an empty list.
+		await expect(page.locator('tro-production-type-button').first()).toBeVisible();
+
+		// 1. The DOCUMENT must not scroll sideways. This was already true before the narrow
+		//    layout — the component scrolled instead — so on its own it proves nothing. It is
+		//    here because it is the thing that would regress if the fix were "let the page
+		//    scroll", and a regression there is invisible in the assertions below.
+		const doc = await page.evaluate(() => ({
+			scrollWidth: document.documentElement.scrollWidth,
+			clientWidth: document.documentElement.clientWidth,
+		}));
+		expect(doc.scrollWidth, `document scrolls sideways at ${width}px`)
+			.toBeLessThanOrEqual(doc.clientWidth + 1);
+
+		// 2. Every production type reachable without scrolling. This is the one that failed:
+		//    three of six sat outside the viewport at 390px.
+		const buttons = page.locator('tro-production-type-button');
+		const count = await buttons.count();
+		expect(count, 'no production types rendered; this test would be checking nothing').toBeGreaterThan(0);
+
+		const offScreen: number[] = [];
+		for (let i = 0; i < count; i++) {
+			if (!await fullyOnScreen(page, 'tro-production-type-button', i)) offScreen.push(i);
+		}
+		expect(offScreen, `${offScreen.length} of ${count} production types are off-screen at ${width}px`)
+			.toEqual([]);
+
+		// 3. And the control that ends the round.
+		const next = page.locator('button.btn-next');
+		await expect(next).toBeVisible();
+		expect(await fullyOnScreen(page, 'button.btn-next'), `Next Level is off-screen at ${width}px`)
+			.toBe(true);
+	});
+}
+
+// The grid game is the canonical one — it is what GitHub Pages serves — and it shares
+// level-base.component.scss with the SVG level, so it takes this layout whether or not anyone
+// aimed it there. Its board is a 28x29 grid rather than 466 hexagons, so it is a different shape
+// at the same width and worth one pass of its own.
+test('the grid game fits on a phone too', async ({ page }) => {
+	await page.setViewportSize({ width: 390, height: 844 });
+	await page.goto('/');
+	await expect(page.locator('tro-production-type-button').first()).toBeVisible();
+
+	const doc = await page.evaluate(() => ({
+		scrollWidth: document.documentElement.scrollWidth,
+		clientWidth: document.documentElement.clientWidth,
+	}));
+	expect(doc.scrollWidth, 'document scrolls sideways on the grid game at 390px')
+		.toBeLessThanOrEqual(doc.clientWidth + 1);
+
+	const count = await page.locator('tro-production-type-button').count();
+	expect(count, 'no production types rendered; this test would be checking nothing').toBeGreaterThan(0);
+	const offScreen: number[] = [];
+	for (let i = 0; i < count; i++) {
+		if (!await fullyOnScreen(page, 'tro-production-type-button', i)) offScreen.push(i);
+	}
+	expect(offScreen, `${offScreen.length} of ${count} production types are off-screen`).toEqual([]);
+
+	expect(await fullyOnScreen(page, 'button.btn-next'), 'Next Level is off-screen').toBe(true);
+});
+
+test('the panels are a row when there is room for one, and a column when there is not', async ({ page }) => {
+	// The 25/50/25 row is the layout this game was designed around and is what a projector or a
+	// tablet gets. Asserting only "everything fits" would be satisfied by stacking at every width,
+	// which would quietly throw that away — so assert the direction itself, both ways.
+	await page.goto('/dynamic-game');
+	await expect(page.locator('tro-production-type-button').first()).toBeVisible();
+
+	const direction = () => page.evaluate(() => {
+		const host = document.querySelector('tro-svg-level');
+		return host ? getComputedStyle(host).flexDirection : null;
+	});
+
+	await page.setViewportSize({ width: 1024, height: 768 });
+	expect(await direction(), 'the wide layout should still be a row').toBe('row');
+
+	await page.setViewportSize({ width: 390, height: 844 });
+	expect(await direction(), 'the narrow layout should be a column').toBe('column');
+
+	// 620px is the width the row needs; the breakpoint is max-width: 619px, so 620 is still a row.
+	await page.setViewportSize({ width: 620, height: 900 });
+	expect(await direction(), '620px is the width the row needs, so it should still be a row').toBe('row');
+});

--- a/v2/src/app/level/level-base.component.scss
+++ b/v2/src/app/level/level-base.component.scss
@@ -87,3 +87,77 @@
 	gap: 15px;
 	margin-bottom: 15px;
 }
+
+
+// ---------------------------------------------------------------------------------------------
+// Narrow layout.
+//
+// The three panels are 25% / 50% / 25% of a row, and the row needs about 620px before the centre
+// column stops being usable. Measured against a live deployment at four widths, on /dynamic-game:
+//
+//   390px viewport | content 619px | overflow 229px | 3/6 production buttons clipped | Next clipped
+//   600px viewport | content 619px | overflow  19px | 0/6 clipped                    | Next visible
+//   768px viewport | content 768px | overflow   0px | 0/6 clipped                    | Next visible
+//
+// Nothing was unreachable — tro-svg-level sets overflow: auto, so the content scrolled sideways
+// and every control could be scrolled to. But a player on a phone had to discover that scroll to
+// advance a level, with half the production types off-screen until they did.
+//
+// So below the width the row needs, the panels stop being a row: production types, board, scores
+// and Next Level in one column, with the side maps above and below. The board keeps its size and
+// scrolls inside its own wrapper rather than taking the page with it.
+//
+// 619px, not 620px: the row is fine AT 620, and `max-width` is inclusive.
+// ---------------------------------------------------------------------------------------------
+@media (max-width: 619px) {
+	:host {
+		flex-direction: column;
+
+		.panel,
+		.left-panel,
+		.center-panel,
+		.right-panel {
+			// Not `flex: 1`: in a column that distributes the viewport height between the panels
+			// and squashes the board. Each panel takes the height its content needs.
+			flex: 0 0 auto;
+			// border-box is load-bearing, not tidiness. .panel carries `padding: 0 15px`, and with
+			// the default content-box `width: 100%` means 100% PLUS 30px — measured at 420px in a
+			// 390px viewport, which put Next Level 15px past the right edge while every other
+			// control looked fine. That is the same 30px in every panel.
+			box-sizing: border-box;
+			width: 100%;
+			align-self: stretch;
+		}
+
+		// Sticky is what keeps the board in view while the side columns scroll past it. In a
+		// single column there is nothing to scroll past — it would pin the board over the maps
+		// stacked below it instead.
+		.panel.center-panel {
+			position: static;
+		}
+
+		// The six buttons are a single flex row, which is what clipped three of them. Wrapping is
+		// the whole fix for that; centring keeps a part-full last row from hugging the left edge.
+		.production-type-buttons {
+			flex-wrap: wrap;
+			justify-content: center;
+			gap: 15px;
+		}
+
+		// flex-end lines the board up with the right-hand column in the wide layout. Centred here,
+		// and allowed to scroll itself: the board is a fixed-aspect hexagon grid built for a
+		// projector, so on a phone something has to give, and it should be the board's own box
+		// rather than the document.
+		.game-board-wrapper {
+			max-width: 100%;
+			align-items: center;
+			overflow-x: auto;
+		}
+
+		// Two equal columns put Previous and Next side by side at ~150px each. Stacked, each
+		// control gets the full width instead.
+		.score-board-wrapper {
+			grid-template-columns: 1fr;
+		}
+	}
+}


### PR DESCRIPTION
The last item on the parked list, and the only one that was blocked on a decision rather than on work. You chose stacking; this implements it.

## The problem, as recorded

Three panels at 25% / 50% / 25% of a row, and that row needs about 620px:

```
phone          390px viewport | content 619px | overflow 229px | 3/6 production buttons clipped | Next Level clipped
small tablet   600px viewport | content 619px | overflow  19px | 0/6 clipped                    | Next Level visible
iPad           768px viewport | content 768px | overflow   0px | 0/6 clipped                    | Next Level visible
laptop        1024px viewport | content 1024px| overflow   0px | 0/6 clipped                    | Next Level visible
```

Nothing was ever *unreachable* — `tro-svg-level` sets `overflow: auto`, so the content scrolled sideways and every control could be scrolled to. But a player on a phone had to discover that scroll to advance a level.

## The change

Below 620px the panels stop being a row: production types, board, scores and *Next Level* in one column, side maps above and below. The board keeps its size and scrolls inside its own wrapper rather than taking the page with it.

**The wide layout is untouched.** 25/50/25 is what a projector or a tablet gets, and is what the game was designed around.

## One thing was load-bearing and not obvious

`.panel` carries `padding: 0 15px`, so with the default `content-box` a panel at `width: 100%` is 100% **plus 30px** — measured at **420px in a 390px viewport**, which put *Next Level* past the right edge while every other control looked fine. `box-sizing: border-box` is the fix.

## Asserted, not re-measured by hand

`v2/e2e/narrow-layout.spec.ts` covers the same four widths plus the grid game — which shares this stylesheet and so takes the layout whether or not anyone aimed it there. Each width checks that the document does not scroll sideways, that **every** production type is fully on screen, and that *Next Level* is.

A separate spec asserts `flex-direction` in **both** directions — 1024px and 620px must still be a row, 390px a column. "Everything fits" alone would be satisfied by stacking at every width, quietly throwing the wide layout away.

**Confirmed by mutation.** With the media query removed:

```
Error: 3 of 6 production types are off-screen at 390px
Error: the narrow layout should be a column
```

— reproducing the recorded measurement exactly, at the width it was taken.

## Two false readings on the way

Both caught by presence-first guards rather than by luck, and both worth recording:

- The spec first waited on the **board**, which becomes visible a beat before the production types populate → `no production types rendered; this test would be checking nothing`.
- `npx playwright test` does **not** rebuild, so an early measurement was of the previous `dist` — I "fixed" `box-sizing` and watched it not take effect.

Neither would have shown up as anything but a green run.

## Verified

```
e2e         18 passed  (12 -> 18)
unit       385 passed  (unchanged)
lighthouse green, all budget assertions pass
docs       sphinx -W clean, :file: references resolve
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AnDjKpsry35P8YQHkVr8p