### PR TITLE
feat: the compose stacks can move off their default ports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,11 @@
 #                                     FastAPI calculator + seeded GeoServer) - playable end to end
 #   make esgame-dynamic-example-down  stop + remove the example
 #
-# (All stacks publish the frontend on :81, so run one at a time on a given host.)
+# (All stacks publish the frontend on :81 by default, so run one at a time on a given host —
+# or move them: ESGAME_FRONTEND_PORT, ESGAME_GEOSERVER_PORT and ESGAME_PYGEOAPI_PORT override the
+# published ports, and the browser-facing URLs the calculator returns follow them. The example's
+# calculator port is deliberately fixed at 8000 because that example bakes calcUrl into
+# examples/esgame-dynamic/frontend/config.json — see the comment there.)
 
 COMPOSE_STATIC  := docker compose -p esgame -f v2/docker-compose.yml
 COMPOSE_DYNAMIC := docker compose -p esgame-dynamic -f v2/docker-compose.yml -f v2/docker-compose.dynamic.yml
@@ -35,7 +39,7 @@ esgame-build:
 esgame-up: esgame-build
 	$(COMPOSE_STATIC) up -d
 	@echo ""
-	@echo "esgame stack up:  http://localhost:81/   (static grid / Configuration 2)"
+	@echo "esgame stack up:  http://localhost:$(or $(ESGAME_FRONTEND_PORT),81)/   (static grid / Configuration 2)"
 
 ## Stop and remove the 'esgame' stack.
 esgame-down:
@@ -52,9 +56,9 @@ esgame-dynamic-up: esgame-dynamic-build
 	$(COMPOSE_DYNAMIC) up -d
 	@echo ""
 	@echo "esgame-dynamic stack up:"
-	@echo "  frontend    http://localhost:81/"
-	@echo "  calculator  http://localhost:8000/"
-	@echo "  geoserver   http://localhost:8080/geoserver"
+	@echo "  frontend    http://localhost:$(or $(ESGAME_FRONTEND_PORT),81)/"
+	@echo "  calculator  http://localhost:$(or $(ESGAME_CALC_PORT),8000)/"
+	@echo "  geoserver   http://localhost:$(or $(ESGAME_GEOSERVER_PORT),8080)/geoserver"
 
 ## Stop and remove the 'esgame-dynamic' stack.
 esgame-dynamic-down:
@@ -74,8 +78,8 @@ esgame-dynamic-example-build:
 esgame-dynamic-example-up: esgame-dynamic-example-build
 	$(COMPOSE_EXAMPLE) up -d
 	@echo ""
-	@echo "esgame-dynamic example up:  http://localhost:81/  (place fields, press Next Level)"
-	@echo "  calculator http://localhost:8000/   geoserver http://localhost:8080/geoserver"
+	@echo "esgame-dynamic example up:  http://localhost:$(or $(ESGAME_FRONTEND_PORT),81)/  (place fields, press Next Level)"
+	@echo "  calculator http://localhost:8000/   geoserver http://localhost:$(or $(ESGAME_GEOSERVER_PORT),8080)/geoserver"
 	@echo "  (GeoServer needs ~30-60s to start + be seeded before round 2 works)"
 
 ## Stop and remove the example (keeps the geoserver-data volume; add 'down -v' to wipe it).
@@ -96,8 +100,8 @@ esgame-dynamic-pygeoapi-build:
 esgame-dynamic-pygeoapi-up: esgame-dynamic-pygeoapi-build
 	$(COMPOSE_PYGEOAPI) up -d
 	@echo ""
-	@echo "esgame-dynamic (pygeoapi) up:  http://localhost:81/  (place fields, press Next Level)"
-	@echo "  calculator http://localhost:8000/   pygeoapi http://localhost:5005/"
+	@echo "esgame-dynamic (pygeoapi) up:  http://localhost:$(or $(ESGAME_FRONTEND_PORT),81)/  (place fields, press Next Level)"
+	@echo "  calculator http://localhost:8000/   pygeoapi http://localhost:$(or $(ESGAME_PYGEOAPI_PORT),5005)/"
 	@echo "  (pygeoapi starts in a few seconds; rasters are read-only, from its static config)"
 
 ## Stop and remove the pygeoapi variant.

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -76,6 +76,14 @@ Verified working
    * - ``examples/esgame-dynamic`` (GeoServer)
      - Full stack up: seeder reports ``verified 8 coverage stores``, WCS ``GetCoverage``
        returns a GeoTIFF for 8/8, calculator healthy, frontend serves.
+
+       **Re-run 2026-08-06 on non-default ports**, after the frontend image moved to 8080 and
+       the published host ports became overridable. With ``ESGAME_FRONTEND_PORT=8191`` and
+       ``ESGAME_GEOSERVER_PORT=8192``: seeder ``verified 8 coverage stores``, frontend 200,
+       GeoServer 302, calculator 200, and a round returned **8/8 coverage URLs on :8192 and
+       none on :8080**, all fetched back as GeoTIFFs. That last count is the point — the URLs
+       are browser-facing, so a published port that moved without them would have returned 200
+       with URLs nothing could resolve.
    * - ``examples/esgame-dynamic`` (pygeoapi)
      - Same, via OGC API - Coverages: 8 collections advertised, 8/8 return GeoTIFFs, and
        the calculator emits only pygeoapi coverage URLs with no WCS anywhere — which is

--- a/examples/esgame-dynamic/docker-compose.pygeoapi.yml
+++ b/examples/esgame-dynamic/docker-compose.pygeoapi.yml
@@ -35,7 +35,7 @@ services:
       - ./frontend/config.json:/usr/share/nginx/html/assets/config.json:ro
     ports:
       # 8080 container-side: the upstream esgame image runs nginx unprivileged (v2/Dockerfile).
-      - "81:8080"
+      - "${ESGAME_FRONTEND_PORT:-81}:8080"
     depends_on: [calculator]
 
   calculator:
@@ -46,7 +46,10 @@ services:
       # Point the calculator at pygeoapi's OGC API - Coverages instead of GeoServer's WCS. The
       # browser fetches this URL directly, so it is the host-facing pygeoapi address. {coverage} is
       # substituted with the coverage name (e.g. ag_carbon).
-      RASTER_URL_TEMPLATE: "http://localhost:5005/collections/{coverage}/coverage?f=GTiff"
+      # Browser-facing, so it must track the published port below. Left behind, the round
+      # returns 200 with coverage URLs nothing can fetch — the same shape as the portless
+      # CALC_URL in docs/verification-status.rst, which every server-side check passed.
+      RASTER_URL_TEMPLATE: "http://localhost:${ESGAME_PYGEOAPI_PORT:-5005}/collections/{coverage}/coverage?f=GTiff"
     ports:
       - "8000:8000"
 
@@ -59,4 +62,4 @@ services:
     volumes:
       - ./geoserver/rasters:/rasters:ro
     ports:
-      - "5005:80"
+      - "${ESGAME_PYGEOAPI_PORT:-5005}:80"

--- a/examples/esgame-dynamic/docker-compose.yml
+++ b/examples/esgame-dynamic/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - ./frontend/config.json:/usr/share/nginx/html/assets/config.json:ro
     ports:
       # 8080 container-side: the upstream esgame image runs nginx unprivileged (v2/Dockerfile).
-      - "81:8080"
+      - "${ESGAME_FRONTEND_PORT:-81}:8080"
     depends_on: [calculator]
 
   calculator:
@@ -40,8 +40,16 @@ services:
     image: esgame-dynamic-example-calculator
     container_name: esgame-dynamic-calculator
     environment:
-      GEOSERVER_PUBLIC_URL: http://localhost:8080/geoserver    # browser-facing (the WCS URLs it returns)
+      # Browser-facing: these are the WCS URLs the calculator hands back, and the BROWSER
+      # fetches them. It must therefore be the published host port below, not the in-network
+      # name — and it has to move with it, or the round returns 200 with URLs nothing can
+      # resolve. That failure mode is documented in docs/verification-status.rst.
+      GEOSERVER_PUBLIC_URL: http://localhost:${ESGAME_GEOSERVER_PORT:-8080}/geoserver
     ports:
+      # Deliberately NOT parameterised. This example bakes calcUrl into ./frontend/config.json
+      # (that is the point it demonstrates), and the browser reads it from there — so a published
+      # port that did not match would leave the stack starting cleanly and the round failing only
+      # in the browser. Change both together or neither.
       - "8000:8000"
 
   geoserver:
@@ -50,7 +58,7 @@ services:
     environment:
       CORS_ENABLED: "true"
     ports:
-      - "8080:8080"
+      - "${ESGAME_GEOSERVER_PORT:-8080}:8080"
     volumes:
       - geoserver-data:/opt/geoserver_data    # persistent catalog: reloaded on every boot, no re-seed
       - ./geoserver/rasters:/rasters:ro        # the TIFF folder, referenced in place by external coverages

--- a/v2/docker-compose.dynamic.yml
+++ b/v2/docker-compose.dynamic.yml
@@ -9,14 +9,14 @@ services:
   esgame-core:
     environment:
       # The browser reaches the calculator via the published host port (it POSTs client-side).
-      CALC_URL: "http://localhost:8000"
+      CALC_URL: "http://localhost:${ESGAME_CALC_PORT:-8000}"
 
   esgame-calculator:
     build:
       context: ../tools/R
     image: local/esgame-calculator
     ports:
-      - "8000:8000"
+      - "${ESGAME_CALC_PORT:-8000}:8000"
     # url: http://localhost:8000/openapi.json
 
   esgame-geoserver:
@@ -26,5 +26,5 @@ services:
     environment:
       CORS_ENABLED: "true"
     ports:
-      - "8080:8080"
+      - "${ESGAME_GEOSERVER_PORT:-8080}:8080"
     # url: http://localhost:8080/geoserver

--- a/v2/docker-compose.yml
+++ b/v2/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     container_name: esgame-core
     ports:
       # 8080 container-side: the image runs nginx unprivileged (v2/Dockerfile). Host port unchanged.
-      - "81:8080"
+      - "${ESGAME_FRONTEND_PORT:-81}:8080"
     # No CALC_URL set -> the image keeps its built-in assets/config.json (calcUrl ""),
     # i.e. the fully client-side grid game. The dynamic overlay sets CALC_URL.
     # url: http://localhost:81/


### PR DESCRIPTION
Found by hitting it. #166 changed these stacks' *container-side* port on reasoning alone and never ran them, so verifying that was the first job — and the example stack then refused to start, because an unrelated container on this host already held `:8080` and the port was hardcoded.

## The change

`ESGAME_FRONTEND_PORT`, `ESGAME_CALC_PORT`, `ESGAME_GEOSERVER_PORT` and `ESGAME_PYGEOAPI_PORT` override the published ports, defaulting to exactly what was there before. PLACES has worked this way for a while; this is the same pattern.

## The care is all in one place

Some of those ports appear in URLs the **browser** fetches. A published port that moves without them leaves the stack starting cleanly and the round failing only in the browser.

That is not hypothetical — it is the portless `CALC_URL` already written up in `verification-status.rst`, which every server-side check passed. So `GEOSERVER_PUBLIC_URL` and pygeoapi's `RASTER_URL_TEMPLATE` are built from the same variables as the ports they name.

The example's **calculator** port is deliberately *not* parameterised, and says so. That example bakes `calcUrl` into `./frontend/config.json` — the thing it exists to demonstrate — and compose cannot keep a bind-mounted file in step. The two move together or not at all: failing to start beats failing in the browser.

## Verified by running it

The example stack on `ESGAME_FRONTEND_PORT=8191 ESGAME_GEOSERVER_PORT=8192`:

```
seeder       [seed] verified 8 coverage stores
frontend     200 on :8191
geoserver    302 on :8192
calculator   200
a round ->   8/8 coverage URLs on :8192,  0 on :8080,  all fetched back as GeoTIFFs
```

That last line is the one worth having — it is the assertion that the browser-facing URLs followed.

## And it closes #166's untested half

At the defaults, the example frontend serves on `:81` as **uid 101**, with its own `config.json` and `data.json` and its rasters (`200 image/png`); a missing raster 404s and an unknown route falls back to the app. I changed those compose files in #166 without running them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AnDjKpsry35P8YQHkVr8p