### PR TITLE
docs(k8s): there is no rootless GeoServer, and runAsUser here 404s

### DIFF
--- a/deploy/k8s/base/geoserver-deployment.yaml
+++ b/deploy/k8s/base/geoserver-deployment.yaml
@@ -68,6 +68,19 @@ spec:
           # would refuse to start it. The other two containers do set it: the calculation image
           # runs as uid 10001, the frontend as uid 101.
           #
+          # Do not "just add runAsUser" on the strength of those two. Forcing this image to a
+          # non-root uid does not fail; it 404s. Measured 2026-08-06 with `--user 10001:0`:
+          # Tomcat logs `Server startup in [28806] milliseconds` and /geoserver/web returns 404,
+          # because the webapp never deployed — `Unable to create directory for deployment:
+          # /usr/local/tomcat/conf/Catalina/localhost`, plus `Cannot create logs` and a failed
+          # rewrite of its own server.xml. The readiness probe below does catch it — it requests
+          # /geoserver/index.html, which is part of that undeployed webapp and 404s, so the pod
+          # never goes Ready. Visible failure, but no reason to choose it.
+          #
+          # kartoza/geoserver is not an escape either: forced non-root it exits 10 with
+          # `groupadd: Permission denied` — its entrypoint needs root. 2.28.4 is the newest tag
+          # docker.osgeo.org publishes (2.28.5 and 2.29.0 are not). Checked, so nobody re-checks.
+          #
           # readOnlyRootFilesystem is refused here on evidence rather than caution. Run with
           # --read-only it does NOT fail; Tomcat binds and reports "Server startup in 6409 ms"
           # while:

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -602,6 +602,31 @@ Container security context — *added 2026-07-31*, extended *2026-08-05* and *20
    upstream image whose next patch release can move them, with that same silent failure as the
    penalty. ``runAsNonRoot`` is out for the same upstream reason: it runs as uid 0.
 
+   **A rootless GeoServer was looked for on 2026-08-06, and there is not one.** Two findings worth
+   not re-deriving. First, forcing this image to a non-root uid does not fail — it **404s**. With
+   ``--user 10001:0`` Tomcat logs ``Server startup in [28806] milliseconds`` while
+   ``/geoserver/web`` returns 404, because the webapp never deployed:
+
+   .. code-block:: text
+
+      SEVERE [main] HostConfig.beforeStart Unable to create directory for deployment:
+             [/usr/local/tomcat/conf/Catalina/localhost]
+      java.lang.IllegalStateException: Cannot create logs
+      /opt/startup.sh: line 14: /usr/local/tomcat/conf/server.xml: Permission denied
+
+   So a ``runAsUser`` added here on the strength of the other two containers would give a
+   container that logs a successful startup and serves nothing.
+
+   **The readiness probe catches it, and that is worth stating because the first draft of this
+   entry said the opposite.** The probe requests ``/geoserver/index.html``, which is part of the
+   webapp that failed to deploy — measured at **404** on the same container — so the pod never
+   becomes Ready and the rollout fails visibly rather than going green and empty. The probe added
+   in #159 is doing real work here, on a failure mode it was not written for.
+
+   Second, ``kartoza/geoserver`` is not an escape: forced non-root it exits 10 with ``groupadd:
+   Permission denied``, because its entrypoint needs root. It at least fails loudly. 2.28.4 is the
+   newest tag ``docker.osgeo.org`` publishes — 2.28.5 and 2.29.0 are not.
+
    **This breaks anything that maps a host port to container :80, and PLACES is one.** Its
    ``deploy/compose/docker-compose.places.yml`` publishes ``${PLACES_FRONTEND_PORT:-81}:80``
    against a thin image built ``FROM ghcr.io/mlacayoemery/esgame:master``, so the next publish of


### PR DESCRIPTION
You asked me to look for a maintained rootless GeoServer image rather than seed four Tomcat emptyDirs in our manifest. **There isn't one** — but the hunt turned up something more useful than a negative result.

## Forcing a non-root uid doesn't fail. It 404s.

I had documented GeoServer as "runs as uid 0 — measured", which describes its *default* and not what `runAsUser` does. So I tested it. With `--user 10001:0`:

```
INFO  Catalina.start Server startup in [28806] milliseconds     ← looks fine
/geoserver/web         -> 404
/geoserver/index.html  -> 404
```

Because the webapp never deployed:

```
SEVERE HostConfig.beforeStart Unable to create directory for deployment:
       [/usr/local/tomcat/conf/Catalina/localhost]
java.lang.IllegalStateException: Cannot create logs
/opt/startup.sh: line 14: /usr/local/tomcat/conf/server.xml: Permission denied
```

That matters because the other two containers accepted `runAsUser` without argument, and this one *looks* like it does too — it starts, stays up, and logs success.

## kartoza isn't an escape

Forced non-root it exits 10 with `groupadd: Permission denied` — its entrypoint needs root. It fails loudly, which is better, but it doesn't solve the problem. `2.28.4` is still the newest tag `docker.osgeo.org` publishes (2.28.5 and 2.29.0 aren't).

## A correction I made before shipping

My first draft of this entry claimed no probe would catch the 404 pod. **It does.** The readiness probe requests `/geoserver/index.html` — part of the webapp that failed to deploy — so the pod never goes Ready and the rollout fails visibly.

I only noticed because the claim felt too convenient, and checked it on the same container rather than reasoning about it. The probe from #159 turns out to guard a failure mode it wasn't written for.

**The manifest is unchanged — that's the conclusion.** Comment and docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AnDjKpsry35P8YQHkVr8p