### PR TITLE
fix(ci): two more checks could not run on the file they read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,21 @@ name: CI
 # close that hole — master gets exercised whether or not anyone touches v2/, and
 # breakage that arrives from outside the repo (a runner image change, a deprecated
 # action, a new advisory) surfaces on its own.
+#
+# docs/verification-status.rst is in the filter because two steps below READ IT: they compare
+# the unit and e2e counts it claims against what the suite actually ran. A filter of `v2/**`
+# alone meant those checks could not run on a change to their own input — a documentation-only
+# pull request could put any number in that line and merge green. Same shape as the doc-path
+# check moved out in #191, and the fix is the opposite one: that check needed no build, so it
+# left; these need the suite output, so the trigger comes to them. ~2 minutes, and that file
+# changes on most pull requests here, so in practice CI now runs on nearly all of them. That is
+# the cost of the claims being checked against a run rather than against nothing.
 on:
   pull_request:
-    paths: ['v2/**', '.github/workflows/ci.yml']
+    paths: ['v2/**', '.github/workflows/ci.yml', 'docs/verification-status.rst']
   push:
     branches: [master]
-    paths: ['v2/**', '.github/workflows/ci.yml']
+    paths: ['v2/**', '.github/workflows/ci.yml', 'docs/verification-status.rst']
   schedule:
     # Mondays 06:00 UTC.
     - cron: '0 6 * * 1'

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -1097,10 +1097,40 @@ A second shape, found 2026-08-07 — *the check was sound and could not run*
 
    **A path filter is an assertion about what can break a check**, and it is invisible in the
    check's own text. Reading `ci.yml`'s step told you nothing about the fact that it could not
-   see the file it was reading. Worth applying to the rest: ``manifests.yml`` validates
-   ``tools/R`` and ``deploy/**`` and is filtered to those, which matches; ``docs.yml`` builds
-   ``docs/**`` and is filtered to it, which matches. This one did not, and the mismatch had
-   been there since the check was written.
+   see the file it was reading.
+
+   **Two more of the same shape, in the same workflow — found by re-auditing rather than by
+   a failure** (*2026-08-07*). The first pass checked whether each *workflow's* filter matched
+   what it validated, and cleared ``manifests.yml`` and ``docs.yml`` on that basis. That was
+   the wrong granularity: a filter belongs to a workflow, but the claim belongs to a *step*, and
+   ``ci.yml`` holds two steps that read this very page —
+
+   .. code-block:: text
+
+      The documented test count is current   compares "385 unit tests" against the suite
+      The documented e2e count is current    compares "18 Playwright e2e" against the suite
+
+   — while being filtered to ``v2/**``. Both are live: changing the claim to 384 and re-running
+   the comparison by hand gives a mismatch. But neither could run on a documentation-only pull
+   request, so **any number could have been written into that line and merged green.** Both
+   directions matter and only one was covered: if the suite grows, ``v2/**`` fires and the claim
+   is checked; if the claim is edited, nothing fired at all.
+
+   The fix is the *opposite* of the doc-path one, and the difference is worth keeping straight.
+   That check needed no build, so it left ``ci.yml`` for an unfiltered workflow. These need the
+   suite's output, so the check cannot leave — the trigger comes to it instead, by adding
+   :file:`docs/verification-status.rst` to ``ci.yml``'s filter. It costs about two minutes, and
+   this page changes on most pull requests here, so in practice CI now runs on nearly all of
+   them. That is the price of the claims being checked against a run rather than against
+   nothing, and it is worth paying: a coverage number nobody re-derives is exactly the kind of
+   evidence this page exists to stop trusting.
+
+   The change was verified by simulating both filters against a list of paths — this page and
+   ``v2/**`` trigger CI, other documents still do not — and **not** by the pull request that
+   made it, which is worth recording because that was the first thing claimed and it was wrong.
+   That pull request also edited ``ci.yml``, which the *old* filter already matched, so CI would
+   have run on it either way. A change that carries its own trigger cannot demonstrate that
+   trigger. The first real demonstration is the next documentation-only change to this page.
 
    **Widened to all of** :file:`docs` **the same day**, once it was clear the alternative to
    rewriting 131 references was to let the documents say where their paths resolve from. Each


### PR DESCRIPTION
Found by re-auditing after #191, not by a failure.

## The gap

`ci.yml` holds two steps that read `docs/verification-status.rst`:

```
The documented test count is current   compares "385 unit tests"    vs the suite
The documented e2e count is current    compares "18 Playwright e2e" vs the suite
```

Both are **live** — changing the claim to 384 and re-running the comparison by hand gives a mismatch:

```
as committed          suite=385 docs=385 -> MATCH
docs mutated to 384   suite=385 docs=384 -> MISMATCH
```

But `ci.yml` is filtered to `v2/**`, so neither could run on a documentation-only PR. **Any number could have been written into that line and merged green.** Only one direction was covered: if the suite grows, `v2/**` fires and the claim is checked; if the claim is edited, nothing fired at all.

## Why #191 missed it

#191 audited exactly this and cleared `manifests.yml` and `docs.yml` — but at the wrong granularity. **A path filter belongs to a workflow; the claim belongs to a step.** Asking "does this workflow's filter match what it validates" missed two steps inside the very workflow the finding came from.

## The fix is the opposite of #191's

Worth keeping straight, because the two look like the same problem:

| | needs a build? | fix |
|---|---|---|
| doc-path check (#191) | no | **the check leaves** `ci.yml` for an unfiltered workflow |
| these two | **yes** — they compare against the suite's output | **the trigger comes to the check**: add `docs/verification-status.rst` to `ci.yml`'s filter |

## How it was verified — and how it wasn't

By simulating both filters against a path list:

```
                                     OLD filter   NEW filter
docs/verification-status.rst         skipped      RUNS
v2/src/app/x.ts                      RUNS         RUNS
docs/architecture.rst                skipped      skipped
```

**Not by this PR, which is what I claimed first and was wrong.** This PR also edits `.github/workflows/ci.yml`, which the *old* filter already matched — so CI would have run on it either way. A change that carries its own trigger cannot demonstrate that trigger. The first real demonstration is the next documentation-only change to that page. The correction is recorded in `verification-status.rst` rather than just fixed here.

## The cost, stated

About two minutes, and this page changes on most PRs here — so in practice CI now runs on nearly all of them. That's the price of the claims being checked against a run rather than against nothing, and it's worth paying: a coverage number nobody re-derives is exactly the kind of evidence this page exists to stop trusting.

## Also run

`sphinx-build -W --keep-going` clean, `check-references.py` clean, `check-file-paths.py` 301/301, `actionlint` clean across all nine workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHv4YE8wLeH8UyPrt6ftjs