### PR TITLE
docs: the published site, re-checked live after a day that changed a lot of it

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -110,6 +110,15 @@ Verified working
        **2,436 fields** from real GeoTIFFs with no page errors, ``assets/config.json``
        serves ``defaultMode: static`` / ``calcUrl: ""``, and the published docs resolve —
        including the links places' README points at.
+
+       **Re-checked 2026-08-06** (``a7591c9``), after a day that rebuilt the image on an
+       unprivileged nginx, changed the level layout and added a dialog to the round. Still
+       2,436 fields, the same served config, **zero page errors and zero responses ≥ 400**.
+       The narrow layout is live: ``/dynamic-game`` renders its 466 hexagons at 390, 600, 768
+       and 1024px with **6/6 production types on screen and *Next Level* reachable at every
+       one** — against the 3/6 clipped that was measured there before. ``flex-direction`` is
+       ``column`` at 390 and 600, ``row`` at 768 and 1024, and the document never scrolls
+       sideways.
    * - Multi-round game
      - Three consecutive rounds against the real ``tools/R``: three distinct GeoServer
        workspaces, scores that moved with each allocation, and 15/15 coverages still


### PR DESCRIPTION
Today rebuilt the frontend image on an unprivileged nginx, moved its port, changed the level layout and added a dialog to the round. The Pages workflow went green for all of it — which proves a build and a deploy, and not that anyone can play the game. That distinction is why this page exists.

So I opened it, at `a7591c9`:

```
grid game        2,436 fields, config.json unchanged, 0 page errors, 0 responses >= 400

/dynamic-game    466 hexagons at every width
                 390px  dir=column  types on screen=6/6  Next visible=true  doc scrolls sideways=false
                 600px  dir=column  types on screen=6/6  Next visible=true  doc scrolls sideways=false
                 768px  dir=row     types on screen=6/6  Next visible=true  doc scrolls sideways=false
                1024px  dir=row     types on screen=6/6  Next visible=true  doc scrolls sideways=false
```

**The 6/6 at 390px is the one worth having** — that is where 3 of 6 were clipped when the layout was first measured. #172's specs assert this against a local build; this is the deployed artefact, and it is the only evidence that what a visitor actually loads is what the suite tested.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AnDjKpsry35P8YQHkVr8p