### PR TITLE
fix(deps): js-yaml 3.15.0 -> 3.15.1, which the declared range already allowed

### DIFF
--- a/docs/dependency-review.rst
+++ b/docs/dependency-review.rst
@@ -127,6 +127,35 @@ changed APIs), so they are verified by running Lighthouse rather than assumed
 safe. **Drop them once ``@lhci/cli`` ships a refreshed tree** — re-check with
 ``npm audit`` after removing the block.
 
+``js-yaml`` needed no override — *2026-08-07*
+   GHSA-5p4m-2wfm-xmqj (quadratic CPU in ``!!omap`` resolution, CVSS 7.5) landed against
+   ``js-yaml@3.15.0`` in the same ``@lhci/cli`` tree, and its title —
+   "CVE-2026-59870 fix **not backported**" — reads like the 3.x line is unfixable and an
+   override to 4.x is the only way out. It is not: the advisory patches **both** lines,
+   ``4.3.1`` and ``3.15.1``, and ``@lhci/utils`` already declares ``js-yaml: ^3.13.1``,
+   which reaches ``3.15.1`` on its own. A lockfile bump of three lines closed it.
+
+   That is the second time here that a transitive looked blocked and was not. **Read the
+   advisory's own patched-version list before believing the summary**, and check it against
+   the declared range::
+
+      gh api /advisories/GHSA-xxxx --jq '.vulnerabilities[]
+        | "\(.vulnerable_version_range) -> \(.first_patched_version)"'
+
+   **It was also not reachable here**, which is worth recording so the next person does not
+   over-value the fix. ``js-yaml`` has one call site in the tree —
+   ``@lhci/utils/src/lighthouserc.js:84``, ``yaml.safeLoad(contents)`` — and it is gated on
+   the config path matching ``/\.ya?ml$/``. This repository passes
+   ``--config=lighthouserc.json``, so parsing falls through to ``JSON.parse`` and the
+   vulnerable code never runs. Dev-only, unreachable, and free to fix: taken as hygiene, not
+   as an exploit.
+
+   **No CI job would have caught it.** The audit in :file:`ci.yml` is ``--omit=dev`` *and*
+   scheduled-only — deliberately, so a new advisory against a shipped dependency does not
+   block an unrelated PR. A dev-tree advisory therefore surfaces only through Dependabot.
+   This case argues for leaving that as it is rather than widening the gate: an unreachable
+   finding in a dev tool is exactly what should not stop a merge.
+
 
 Reproducibility gaps
 --------------------

--- a/v2/package-lock.json
+++ b/v2/package-lock.json
@@ -7154,9 +7154,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## The alert

`GHSA-5p4m-2wfm-xmqj` — quadratic CPU consumption in js-yaml's `!!omap` resolution, **CVSS 7.5** — against `js-yaml@3.15.0` in `@lhci/cli`'s tree. The one open Dependabot alert, and the only finding since the tree reached 0 yesterday (the other 30 alerts are all `fixed`).

## It needed no override

The advisory's title reads *"CVE-2026-59870 fix **not backported**"*, which makes the 3.x line look unfixable and an override to 4.x look like the only way out. **It is not.** The advisory patches both lines:

```
>= 4.0.0, < 4.3.1   ->  4.3.1
>= 3.0.0, < 3.15.1  ->  3.15.1
```

`@lhci/utils` already declares `js-yaml: ^3.13.1`, which reaches `3.15.1` unaided. The whole fix is three lockfile lines — no `overrides` entry, no pin, nothing new to maintain.

That is the **second** time in this repository that a transitive looked blocked and was not. The lesson is written into `dependency-review.rst`: read the advisory's own patched-version list, not its summary.

```
gh api /advisories/GHSA-xxxx --jq '.vulnerabilities[]
  | "\(.vulnerable_version_range) -> \(.first_patched_version)"'
```

## It was also not reachable

Worth stating so nobody over-values the fix. `js-yaml` has exactly one call site in the tree:

```js
// @lhci/utils/src/lighthouserc.js:82-88
if (YAML_FILE_EXTENSION_REGEX.test(pathToRcFile)) {
  return yaml.safeLoad(contents);   // <- the vulnerable path
}
return JSON.parse(contents);        // <- what this repo actually takes
```

This repository runs `lhci autorun --config=lighthouserc.json`, so parsing falls through to `JSON.parse` and the vulnerable code never executes. Dev-only, unreachable, and free to fix — **taken as hygiene, not as an exploit**.

## No CI job would have caught it

`ci.yml`'s audit is `--omit=dev` **and** `if: github.event_name == 'schedule'` — deliberately, so a new advisory against a shipped dependency doesn't block an unrelated open PR. A dev-tree advisory therefore surfaces only through Dependabot.

This case argues for **leaving that as it is** rather than widening the gate: an unreachable finding in a dev tool is exactly what should not stop a merge. Recorded rather than changed.

## Verification

| | |
|---|---|
| `npm ci` from the lockfile | resolves `js-yaml@3.15.1` |
| `npm audit` | **0 vulnerabilities**, including dev |
| production build | succeeds |
| unit tests | **385 passed** in 36 files |
| **Lighthouse CI** | **green** against a real Chrome — the check that matters, since the chain is `@lhci/cli`'s own |

Docs also rebuilt with `-W --keep-going`, `check-references.py` clean, and the new build-stamp gate from #189 passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHv4YE8wLeH8UyPrt6ftjs