### PR TITLE
fix(ci): the doc-path check could not run on a docs-only change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,32 +75,11 @@ jobs:
           fi
           echo "documented count matches the suite"
 
-      - name: Every file the verification doc points at must exist
-        run: |
-          # Same failure mode as the test count, different shape: verification-status.rst names
-          # ~16 files as evidence, and a rename leaves the doc pointing at nothing while every
-          # other check stays green. Nothing re-derived these, so this does.
-          cd "${GITHUB_WORKSPACE}"
-          paths=$(grep -oE ':file:`[^`]+`' docs/verification-status.rst \
-                  | sed -E 's/^:file:`//; s/`$//' | sort -u)
-          # Presence first: an empty list would validate nothing and report success.
-          n=$(printf '%s\n' "$paths" | grep -c . || true)
-          echo "$n paths referenced"
-          if [ "$n" -lt 5 ]; then
-            echo "::error file=docs/verification-status.rst::found only $n :file: references; this check is not looking at the right thing"
-            exit 1
-          fi
-          bad=0
-          for p in $paths; do
-            # Absolute paths are system files being described (/etc/hosts), not repo paths.
-            case "$p" in /*) continue ;; esac
-            if [ ! -e "$p" ]; then
-              echo "::error file=docs/verification-status.rst::references $p, which does not exist"
-              bad=1
-            fi
-          done
-          [ "$bad" = 0 ] && echo "every referenced path exists"
-          exit $bad
+      # "Every file the verification doc points at must exist" used to live here. It has moved to
+      # .github/workflows/doc-paths.yml, unchanged in substance, because this workflow is
+      # path-filtered to `v2/**` and the file it validates is under `docs/` — so it could not run
+      # on the change most likely to break it, and #189 broke it exactly that way. The new
+      # workflow has no path filter, which is what the check actually needs.
 
       - name: E2E (Playwright)
         run: |

--- a/.github/workflows/doc-paths.yml
+++ b/.github/workflows/doc-paths.yml
@@ -1,0 +1,42 @@
+name: Doc paths resolve
+
+# docs/verification-status.rst names files as evidence, so a path that stops existing makes the
+# document lie while every other check stays green.
+#
+# That check already existed — inside ci.yml. But ci.yml is path-filtered to `v2/**`, and the
+# file it validates is under `docs/`. So the check could not run on the change most likely to
+# break it. #189 proved it: a docs-only pull request added three bad references
+# (`cluster.yml` and `deploy.yml` bare rather than under .github/workflows/, and
+# `.github/workflows/overlay.yml`, which is a file in the *places* repository), ci.yml never
+# ran, Docs passed, and it merged. The failure surfaced on the next unrelated pull request that
+# happened to touch v2/ — attached to a change that had nothing to do with it.
+#
+# NO PATH FILTER, deliberately, because the check can be broken from two directions and a
+# filter can only face one:
+#
+#   * edit docs/verification-status.rst to name a path that does not exist  -> needs docs/**
+#   * rename or delete a file the document already names                    -> needs everything
+#
+# It is a checkout and a few milliseconds of Python — there is nothing to trade off against
+# running it everywhere. That is also why it is not folded into docs.yml, which builds Sphinx
+# and would then have to run on every source change to cover the second direction.
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  paths:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        # Quoted: an unquoted step name containing ": " is a YAML mapping, not a string, and
+        # the whole file fails to parse. actionlint catches it; a plain `git push` does not.
+      - name: "Every :file: path in verification-status.rst must exist"
+        run: python3 docs/_checks/check-file-paths.py

--- a/docs/_checks/check-file-paths.py
+++ b/docs/_checks/check-file-paths.py
@@ -1,0 +1,71 @@
+"""Every :file:`...` path in verification-status.rst must exist.
+
+That document names files as *evidence* — "verified by running :file:`deploy/k8s/ingress-test.sh`"
+— so a rename leaves it pointing at nothing while every other check stays green. Nothing
+re-derived these, so this does.
+
+**Scoped to verification-status.rst on purpose.** The other 15 rst files use :file: for paths
+relative to whatever the reader is looking at (``field/field-base.component.ts``,
+``esgame/v2/angular.json``, ``places/calculation/calculation.r``), and 131 of the 210 distinct
+references across docs/ do not resolve from the repository root. Widening this check would mean
+rewriting that convention, which is a decision about how the documentation reads rather than a
+defect. verification-status.rst is the one file whose contract is "these are repo-root paths you
+can go and look at".
+
+    python3 docs/_checks/check-file-paths.py            # from the repository root
+    python3 docs/_checks/check-file-paths.py --doc other.rst --root .
+"""
+import argparse
+import pathlib
+import re
+import sys
+
+MIN_REFERENCES = 5
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--doc", default="docs/verification-status.rst")
+    ap.add_argument("--root", default=".", help="paths are resolved relative to this")
+    args = ap.parse_args()
+
+    root = pathlib.Path(args.root)
+    doc = root / args.doc
+    # Presence first, twice over: a rename of the document itself would otherwise find no
+    # references, validate nothing, and report success — the shape audited for in
+    # "The checks were audited for vacuity".
+    if not doc.is_file():
+        print(f"::error::{doc} does not exist; this check is not looking at the right file")
+        return 1
+
+    refs = sorted(set(re.findall(r":file:`([^`]+)`", doc.read_text(encoding="utf-8"))))
+    print(f"{len(refs)} distinct :file: references in {args.doc}")
+    if len(refs) < MIN_REFERENCES:
+        print(f"::error file={args.doc}::found only {len(refs)} :file: references; "
+              f"this check is not looking at the right thing")
+        return 1
+
+    bad = []
+    for p in refs:
+        # Absolute paths are system files being described (/etc/hosts, /app/data), not repo
+        # paths. Same for anything with a glob or a placeholder in it — those name a shape,
+        # not a file, and asserting they exist would be wrong rather than merely noisy.
+        if p.startswith("/") or any(c in p for c in "*?<>"):
+            continue
+        if not (root / p).exists():
+            bad.append(p)
+
+    for p in bad:
+        print(f"::error file={args.doc}::references {p}, which does not exist")
+    if bad:
+        print(f"\n{len(bad)} of {len(refs)} references do not resolve. Either the path moved, or "
+              f"it is relative to something other than the repository root — in which case write "
+              f"it as ``literal`` rather than :file:, which is what the rest of docs/ does.")
+        return 1
+
+    print("every referenced path exists")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -356,20 +356,22 @@ The published site was twelve commits behind master — *closed 2026-08-07*
    * :file:`.github/workflows/published.yml` fetches that JSON back off the live site daily
      and reports how many commits behind master it is, naming them. Scheduled only — the site
      legitimately lags a push, so as a required check it would fail after every merge and
-     teach people to click through it. Same reasoning as :file:`cluster.yml`.
+     teach people to click through it. Same reasoning as
+     :file:`.github/workflows/cluster.yml`.
    * :file:`.github/workflows/docs.yml` gates the producer on every pull request: the stamp
      must exist, must name a real sha rather than ``unknown``, must be on every page built,
      and must match ``build-info.json``. A freshness check downstream is worth nothing if the
      thing it reads can quietly stop being written.
 
    **One stamp covers the game as well as the documentation**, which is worth saying because
-   the check only ever fetches a docs URL. :file:`deploy.yml` builds the Angular app into
+   the check only ever fetches a docs URL. :file:`.github/workflows/deploy.yml` builds the
+   Angular app into
    ``v2/dist/tradeoff-v2`` and Sphinx into ``v2/dist/tradeoff-v2/docs``, then uploads *that
    whole directory* as one Pages artifact — so the app at ``/esgame/`` and the docs at
    ``/esgame/docs/`` are published atomically and cannot be at different commits. A stale
    ``build-info.json`` means the game is equally stale. (places has no Pages deploy and no
-   Sphinx docs — only :file:`.github/workflows/overlay.yml` — so there is nothing to mirror
-   there.)
+   Sphinx docs — only ``overlay.yml``, which is *its* workflow and not a path in this
+   repository — so there is nothing to mirror there.)
 
    Both halves were tested by mutation rather than by assertion — the trap in
    `The checks were audited for vacuity`_. The producer gate was run against six broken
@@ -1068,6 +1070,44 @@ specs guarded by a preceding length assertion.
 
 **The lesson is specific, not general:** *"assert X is not present"* is satisfied by *"the
 file is gone"*. Every absence-assertion needs a presence-assertion in front of it.
+
+A second shape, found 2026-08-07 — *the check was sound and could not run*
+   Every check above could run and might not fail. This one was the other way round: it was
+   correct, it had a presence guard, and **its workflow's path filter kept it away from the
+   change that breaks it**.
+
+   "Every file the verification doc points at must exist" lived in :file:`.github/workflows/ci.yml`,
+   which is filtered to ``paths: ['v2/**', ...]``. The file it validates is
+   :file:`docs/verification-status.rst`. So a documentation-only pull request — the single most
+   likely way to introduce a bad path — could not trigger it.
+
+   #189 did exactly that. It added three references that do not resolve: ``cluster.yml`` and
+   ``deploy.yml`` written bare instead of under ``.github/workflows/``, and
+   ``.github/workflows/overlay.yml``, which is a file in the **places** repository, not this
+   one. ``Docs`` passed, ``ci.yml`` never ran, and it merged. The failure then appeared on the
+   next unrelated pull request that happened to touch ``v2/`` — attached to a change with
+   nothing to do with it, which is the most expensive place for it to show up.
+
+   The check now lives in :file:`.github/workflows/doc-paths.yml` with **no path filter**,
+   because it can be broken from two directions and a filter only ever faces one: editing the
+   document to name a missing path needs ``docs/**``, while renaming a file the document
+   already names needs the whole tree. It is a checkout and a few milliseconds of
+   :file:`docs/_checks/check-file-paths.py`, so there is nothing to trade against running it
+   everywhere.
+
+   **A path filter is an assertion about what can break a check**, and it is invisible in the
+   check's own text. Reading `ci.yml`'s step told you nothing about the fact that it could not
+   see the file it was reading. Worth applying to the rest: ``manifests.yml`` validates
+   ``tools/R`` and ``deploy/**`` and is filtered to those, which matches; ``docs.yml`` builds
+   ``docs/**`` and is filtered to it, which matches. This one did not, and the mismatch had
+   been there since the check was written.
+
+   Scope stayed narrow on purpose. The check reads only
+   :file:`docs/verification-status.rst`, whose convention is repo-root paths. The other 15 rst
+   files use ``:file:`` for paths relative to whatever the reader is looking at — 131 of the 210
+   distinct references across :file:`docs` do not resolve from the root — so widening it would
+   mean rewriting how the documentation reads, which is a decision about style rather than a
+   defect to fix.
 
 
 Not verified


### PR DESCRIPTION
## master is red on this

#189 (mine) added three `:file:` references that do not resolve:

| Reference | Problem |
|---|---|
| `cluster.yml` | bare filename, not `.github/workflows/cluster.yml` |
| `deploy.yml` | bare filename, not `.github/workflows/deploy.yml` |
| `.github/workflows/overlay.yml` | a file in the **places** repository, not this one |

All three are fixed. The third becomes a ``literal`` rather than a `:file:` role, because it genuinely isn't a path in this repo.

## The interesting half is why nothing caught it

"Every file the verification doc points at must exist" lived in `ci.yml`:

```yaml
on:
  pull_request:
    paths: ['v2/**', '.github/workflows/ci.yml']
```

…while the file it validates is `docs/verification-status.rst`.

**So the check could not run on the change most likely to break it.** #189 touched only `docs/` and `.github/workflows/`: `Docs` passed, `ci.yml` never ran, it merged. The failure then surfaced on the next unrelated PR that happened to touch `v2/` (#190, a js-yaml lockfile bump) — attached to a change with nothing to do with it, which is the most expensive place for it to show up.

Every vacuity finding recorded in `verification-status.rst` so far was *a check that could run and could not fail*. This is the other shape: **sound, presence-guarded, and kept away from its trigger by a path filter**. A path filter is an assertion about what can break a check, and it's invisible in the check's own text — reading the step told you nothing about the fact that it couldn't see the file it was reading.

I re-read the others against that lens: `manifests.yml` validates `tools/R` and `deploy/**` and is filtered to those — matches. `docs.yml` builds `docs/**` and is filtered to it — matches. This one didn't, and hadn't since it was written.

## The fix

The check moves to `.github/workflows/doc-paths.yml` with **no path filter**, because it breaks from two directions and a filter only ever faces one:

- edit the document to name a missing path → needs `docs/**`
- rename or delete a file the document already names → needs the whole tree

It's a checkout and a few milliseconds of `docs/_checks/check-file-paths.py`, so there's nothing to trade against running it everywhere. That's also why it isn't folded into `docs.yml`, which builds Sphinx and would then have to run on every source change to cover the second direction.

## Scope stayed narrow deliberately

The check reads only `verification-status.rst`, whose convention is repo-root paths you can go and look at. The other 15 rst files use `:file:` for reader-relative paths (`field/field-base.component.ts`, `esgame/v2/angular.json`, `places/calculation/calculation.r`) — **131 of the 210 distinct references across `docs/` do not resolve from the root**. Widening the check would mean rewriting how the documentation reads, which is a style decision rather than a defect, so I left it alone and wrote down why.

## Verification

- `check-file-paths.py` reproduces master's failure **exactly** — 3 of 38 unresolved, naming the same three — and passes on this tree (40 of 40).
- `sphinx-build -W --keep-going` clean; `check-references.py` clean; #189's build-stamp gate passes.
- `actionlint` clean across all nine workflows, and **it caught a real bug on the way**: an unquoted step name containing `": "` made the new file unparseable YAML. A plain push would not have.

Once this lands I'll rebase #190, which is only red because of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHv4YE8wLeH8UyPrt6ftjs