### PR TITLE
fix(k8s): kind.sh up required a local registry it does not need

### DIFF
--- a/deploy/k8s/kind.sh
+++ b/deploy/k8s/kind.sh
@@ -98,22 +98,35 @@ nodes:
 EOF
     fi
 
-    echo ">> pointing containerd at the local registry"
-    for node in $(kind get nodes --name "${CLUSTER}"); do
-      docker exec "${node}" mkdir -p "/etc/containerd/certs.d/localhost:${REG_PORT}"
-      docker exec -i "${node}" cp /dev/stdin "/etc/containerd/certs.d/localhost:${REG_PORT}/hosts.toml" <<EOF
+    # The registry is only needed by overlays/local-registry, i.e. for images built here and not
+    # pushed anywhere. overlays/published pulls both from ghcr and needs none of this — which is
+    # what deploy/k8s/README.md already claims, and what .github/workflows/cluster.yml relies on.
+    # Wiring it up unconditionally made `kind.sh up` fail on any host without the registry
+    # running, with `Error response from daemon: No such container: esgame-registry` — after the
+    # cluster had already been created, so a retry hit "cluster already exists" and skipped
+    # straight back to the same line.
+    if docker inspect "${REG_NAME}" >/dev/null 2>&1; then
+      echo ">> pointing containerd at the local registry"
+      for node in $(kind get nodes --name "${CLUSTER}"); do
+        docker exec "${node}" mkdir -p "/etc/containerd/certs.d/localhost:${REG_PORT}"
+        docker exec -i "${node}" cp /dev/stdin "/etc/containerd/certs.d/localhost:${REG_PORT}/hosts.toml" <<EOF
 [host."http://${REG_NAME}:5000"]
   capabilities = ["pull", "resolve"]
   skip_verify = true
 EOF
-    done
+      done
 
-    # Without this the nodes cannot resolve the registry's name at all.
-    if ! docker network inspect kind --format '{{range .Containers}}{{.Name}} {{end}}' | grep -qw "${REG_NAME}"; then
-      docker network connect kind "${REG_NAME}"
-      echo ">> joined ${REG_NAME} to the kind network"
+      # Without this the nodes cannot resolve the registry's name at all.
+      if ! docker network inspect kind --format '{{range .Containers}}{{.Name}} {{end}}' | grep -qw "${REG_NAME}"; then
+        docker network connect kind "${REG_NAME}"
+        echo ">> joined ${REG_NAME} to the kind network"
+      else
+        echo ">> ${REG_NAME} already on the kind network"
+      fi
     else
-      echo ">> ${REG_NAME} already on the kind network"
+      echo ">> no ${REG_NAME} container, so containerd is not being redirected"
+      echo "   overlays/published works as is; for overlays/local-registry, run"
+      echo "   deploy/registry/registry.sh up && deploy/registry/registry.sh push, then this again"
     fi
 
     echo ">> installing ingress-nginx"

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -855,6 +855,14 @@ took ten minutes, so it is written down.
 
        (:file:`deploy/k8s/render-test.sh` is separate and *is* run by ``manifests.yml`` on every
        relevant push.)
+
+       **Its first run failed, which is why it was dispatched rather than assumed.**
+       :file:`deploy/k8s/kind.sh` wired containerd at the local registry unconditionally, so
+       ``up`` died with ``No such container: esgame-registry`` on a host that has none — after
+       creating the cluster, so a retry hit "cluster already exists" and went straight back to the
+       same line. The registry is only needed by ``overlays/local-registry``; that wiring is now
+       skipped when the container is absent, which is what :file:`deploy/k8s/README.md` already
+       claimed of the published path.
    * - ``tools/R`` behaviour
      - **Partly closed 2026-08-06.** :file:`tools/R/test-coverage.R` now runs in
        ``manifests.yml`` — 19 assertions over the coverage reporter, the one piece of R that


### PR DESCRIPTION
The cluster workflow from #182 **failed on its first dispatch** — which is exactly why I dispatched it instead of assuming it worked.

```
>> pointing containerd at the local registry
Error response from daemon: No such container: esgame-registry
```

`kind.sh` wired containerd at the local registry unconditionally. That registry is only needed by `overlays/local-registry` — for images built here and never pushed. `overlays/published` pulls both from ghcr and needs none of it, which is what `deploy/k8s/README.md` already claims and what the workflow relies on.

**Worse than a plain failure:** the cluster had already been created by that point, so a retry took the `cluster already exists` branch and went straight back to the same line. It could not self-heal.

The wiring is now conditional on the container existing, and when it's absent it says what to do rather than dying:

```
>> no esgame-registry container, so containerd is not being redirected
   overlays/published works as is; for overlays/local-registry, run
   deploy/registry/registry.sh up && deploy/registry/registry.sh push, then this again
```

Both branches exercised — `docker inspect` returns 0 for the running registry and non-zero for a name that doesn't exist. I can't create a kind cluster on this host to test the whole path (`kind` isn't installed and the inotify limits are back at 128), so the real proof is re-dispatching the workflow once this merges. I'll report what it does.

## My error, and worth naming

I grepped `kind.sh` for a registry dependency, found nothing in its `need` guards, and concluded there wasn't one. The dependency was thirty lines further down, outside anything a grep for `need` or `registry.sh` would surface. Reading the block would have found it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AnDjKpsry35P8YQHkVr8p