### PR TITLE
docs: the pygeoapi variant, run on moved ports rather than assumed

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -88,6 +88,12 @@ Verified working
      - Same, via OGC API - Coverages: 8 collections advertised, 8/8 return GeoTIFFs, and
        the calculator emits only pygeoapi coverage URLs with no WCS anywhere — which is
        the evidence for the "true drop-in" claim.
+
+       **Re-run 2026-08-06 on non-default ports** (``ESGAME_FRONTEND_PORT=8193``,
+       ``ESGAME_PYGEOAPI_PORT=8194``): frontend 200, pygeoapi 200, 8 collections, and a round
+       returned **8/8 coverage URLs on :8194, none left on :5005, and 0 WCS URLs** — all eight
+       fetched back as ``application/x-geotiff``. ``RASTER_URL_TEMPLATE`` is browser-facing, so
+       the zero on :5005 is what says it followed its port rather than being left behind.
    * - ``tools/R`` calculator
      - The **plumbing**: 465-hexagon allocation POSTed to ``/esgame`` → HTTP 200,
        workspace created in GeoServer, five coverages published, WCS 5/5 GeoTIFFs,


### PR DESCRIPTION
#175 parameterised this stack's ports and its `RASTER_URL_TEMPLATE`, and did not run it — the same gap that PR existed to close for its sibling. So I ran it.

```
ESGAME_FRONTEND_PORT=8193  ESGAME_PYGEOAPI_PORT=8194

frontend 200, pygeoapi 200, 8 collections advertised
a round ->  8/8 coverage URLs on :8194
            0 left on :5005
            0 WCS URLs
            all eight fetched back as application/x-geotiff
```

**The zero on :5005 is the assertion worth having.** `RASTER_URL_TEMPLATE` is browser-facing, so it is exactly the thing that gets left behind when a port moves — and the round would still have returned 200 with it wrong.

The zero WCS URLs is the "true drop-in" claim still holding on moved ports.

## A correction to how that was measured

The first count came out **7/7**. The shell `while read` loop silently dropped the final unterminated line, turning eight URLs into seven — and `7/7` reads exactly as convincingly as `8/8`. I only noticed because the response said 8 results.

Re-counted in python against the parsed response: 8 results, 8 with a url, 8 GeoTIFFs. The number in the doc is that one.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AnDjKpsry35P8YQHkVr8p