### PR TITLE
docs: esgame and PLACES normalise the scores differently, and PLACES cannot NaN

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -867,6 +867,38 @@ Why the scores go NaN, and it is not only all-nature — *diagnosed 2026-08-06*
    50. That property is worth a domain expert's attention in its own right, separately from the
    NaN.
 
+   **PLACES already normalises the other way, and that is the most useful thing found here.**
+   Its ``calculation/calculation.r`` is the same model family — the repository that carries the
+   real data release — and every indicator there is scaled against **fixed bounds** rather than
+   against the round:
+
+   .. code-block:: text
+
+      esgame  tools/R/calculator.r        places  calculation/calculation.r
+      ------------------------------      -------------------------------------------
+      (HH - cellStats(HH,min))            (HH - 0) / (4.2 - 0) * 100
+        / (cellStats(HH,max)              (NP - 0) / (180 - 0) * 100
+           - cellStats(HH,min)) * 100     (water_leach_focal - 0) / (180 - 0) * 100
+                                          (WA_vuln - 0) / (70 - 0) * 100
+      ...and the same for NP, WA,         (round_tot_HC - optimalHC_score)
+      HC and RV                             / (worstHC_score - optimalHC_score) * 100
+                                          (1 - RV_round) * 100
+
+   Two consequences follow directly, neither of which needs a domain opinion. **PLACES cannot
+   produce this NaN at all** — every denominator is a constant, so neither the empty-surface nor
+   the degenerate-surface case can divide by zero. And **PLACES' scores are comparable across
+   rounds**, because the scale does not move with the data; esgame's are not.
+
+   PLACES also scores **six** indicators to esgame's five, adding water leaching. Taken together
+   that reads like esgame's ``calculator.r`` being the earlier vintage and PLACES' being where the
+   model went — but that is an inference from the code, not something established here, and it is
+   the one part of this worth confirming with whoever wrote them.
+
+   It does change the shape of the question, though. "What should an empty surface score?" is no
+   longer an open modelling problem with no reference: there is a sibling implementation in the
+   same family that does not have the problem, and adopting its approach is a concrete option
+   rather than an invention.
+
 No default IngressClass is assumed
    The three Ingresses set no ``ingressClassName``. If the cluster has no default
    ``IngressClass`` they apply cleanly and route nothing, with no error. Check

--- a/tools/R/scores-sheet.sh
+++ b/tools/R/scores-sheet.sh
@@ -130,4 +130,7 @@ say "2. **Is the direction right?** For each indicator, does the landscape you w
 say "   worst actually score worst? A sign error would be invisible to every test in this repository."
 say "3. **Is the spread usable?** If every landscape lands within a few points, players will not see"
 say "   their choices reflected, whatever the model does internally."
-say "4. **Is NaN acceptable for \`all-nature\`, or should it be a number?** See caveat 2."
+say "4. **Is NaN acceptable for \`all-nature\`, or should it be a number?** See caveat 2. Note that"
+say "   PLACES' \`calculation.r\` normalises every indicator against *fixed* bounds rather than"
+say "   against the round, so it cannot produce this NaN and its scores *are* comparable between"
+say "   rounds. Whether esgame should do the same is the question underneath all of the above."


### PR DESCRIPTION
#185 diagnosed the NaN and left "what should an empty surface score?" as an open modelling question with nothing to reason from. **There is a reference — in the sibling repo.**

PLACES' `calculation/calculation.r` is the same model family (the one carrying the real data release), and scales every indicator against **fixed bounds** rather than against the round:

```
esgame   (HH - cellStats(HH,min)) / (cellStats(HH,max) - cellStats(HH,min)) * 100

places   (HH - 0) / (4.2 - 0) * 100
         (NP - 0) / (180 - 0) * 100
         (water_leach_focal - 0) / (180 - 0) * 100
         (WA_vuln - 0) / (70 - 0) * 100
         (round_tot_HC - optimalHC_score) / (worstHC_score - optimalHC_score) * 100
         (1 - RV_round) * 100
```

## Two consequences, from the code alone

- **PLACES cannot produce this NaN.** Every denominator is a constant, so neither the empty-surface nor the degenerate-surface case from #185 can divide by zero.
- **PLACES' scores are comparable across rounds**, because the scale doesn't move with the data. esgame's aren't — which is the caveat the scores sheet leads with.

PLACES also scores **six** indicators to esgame's five, adding water leaching.

## What I'm inferring vs. what I know

I *know* the two differ as above. I'm **inferring** that esgame's `calculator.r` is the earlier vintage and PLACES' is where the model went — that's flagged as an inference in the doc, not asserted, and it's the one part worth confirming with whoever wrote them.

## Why it matters

It changes the shape of the question rather than answering it. "What should an empty surface score?" is no longer open with nothing to reason from: a sibling implementation in the same family doesn't have the problem, so **adopting its approach is a concrete option rather than an invention**. The scores sheet now says so, since that's where the question gets asked.

Docs and the sheet's closing question only — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AnDjKpsry35P8YQHkVr8p