### PR TITLE
docs: the published site was 12 commits behind, and nothing could tell

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,3 +61,61 @@ jobs:
             echo "::error::sphinx produced ${n} pages; it is not building the docs it should be"
             exit 1
           fi
+
+      - name: The build must say which commit it came from
+        run: |
+          # docs/conf.py stamps build-info.json and a footer line into every build so that
+          # .github/workflows/published.yml can fetch them back off the live site and say
+          # whether it is current. That check is only as good as the stamp: if conf.py stops
+          # emitting it, or emits "unknown", the freshness check downstream starts reporting
+          # "cannot establish" for every run and the twelve-commits-behind condition it exists
+          # to catch becomes invisible again.
+          #
+          # So this gates the producer. It is the cheap, deterministic half of the pair — no
+          # network, no schedule — and it is here rather than in published.yml because this is
+          # where a change to conf.py is actually being reviewed.
+          set -euo pipefail
+          info=/tmp/docs-html/build-info.json
+          test -f "$info" || { echo "::error file=docs/conf.py::no build-info.json; the published site would have no identity"; exit 1; }
+          # The trailing echo is not cosmetic. A ::error:: annotation is only recognised at the
+          # start of a line, so if build-info.json ever lands without a final newline the next
+          # message is glued to the JSON and GitHub renders it as ordinary log text — the step
+          # still fails, but with no annotation pointing at the file. conf.py writes the newline;
+          # this does not depend on it having done so.
+          cat "$info"; echo
+
+          commit=$(python3 -c "import json;print(json.load(open('$info')).get('commit',''))")
+          # "unknown" is what conf.py writes when it cannot identify the build, and an empty
+          # string is what a truncated write leaves. Both must fail here: a stamp that names no
+          # commit is indistinguishable, downstream, from a site that was never redeployed.
+          if [ -z "$commit" ] || [ "$commit" = "unknown" ]; then
+            echo "::error file=docs/conf.py::build-info.json does not name a commit (got '${commit}')"
+            exit 1
+          fi
+          case "$commit" in
+            [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*) ;;
+            *) echo "::error::build-info.json commit '${commit}' is not a sha"; exit 1 ;;
+          esac
+          echo "build-info.json names ${commit}"
+
+          # And the human-readable half, on every page rather than on one: the footer is what a
+          # reader looking at a suspicious page has. Sphinx emits it from html_last_updated_fmt,
+          # which is easy to lose in a conf.py edit without any warning being raised.
+          pages=$(find /tmp/docs-html -name '*.html' | wc -l)
+          stamped=$(grep -rl 'Last updated on' /tmp/docs-html --include='*.html' | wc -l)
+          echo "${stamped}/${pages} pages carry the footer stamp"
+          if [ "${stamped}" -ne "${pages}" ]; then
+            echo "::error file=docs/conf.py::${pages} pages built but only ${stamped} carry a build stamp"
+            exit 1
+          fi
+
+          # The stamp must be the UTC instant the JSON records, not a localised rendering of it.
+          # html_last_updated_fmt goes through Sphinx's date formatter, which substitutes %
+          # codes against LOCAL time; the first version of this printed "06:01:31 UTC" for a
+          # 04:01:33Z build. A wrong timestamp is worse than none, and nothing warns about it.
+          built_at=$(python3 -c "import json;print(json.load(open('$info')).get('built_at',''))")
+          if ! grep -q "Last updated on ${built_at}" /tmp/docs-html/index.html; then
+            echo "::error file=docs/conf.py::the footer stamp does not match build-info.json's built_at (${built_at}); check html_last_updated_fmt is not being re-formatted against local time"
+            exit 1
+          fi
+          echo "footer and build-info.json agree on ${built_at}"

--- a/.github/workflows/published.yml
+++ b/.github/workflows/published.yml
@@ -1,0 +1,75 @@
+name: Published site is current (scheduled)
+
+# Does the documentation people actually read match master?
+#
+# On 2026-08-07 it did not, by twelve commits. Everything from #177 onwards was missing from
+# https://mlacayoemery.github.io/esgame/docs/ and nothing anywhere said so. deploy.yml's
+# `build` job had succeeded; its `deploy` job had failed with "The job was not acquired by
+# Runner of type hosted even after multiple attempts". So the artefact was built and never
+# published, and the site went on serving the previous build with a 200.
+#
+# Every other check in this repository asks a question about the repository. This one asks
+# about a REMOTE ARTEFACT — whether a deploy that reported failure hours ago actually left
+# the world in the state master describes. Nothing else can answer that, because the evidence
+# is not in the tree; it is on the far end of an HTTP request.
+#
+# SCHEDULED ONLY, and it must not become a PR gate. The site legitimately lags a push by the
+# length of a deploy, so as a required check it would fail for a minute or two after every
+# merge and teach people to re-run it — the reasoning set out at the top of cluster.yml. A
+# red scheduled run is a signal someone reads; a red required check is a thing people click
+# through. It is its own workflow rather than a skipped job inside docs.yml so that a pull
+# request never sees it at all: a skipped check is not a pass, and should not have to be
+# explained away on every unrelated PR.
+
+on:
+  schedule:
+    # Daily, unlike the weekly cluster job: a docs deploy runs on every push to master, so the
+    # window in which this can go wrong opens far more often than the cluster's does. 07:10 UTC
+    # is after Monday's other crons (06:00, 06:20, 06:40) so a Monday failure is not read
+    # alongside three unrelated ones.
+    - cron: '10 7 * * *'
+  workflow_dispatch:
+    inputs:
+      max_behind:
+        description: 'Commits the site may lag before this fails'
+        required: false
+        default: '0'
+
+permissions:
+  contents: read
+
+jobs:
+  freshness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The check counts commits between the published sha and master, so it needs the
+          # history. At the default depth of 1 the published commit is not in the clone and
+          # the check cannot tell "12 behind" from "a different repository" — it reports the
+          # latter, which is true but useless.
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: The published site must be built from master
+        run: |
+          python3 docs/_checks/check-published.py \
+            --ref origin/master \
+            --max-behind "${{ github.event.inputs.max_behind || 0 }}"
+
+      - name: What to do when this fails
+        if: failure()
+        run: |
+          echo "The site at https://mlacayoemery.github.io/esgame/docs/ is not built from master."
+          echo
+          echo "Almost always this means the last 'Deploy v2 to GitHub Pages' run did not finish."
+          echo "Check its most recent run and re-dispatch it:"
+          echo "  gh run list --workflow=deploy.yml --limit 5"
+          echo "  gh workflow run deploy.yml --ref master"
+          echo
+          echo "A 404 on build-info.json means the live site predates that file (added 2026-08-07),"
+          echo "which is itself a deploy that never happened."

--- a/docs/_checks/check-published.py
+++ b/docs/_checks/check-published.py
@@ -1,0 +1,125 @@
+"""Is the documentation site people actually read built from the current master?
+
+Found on 2026-08-07: it was not. The live site was twelve commits behind — everything from
+#177 onwards was missing — and no signal existed anywhere. deploy.yml's `build` job had
+succeeded and its `deploy` job had failed to get a runner, so the artefact was produced and
+never published. The site kept serving the previous build with a 200 and no indication that
+it was old.
+
+Sphinx's own build says nothing about this, and neither can any check that only looks at the
+repository: the question is about a *remote artefact*, so it has to be fetched. conf.py
+stamps build-info.json into every build for exactly that reason; this reads it back.
+
+    python3 docs/_checks/check-published.py                     # against HEAD
+    python3 docs/_checks/check-published.py --ref origin/master
+    python3 docs/_checks/check-published.py --url https://example.com/docs/build-info.json
+
+Exit status is 0 only when the published commit is HEAD or an ancestor of it that is at most
+--max-behind commits back. It is deliberately NOT a pull-request gate: the site legitimately
+lags a push by the length of a deploy, so blocking a merge on it would gate unrelated work on
+GitHub Pages' latency. It runs on a schedule, where a red run is a signal rather than a
+roadblock — the same call made for the cluster round-trip in .github/workflows/cluster.yml.
+"""
+import argparse
+import json
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+DEFAULT_URL = "https://mlacayoemery.github.io/esgame/docs/build-info.json"
+
+
+def fail(msg: str) -> None:
+    print(f"::error::{msg}")
+    raise SystemExit(1)
+
+
+def git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args], capture_output=True, text=True, check=True, timeout=30
+    ).stdout.strip()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", default=DEFAULT_URL)
+    ap.add_argument("--ref", default="HEAD", help="the commit the site should have been built from")
+    ap.add_argument("--max-behind", type=int, default=0,
+                    help="commits the site may lag before this fails (0 = must be current)")
+    ap.add_argument("--timeout", type=float, default=30.0)
+    args = ap.parse_args()
+
+    print(f"fetching {args.url}")
+    try:
+        with urllib.request.urlopen(args.url, timeout=args.timeout) as r:
+            body = r.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        # A 404 is the interesting case: it means the live site predates this check, so it was
+        # built before conf.py stamped anything. That is itself staleness, and saying "cannot
+        # tell" would turn the very condition being looked for into a pass.
+        fail(f"{args.url} returned HTTP {e.code}. If this is a 404 the published site was built "
+             f"before build-info.json existed, which means it is stale by at least that much.")
+    except (urllib.error.URLError, TimeoutError) as e:
+        fail(f"could not fetch {args.url}: {e}")
+
+    try:
+        info = json.loads(body)
+    except json.JSONDecodeError as e:
+        fail(f"{args.url} is not JSON ({e}); Pages may be serving an SPA fallback page instead")
+
+    published = str(info.get("commit", "")).strip()
+    built_at = info.get("built_at", "?")
+    print(f"published commit {published or '(none)'} built at {built_at}")
+
+    # "unknown" is what conf.py writes when it could not identify the build. Treating it as a
+    # match would make this check pass precisely when provenance is missing.
+    if not published or published == "unknown":
+        fail("the published site does not name a commit, so its freshness cannot be established")
+
+    try:
+        expected = git("rev-parse", args.ref)
+    except (OSError, subprocess.SubprocessError) as e:
+        fail(f"cannot resolve {args.ref} locally: {e}")
+    print(f"expected commit  {expected} ({args.ref})")
+
+    if published == expected:
+        print(f"PASS: the published site is built from {args.ref}")
+        return
+
+    # Not equal. Distinguish "behind" from "unrelated" — a commit this clone has never seen is
+    # a different failure from a commit that is simply older, and the fix differs too.
+    try:
+        git("cat-file", "-e", f"{published}^{{commit}}")
+    except (OSError, subprocess.SubprocessError):
+        fail(f"published commit {published[:12]} is not in this clone — fetch with depth 0, or the "
+             f"site was built from another repository")
+
+    try:
+        behind = int(git("rev-list", "--count", f"{published}..{expected}"))
+        ahead = int(git("rev-list", "--count", f"{expected}..{published}"))
+    except (OSError, subprocess.SubprocessError, ValueError) as e:
+        fail(f"cannot count the distance from {published[:12]} to {expected[:12]}: {e}")
+
+    if ahead:
+        fail(f"the published site is built from {published[:12]}, which is NOT an ancestor of "
+             f"{args.ref} ({ahead} commits ahead, {behind} behind)")
+
+    print(f"the published site is {behind} commit(s) behind {args.ref}:")
+    # git writes to fd 1 directly while print() buffers, so without this flush the commit list
+    # lands ABOVE the line introducing it — which reads, in a CI log, as a list of commits with
+    # no explanation attached to it.
+    sys.stdout.flush()
+    subprocess.run(["git", "log", "--oneline", f"{published}..{expected}"], check=False)
+    sys.stdout.flush()
+
+    if behind > args.max_behind:
+        fail(f"the published site is {behind} commit(s) behind {args.ref} (allowed: "
+             f"{args.max_behind}). The last deploy did not publish. Re-run the "
+             f"'Deploy v2 to GitHub Pages' workflow.")
+
+    print(f"PASS: {behind} commit(s) behind, within the allowed {args.max_behind}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,11 @@
 # Configuration file for the Sphinx documentation builder.
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import json
+import os
+import subprocess
+import time
+
 project = "esgame"
 copyright = "2026, esgame contributors"
 author = "esgame contributors"
@@ -29,3 +34,99 @@ html_title = "esgame documentation"
 
 # MyST niceties
 myst_heading_anchors = 3
+
+# -- Build provenance --------------------------------------------------------
+#
+# The published site had no way to say which commit it was built from, and on 2026-08-07 it
+# was found to be TWELVE commits behind master: everything from #177 onwards was missing.
+# Nothing reported that. deploy.yml's `build` job had succeeded and its `deploy` job had
+# failed on runner acquisition ("The job was not acquired by Runner of type hosted"), so the
+# Actions tab showed a red run that nobody was watching, while the site itself looked
+# perfectly healthy — it just quietly served day-old documentation.
+#
+# That is the failure mode this repository keeps finding: silent in the passing direction.
+# A reader cannot tell a current page from a stale one, and neither could any check, because
+# the artefact carried no identity at all.
+#
+# So every build stamps what produced it, in two places:
+#
+#   * a visible "Last updated" line in the footer of every page, for a human who is reading
+#     something that looks wrong and wants to know if they are looking at the current text;
+#   * docs/build-info.json next to it, for docs/_checks/check-published.py, which fetches it
+#     from the live site and says how many commits behind master the site actually is.
+#
+# The JSON is what makes staleness *checkable* rather than merely visible. A footer nobody
+# reads catches nothing.
+
+
+def _commit() -> str:
+    """The commit this build came from, or "unknown" — never a plausible-looking guess.
+
+    GITHUB_SHA first, because that is authoritative in Actions and does not need a .git
+    directory. Note it is the *merge* commit on a pull_request event and the pushed commit
+    on a push — which is what we want, since only the push to master is ever published.
+
+    Falling back to `git rev-parse` covers a local `make html`. If both fail the answer is
+    "unknown", and check-published.py treats that as a failure rather than as a match: a
+    build that cannot name itself must not be able to satisfy a freshness check.
+    """
+    sha = os.environ.get("GITHUB_SHA", "").strip()
+    if sha:
+        return sha
+    try:
+        return subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=os.path.dirname(os.path.abspath(__file__)),
+            capture_output=True, text=True, check=True, timeout=10,
+        ).stdout.strip() or "unknown"
+    except (OSError, subprocess.SubprocessError):
+        return "unknown"
+
+
+_COMMIT = _commit()
+_SHORT = _COMMIT[:7] if _COMMIT != "unknown" else "unknown"
+_BUILT_AT = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+# The footer line, and the one place the build time is decided — build-info.json below reuses
+# this exact string, so the human-readable stamp and the machine-readable one cannot drift.
+#
+# It is written out ALREADY FORMATTED, in UTC, with no % codes left in it. Sphinx renders
+# html_last_updated_fmt through its own date formatter, which substitutes % codes against
+# LOCAL time; the first version of this said "%Y-%m-%d %H:%M:%S UTC" and duly published
+# 06:01:31 UTC for a build that happened at 04:01:33Z, because the runner's clock was not.
+# A timestamp that lies about its zone is worse than none — it is the kind of thing a reader
+# would use to conclude a page is current when it is two hours older than it claims.
+#
+# Sphinx 7.1 added html_last_updated_use_utc, which would also fix it, but docs/requirements.txt
+# floats on `sphinx>=7` and an unknown name in conf.py is ignored in silence rather than
+# refused — so on an older Sphinx that option would have failed the same way, undetectably.
+# Leaving no format codes at all works on every version.
+html_last_updated_fmt = f"{_BUILT_AT} (commit {_SHORT})"
+
+
+def _write_build_info(app, exception):
+    """Emit build-info.json into the built site.
+
+    On build-finished rather than at import, so it lands in the real output directory
+    whatever -b/-d were set to. Skipped when the build failed: a half-written site should not
+    advertise a commit it does not contain.
+    """
+    if exception is not None:
+        return
+    info = {
+        "commit": _COMMIT,
+        "ref": os.environ.get("GITHUB_REF", ""),
+        "run_id": os.environ.get("GITHUB_RUN_ID", ""),
+        "built_at": _BUILT_AT,
+        "project": project,
+        "release": release,
+    }
+    out = os.path.join(app.outdir, "build-info.json")
+    with open(out, "w", encoding="utf-8") as fh:
+        json.dump(info, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+
+
+def setup(app):
+    app.connect("build-finished", _write_build_info)
+    return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -339,6 +339,13 @@ The published site was twelve commits behind master — *closed 2026-08-07*
    ``Validate deploy artifacts`` run that sat queued for over eight hours. The artefact was
    built and never published, and Pages went on serving the previous one.
 
+   **It repaired itself, and that is the argument for detecting it rather than against.**
+   When runners came back the next push to master deployed normally and the site caught up in
+   85 seconds — the page went from 94,716 bytes to 127,676, byte-for-byte the local build. So
+   the whole episode leaves no trace: anyone checking afterwards finds a healthy site and no
+   evidence it was ever a day stale. A fault that is invisible while it is happening and gone
+   before anyone looks is not a fault anyone will find by looking harder.
+
    **What that costs is not the outage; it is that the outage was indistinguishable from
    health.** A reader cannot tell a current page from a day-old one, and neither could any
    check. Three things close that:

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -362,6 +362,15 @@ The published site was twelve commits behind master — *closed 2026-08-07*
      and must match ``build-info.json``. A freshness check downstream is worth nothing if the
      thing it reads can quietly stop being written.
 
+   **One stamp covers the game as well as the documentation**, which is worth saying because
+   the check only ever fetches a docs URL. :file:`deploy.yml` builds the Angular app into
+   ``v2/dist/tradeoff-v2`` and Sphinx into ``v2/dist/tradeoff-v2/docs``, then uploads *that
+   whole directory* as one Pages artifact — so the app at ``/esgame/`` and the docs at
+   ``/esgame/docs/`` are published atomically and cannot be at different commits. A stale
+   ``build-info.json`` means the game is equally stale. (places has no Pages deploy and no
+   Sphinx docs — only :file:`.github/workflows/overlay.yml` — so there is nothing to mirror
+   there.)
+
    Both halves were tested by mutation rather than by assertion — the trap in
    `The checks were audited for vacuity`_. The producer gate was run against six broken
    builds (no JSON, ``unknown`` commit, empty commit, a non-sha, one unstamped page, a

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -312,6 +312,73 @@ The loading spinner does not clear when a level fails to build — *fixed 2026-0
    test written without it measures the harness rather than the component, and would have
    reported this bug as unfixable a second time.
 
+.. _The published site was twelve commits behind master:
+
+The published site was twelve commits behind master — *closed 2026-08-07*
+   The documentation at https://mlacayoemery.github.io/esgame/docs/ was serving the build from
+   ``0c322c8`` (#176) while master was at ``a8b29f7`` (#188). Everything merged after #176 —
+   twelve commits, a full day of work, including every finding written up on this page that
+   day — was simply absent from the site people are pointed at. It answered every request with
+   a 200.
+
+   Nothing reported it, and nothing *could*, because the site carried no identity. Sphinx's
+   build says nothing about deployment; every other check in this repository asks a question
+   about the tree, and this is a question about a remote artefact.
+
+   The cause was not a bad build. :file:`.github/workflows/deploy.yml`'s ``build`` job
+   succeeded in 1m16s; its ``deploy`` job then failed with:
+
+   .. code-block:: text
+
+      The job was not acquired by Runner of type hosted even after multiple attempts
+
+   GitHub-hosted runners were unavailable to this repository for about eleven hours on
+   2026-08-06/07 — githubstatus.com reported Actions "operational" throughout, and the
+   repository is public, so this was neither a posted incident nor a spending cap. The visible
+   symptom was runs "failing" after ~15 minutes without executing a step, and one
+   ``Validate deploy artifacts`` run that sat queued for over eight hours. The artefact was
+   built and never published, and Pages went on serving the previous one.
+
+   **What that costs is not the outage; it is that the outage was indistinguishable from
+   health.** A reader cannot tell a current page from a day-old one, and neither could any
+   check. Three things close that:
+
+   * :file:`docs/conf.py` stamps every build. ``build-info.json`` lands beside the HTML with
+     the commit, the ref, the run id and the build time; a "Last updated" line carrying the
+     same instant and the short sha goes into the footer of **every** page.
+   * :file:`.github/workflows/published.yml` fetches that JSON back off the live site daily
+     and reports how many commits behind master it is, naming them. Scheduled only — the site
+     legitimately lags a push, so as a required check it would fail after every merge and
+     teach people to click through it. Same reasoning as :file:`cluster.yml`.
+   * :file:`.github/workflows/docs.yml` gates the producer on every pull request: the stamp
+     must exist, must name a real sha rather than ``unknown``, must be on every page built,
+     and must match ``build-info.json``. A freshness check downstream is worth nothing if the
+     thing it reads can quietly stop being written.
+
+   Both halves were tested by mutation rather than by assertion — the trap in
+   `The checks were audited for vacuity`_. The producer gate was run against six broken
+   builds (no JSON, ``unknown`` commit, empty commit, a non-sha, one unstamped page, a
+   mislabelled timestamp) and fails each with an annotation; the freshness check was run
+   against fixtures for a current site, a stale one, a site that cannot name its commit, a
+   commit from another repository, and Pages serving an SPA fallback instead of JSON. Pointed
+   at the real site it reproduces the finding from scratch: ``12 commit(s) behind master``.
+
+   **A timestamp that lies about its zone is worse than no timestamp**, and this nearly
+   shipped one. ``html_last_updated_fmt`` is rendered through Sphinx's date formatter, which
+   substitutes ``%`` codes against **local** time; the first version read
+   ``"%Y-%m-%d %H:%M:%S UTC"`` and published *06:01:31 UTC* for a build that happened at
+   *04:01:33Z*. Sphinx 7.1 added ``html_last_updated_use_utc``, but :file:`docs/requirements.txt`
+   floats on ``sphinx>=7`` and an unrecognised name in ``conf.py`` is ignored in silence rather
+   than refused — so on an older Sphinx that option would have failed the same way and said
+   nothing. The stamp is now pre-formatted in UTC with no format codes left in it, and the
+   footer and the JSON are the same string by construction, so they cannot drift.
+
+   One consequence reaches beyond the docs. The merge-on-green policy reads CI verdicts, and
+   for those eleven hours CI could not produce one: #186 and #187 were merged against runs that
+   had failed on runner acquisition rather than on their contents. That is what the
+   "re-verify locally before merging" rule exists for, and it held — but it is worth recording
+   that *"the run is red"* and *"the change is bad"* came apart here for a whole day.
+
 
 Known incomplete
 ----------------
@@ -1070,6 +1137,19 @@ took ten minutes, so it is written down.
    * - :file:`perf/calc-load.js`
      - No workflow. It had no recorded measurement either until **2026-08-06**; it does now, and
        the answer is below.
+   * - Whether the published site is current
+     - **Daily since 2026-08-07**, not on pull requests — :file:`.github/workflows/published.yml`
+       fetches ``build-info.json`` off the live site and fails if it is behind master. Scheduled
+       for the same reason as the cluster job: the site legitimately lags a push by the length of
+       a deploy, so gating on it would fail after every merge.
+
+       So a merge still completes without anyone knowing whether it reached the site — which is
+       exactly the state that let it fall twelve commits behind, undetected, on 2026-08-06. The
+       difference is that the condition is now *discoverable within a day* instead of never. See
+       `The published site was twelve commits behind master`_.
+
+       What **is** gated per pull request is the producer: ``docs.yml`` fails if a build does not
+       carry a stamp naming a real commit on every page.
 
 None of this is an argument for gating all of it: a kind cluster with ingress-nginx and a 2.6 GB
 calculation image is a slow, fragile CI job, and a flaky gate is worse than an honest gap. It is


### PR DESCRIPTION
## What was wrong

`https://mlacayoemery.github.io/esgame/docs/` was serving the build from `0c322c8` (#176) while master was at `a8b29f7` (#188). **Twelve commits** — a full day of work, including every finding written up on `verification-status.rst` that day — absent from the site people are pointed at. It answered every request with a 200.

The cause was not a bad build. `deploy.yml`'s `build` job succeeded in 1m16s; its `deploy` job then failed with:

```
The job was not acquired by Runner of type hosted even after multiple attempts
```

GitHub-hosted runners were unavailable to this repository for about eleven hours. githubstatus.com reported Actions "operational" throughout and the repository is public, so this was neither a posted incident nor a spending cap. The artefact was built and never published; Pages went on serving the previous one.

**Nothing reported it, and nothing could**, because the artefact carried no identity. Every other check here asks a question about the tree. This is a question about a remote artefact, and the evidence is on the far end of an HTTP request.

## What this adds

| | |
|---|---|
| `docs/conf.py` | Stamps every build: `build-info.json` beside the HTML (commit, ref, run id, build time) and a `Last updated` footer carrying the same instant and short sha on **every** page. |
| `.github/workflows/published.yml` | Fetches that back off the live site **daily**, and names the commits it is behind by. |
| `.github/workflows/docs.yml` | Gates the **producer** on every PR — a freshness check is worth nothing if the thing it reads can quietly stop being written. |

The freshness check is scheduled, not gating. The site legitimately lags a push by the length of a deploy, so as a required check it would fail after every merge and teach people to click through it — the reasoning already set out at the top of `cluster.yml`. It is its own workflow rather than a skipped job in `docs.yml` so a PR never sees it at all.

## Verification

Both halves tested by **mutation**, not assertion. The producer gate fails — with an annotation — on six broken builds:

```
no build-info.json                 exit=1  annotations=1
commit unknown                     exit=1  annotations=1
commit empty                       exit=1  annotations=1
commit not a sha                   exit=1  annotations=1
one page unstamped                 exit=1  annotations=1
footer local time labelled UTC     exit=1  annotations=1
real build                         exit=0  annotations=0
```

The freshness check was run against fixtures for a current site, a stale one, a site that cannot name its commit, a commit from another repository, and Pages serving an SPA fallback instead of JSON. **Pointed at the real site it reproduces the finding from scratch: `12 commit(s) behind master`.**

End to end: the simulated Pages artifact built from `a8b29f7` reports exactly `1 commit(s) behind` once this commit lands on top of it, and passes at `--max-behind 1`.

Also run locally: `sphinx-build -W --keep-going` (clean), `check-references.py` (18 rst files, 332 targets, 7 references, exit 0), both new cross-references confirmed rendering as real `<a href>` to existing anchors rather than plain text, `actionlint` clean, all eight workflow files parse.

## One trap worth reading

**A timestamp that lies about its zone is worse than no timestamp**, and this nearly shipped one. `html_last_updated_fmt` is rendered through Sphinx's date formatter, which substitutes `%` codes against **local** time. The first version read `"%Y-%m-%d %H:%M:%S UTC"` and published *06:01:31 UTC* for a build that happened at *04:01:33Z*.

Sphinx 7.1 added `html_last_updated_use_utc`, but `docs/requirements.txt` floats on `sphinx>=7` and an unrecognised name in `conf.py` is **ignored in silence rather than refused** — so on an older Sphinx that option would have failed the same way and said nothing. The stamp is now pre-formatted in UTC with no format codes left in it, and the footer and the JSON are the same string by construction, so they cannot drift. The gate asserts they match.

## A note on CI

The runner outage above is still in progress at the time of writing, so this PR's checks may sit queued. Everything `docs.yml` and `manifests.yml` would run has been reproduced locally and is recorded above.

It also has a consequence beyond the docs: **#186 and #187 were merged against runs that failed on runner acquisition rather than on their contents.** That is what the "re-verify locally before merging" rule exists for, and it held — but "the run is red" and "the change is bad" came apart for a whole day, which is worth recording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHv4YE8wLeH8UyPrt6ftjs