### PR TITLE
test: gate the R that decides whether a round was scored or ignored

### DIFF
--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -150,6 +150,20 @@ jobs:
             for (f in files) { invisible(parse(f)); cat("  parses:", f, "\n") }
           ' "${files[@]}"
 
+      - name: The coverage reporter must be right, not merely parseable
+        run: |
+          # Parsing is not running, and the step above says so. This runs the one piece of R that
+          # decides whether a round was SCORED or IGNORED — and that failure is silent by
+          # construction, since reclassify() drops ids it does not recognise without a word and
+          # the round returns 200 with finite scores either way.
+          #
+          # Base R, no testthat, no raster, no GDAL: coverage.R's arithmetic was split out of the
+          # raster read so these can run in this job, which installs nothing beyond R itself.
+          # Presence first — a rename would otherwise skip the whole thing and pass.
+          test -f tools/R/test-coverage.R \
+            || { echo "::error::tools/R/test-coverage.R is missing; the R behaviour is ungated again"; exit 1; }
+          Rscript tools/R/test-coverage.R
+
       - name: The calculator reports how much of the allocation it actually used
         run: |
           # reclassify() ignores ids that are not in the base raster. Silently. The committed

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -783,11 +783,20 @@ took ten minutes, so it is written down.
      - Never referenced either. The cold-start path the README documents is a by-hand claim.
        (:file:`deploy/k8s/render-test.sh` *is* run by ``manifests.yml``.)
    * - ``tools/R`` behaviour
-     - There is no test directory and no ``testthat``. ``manifests.yml`` **parses**
-       :file:`tools/R/calculator.r` and :file:`tools/R/coverage.R` and nothing more, so a wrong
-       ``reclassify``, a wrong score or a wrong coverage URL is not something CI can catch. The
-       model is exercised only by the by-hand cluster runs — and, per "the committed base raster"
-       above, those run against data that makes the round nearly inert.
+     - **Partly closed 2026-08-06.** :file:`tools/R/test-coverage.R` now runs in
+       ``manifests.yml`` — 19 assertions over the coverage reporter, the one piece of R that
+       distinguishes a round that was *scored* from one that was *ignored*. Base R and
+       ``stopifnot``: no ``testthat``, no ``raster``, no GDAL, because ``coverage.R``'s arithmetic
+       was split out of the raster read (``esgame_coverage_stats``) so it could run in a job that
+       installs nothing beyond R. Confirmed able to fail by three mutations — dropping the
+       ``unique()``, removing the empty-allocation guard, and reading the ``lulc`` column instead
+       of ``id`` — each caught by the assertion written for it, with exit 1.
+
+       **The model itself is still only parsed.** ``manifests.yml`` checks that
+       :file:`tools/R/calculator.r` is syntactically valid and nothing more, so a wrong
+       ``reclassify``, a wrong score or a wrong coverage URL remains outside CI's reach. It is
+       exercised only by the by-hand cluster runs — and, per "the committed base raster" above,
+       those run against data that makes the round nearly inert.
    * - The compose stacks
      - ``docker compose config`` parses and schema-checks all four; none is ever **started** in
        CI. Every measurement of them on this page is by hand.

--- a/tools/R/coverage.R
+++ b/tools/R/coverage.R
@@ -25,16 +25,26 @@ esgame_allocation_ids <- function(map_AG) {
   suppressWarnings(as.numeric(map_AG))
 }
 
+# The arithmetic, separated from the raster read so it can be tested without GDAL on the machine.
+# That is the whole reason this is its own function: everything below needs `raster` and `logger`,
+# and requiring those to test "does 4 of 465 come out as 0.0086" put the only thing standing
+# between a scored round and an ignored one out of reach of any test. See test-coverage.R.
+#
+# `alloc` and `present` are id vectors, already read out of the request and the raster.
+esgame_coverage_stats <- function(alloc, present) {
+  alloc <- unique(stats::na.omit(alloc))
+  present <- unique(stats::na.omit(present))
+  matched <- length(intersect(alloc, present))
+  list(allocated = length(alloc),
+       matched   = matched,
+       fraction  = if (length(alloc)) matched / length(alloc) else 0)
+}
+
 # Returns the stats invisibly so a caller can assert on them; logs as a side effect.
 esgame_report_coverage <- function(LU_hexa, map_AG, warn_below = 0.5) {
-  stats <- tryCatch({
-    alloc <- unique(stats::na.omit(esgame_allocation_ids(map_AG)))
-    present <- unique(stats::na.omit(raster::values(LU_hexa)))
-    matched <- length(intersect(alloc, present))
-    list(allocated = length(alloc),
-         matched   = matched,
-         fraction  = if (length(alloc)) matched / length(alloc) else 0)
-  }, error = function(e) NULL)
+  stats <- tryCatch(
+    esgame_coverage_stats(esgame_allocation_ids(map_AG), raster::values(LU_hexa)),
+    error = function(e) NULL)
 
   # Never let a diagnostic break a round.
   if (is.null(stats)) {

--- a/tools/R/test-coverage.R
+++ b/tools/R/test-coverage.R
@@ -1,0 +1,95 @@
+# Tests for coverage.R — the only thing in this directory that distinguishes a round that was
+# SCORED from one that was IGNORED.
+#
+# Until 2026-08-06 the R here was gated by `parse()` and nothing else: a wrong reclassify, a wrong
+# score or a wrong coverage fraction could not be caught by CI. That is a poor place to have no
+# tests, because the failure it guards against is silent by construction — reclassify() drops ids
+# it does not recognise without a word, and the round returns 200 with finite scores either way.
+#
+# Base R and `stopifnot`, deliberately: no testthat, no raster, no GDAL. coverage.R's arithmetic
+# was split out of the raster read (esgame_coverage_stats) precisely so these can run anywhere R
+# runs, which is what lets them live in a CI job that already has R and installs nothing.
+#
+#   Rscript tools/R/test-coverage.R
+
+here <- dirname(sub("^--file=", "", grep("^--file=", commandArgs(FALSE), value = TRUE)[1]))
+if (is.na(here) || !nzchar(here)) here <- "tools/R"
+source(file.path(here, "coverage.R"))
+
+failed <- 0
+ran <- 0
+ok <- function(label, expr) {
+  ran <<- ran + 1
+  result <- tryCatch(isTRUE(expr), error = function(e) structure(FALSE, msg = conditionMessage(e)))
+  if (isTRUE(result)) {
+    cat("  ok   ", label, "\n", sep = "")
+  } else {
+    cat("  FAIL ", label, if (!is.null(attr(result, "msg"))) paste0("  (", attr(result, "msg"), ")") else "", "\n", sep = "")
+    failed <<- failed + 1
+  }
+}
+
+cat("==> esgame_allocation_ids: the shapes jsonlite can hand us\n")
+# The real one: jsonlite turns [{"id":1,"lulc":10},...] into a data.frame, id first.
+ok("reads ids from a data.frame", identical(esgame_allocation_ids(
+  data.frame(id = c(10, 20, 30), lulc = c(1, 2, 3))), c(10, 20, 30)))
+ok("reads the FIRST column, not the lulc", identical(esgame_allocation_ids(
+  data.frame(id = c(7, 8), lulc = c(99, 99))), c(7, 8)))
+ok("reads ids from a matrix", identical(esgame_allocation_ids(
+  matrix(c(1, 2, 3, 4), ncol = 2)), c(1, 2)))
+ok("reads a bare numeric vector", identical(esgame_allocation_ids(c(5, 6)), c(5, 6)))
+ok("reads numeric strings", identical(esgame_allocation_ids(c("5", "6")), c(5, 6)))
+# Absence must be empty, never an error: this is a diagnostic and must not take a round down.
+ok("NULL is no ids, not an error", identical(esgame_allocation_ids(NULL), numeric(0)))
+ok("a zero-column frame is no ids", identical(esgame_allocation_ids(data.frame()), numeric(0)))
+ok("unparseable ids become NA rather than throwing",
+   all(is.na(esgame_allocation_ids(c("apple", "pear")))))
+
+cat("==> esgame_coverage_stats: the number that says scored or ignored\n")
+# The case this whole mechanism exists for. The raster committed to this repository numbers its
+# hexagons 10-474; the board numbers its own 100-46500 in hundreds. Four ids in common out of 465.
+board <- seq(100, 46500, by = 100)
+raster_ids <- 10:474
+s <- esgame_coverage_stats(board, raster_ids)
+ok("the committed raster matches 4 of 465", s$allocated == 465 && s$matched == 4)
+ok("...which is about 1%, not a rounding artefact", abs(s$fraction - 4 / 465) < 1e-12)
+ok("...and is below the warn threshold", s$fraction < 0.5)
+
+s <- esgame_coverage_stats(1:10, 1:10)
+ok("a fully matching allocation is 1", s$fraction == 1 && s$matched == 10)
+s <- esgame_coverage_stats(1:10, 100:110)
+ok("a fully disjoint allocation is 0", s$fraction == 0 && s$matched == 0)
+s <- esgame_coverage_stats(1:10, 6:15)
+ok("a half-matching allocation is 0.5", s$matched == 5 && s$fraction == 0.5)
+
+cat("==> and the edges that would produce a misleading number\n")
+# Duplicates must not inflate either side, or a payload repeating one id looks like broad coverage.
+s <- esgame_coverage_stats(c(1, 1, 1, 2), c(1, 1))
+ok("duplicate ids are counted once", s$allocated == 2 && s$matched == 1 && s$fraction == 0.5)
+# Division by zero here would give NaN, and NaN < 0.5 is FALSE — so an empty allocation would
+# silently skip the warning it most deserves.
+s <- esgame_coverage_stats(numeric(0), 1:10)
+ok("an empty allocation is 0, not NaN", s$allocated == 0 && s$fraction == 0 && !is.nan(s$fraction))
+s <- esgame_coverage_stats(1:10, numeric(0))
+ok("an empty raster is 0 matched, not an error", s$matched == 0 && s$fraction == 0)
+# NAs come from ids that did not parse; counting them would overstate the allocation.
+s <- esgame_coverage_stats(c(1, NA, 2), c(1, 2, NA))
+ok("NA ids are dropped from both sides", s$allocated == 2 && s$matched == 2)
+
+cat("==> end to end, the way calculator.r uses it\n")
+alloc <- data.frame(id = board, lulc = rep(10, length(board)))
+s <- esgame_coverage_stats(esgame_allocation_ids(alloc), raster_ids)
+ok("a real request shape gives the same 4 of 465", s$allocated == 465 && s$matched == 4)
+
+cat("\n")
+# Presence first: a rename that made every `ok` disappear would otherwise report success.
+if (ran < 15) {
+  cat("coverage.R tests: FAIL   only ", ran, " assertions ran; this file has more than that\n", sep = "")
+  quit(status = 1)
+}
+if (failed == 0) {
+  cat("coverage.R tests: PASS   ", ran, "/", ran, " assertions\n", sep = "")
+} else {
+  cat("coverage.R tests: FAIL   ", ran - failed, "/", ran, " assertions\n", sep = "")
+  quit(status = 1)
+}


### PR DESCRIPTION
#177 recorded that `tools/R` is *parsed* and not tested, and called it the least covered thing in the repository. That's a poor place to have no tests: the failure it guards against is **silent by construction** — `reclassify()` drops ids it doesn't recognise without a word, and the round returns 200 with finite scores either way. `coverage.R` exists solely to tell those two apart, and nothing checked that it did.

**19 assertions now run in `manifests.yml`**, in the job that already sets up R.

## Base R, deliberately

No `testthat`, no `raster`, no GDAL. That is *why* `coverage.R`'s arithmetic is split out of the raster read into `esgame_coverage_stats`: the numbers were unreachable to any test that couldn't first install GDAL, which is how they ended up untested. The split is behaviour-preserving — the raster read and the logging are untouched.

It also means the CI step installs nothing beyond the R that job already has.

## What's covered

- **The shapes `jsonlite` can hand it** — data.frame, matrix, bare vector, numeric strings, `NULL`, empty frame, unparseable ids.
- **The real 4-of-465 case**, derived from the two id spaces (`seq(100, 46500, 100)` vs `10:474`) rather than hard-coded.
- **The edges that would produce a misleading number**: duplicates inflating the count; an empty allocation dividing to `NaN` — and `NaN < 0.5` is `FALSE`, so it would skip the warning it most deserves; an empty raster; NA ids counted as allocated.

## Confirmed able to fail — by exit code, not by message

| Mutation | Result |
|---|---|
| drop the `unique()` | `duplicate ids are counted once` → exit 1 |
| remove the empty-allocation guard | `an empty allocation is 0, not NaN` → exit 1 |
| read the `lulc` column instead of `id` | 4 assertions fail → exit 1 |

It also refuses to pass having run fewer than 15 assertions, so a rename can't turn it into a green no-op.

## The refactor is verified where it runs

Not only in the test. Rebuilt the calculation image, deployed it, drove real rounds:

```
ingress round-trip: PASS   18/18 checks
browser specs:      2 passed
  calculator reported: 4 of 465 ids used (1%)
  warning shown to the player: yes
```

That 1% is the same figure `test-coverage.R` derives from pure arithmetic. **The test and the deployed system agree without either being told the other's answer.**

`calculator.r` itself is still only parsed — the model remains outside CI's reach, and the doc now says exactly that rather than lumping it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AnDjKpsry35P8YQHkVr8p