### PR TITLE
feat(v2): draw the spider chart in the browser; R stops rendering PNGs

### DIFF
--- a/docs/data-flow.rst
+++ b/docs/data-flow.rst
@@ -369,12 +369,15 @@ The frontend casts the response to ``CalculationResult``:
      - Meaning
    * - ``results``
      - ``Result[]``
-     - One entry per consequence map (plus optionally one ``id == "-1"`` image entry).
+     - One entry per consequence map. Older calculators also sent one ``id == "-1"`` image
+       entry; it is filtered out rather than drawn.
    * - ``results[].id``
      - ``string``
      - Matches a ``Consequence`` map ``id`` from the game data. The special id
-       ``"-1"`` is the score/summary **image** (e.g. the R spider plot), not a map; the
-       id ``"-1"`` is also explicitly filtered out of the score list.
+       ``"-1"`` was a rendered summary **image** — the R spider plot — and is no longer sent:
+       :file:`tools/R/calculator.r` stopped rendering it on 2026-08-07 and the browser draws
+       the chart from the scores instead. It is still filtered out on the way in, because a
+       frontend can be deployed against a calculation image that has not been rebuilt.
    * - ``results[].name``
      - ``string``
      - Coverage / human name (informational).

--- a/docs/game-mechanics.rst
+++ b/docs/game-mechanics.rst
@@ -408,8 +408,9 @@ Level progression and carry-over
 
 A :class:`Level` (:file:`esgame/v2/src/app/shared/models/level.ts`) holds a
 ``levelNumber``, its ``gameBoards``, the ``selectedFields`` snapshot, an
-``isReadOnly`` flag, ``showConsequenceMaps``, computed ``scores``, and an
-optional ``scoreImage``. Levels are kept in the private ``levels: Level[]``
+``isReadOnly`` flag, ``showConsequenceMaps``, computed ``scores``, and
+``indicatorScores`` (the calculator's raw 0-100 numbers, which the spider chart is drawn
+from). Levels are kept in the private ``levels: Level[]``
 array of :class:`GameService`.
 
 ``goToNextLevel``
@@ -446,8 +447,9 @@ extended:
 * **SVG:** the previous boards minus old consequence maps are kept; a fresh
   background and the consequence boards returned by the calculator
   (``calculationResult.results``) are loaded, the level ``scores`` are built from
-  the calculator results, and an optional summary image
-  (result with ``id == "-1"``) becomes ``level.scoreImage``.
+  the calculator results, and the raw indicator scores become
+  ``level.indicatorScores`` for the spider chart. A result with ``id == "-1"`` — an older
+  calculator's rendered plot — is excluded.
 
 Whether a player may keep generating levels is governed by
 ``Settings.infiniteLevels`` (``true`` for the SVG example, ``false`` for the
@@ -544,8 +546,8 @@ Key points:
   ``Result { name, id, score, url }``. In ``prepareNextLevel`` each result's
   ``url`` becomes a consequence map's ``urlToData``, and the level ``scores`` are
   built as ``[{ id: "all", score: previousScore }, ...results (id != "-1")
-  mapped to score: -(score*100)]``; the result with ``id == "-1"`` supplies the
-  summary ``scoreImage``.
+  mapped to score: -(score*100)]``. ``level.indicatorScores`` keeps the same results
+  unscaled, for the spider chart; ``id == "-1"`` is excluded from both.
 
 In other words, in dynamic mode the **suitability (income) score is computed
 client-side and sent up**, while the **consequence penalties and the new

--- a/docs/reference/calculator.rst
+++ b/docs/reference/calculator.rst
@@ -97,8 +97,9 @@ A JSON object ``{"results": [...]}``. Each element:
        example.
    * - ``url``
      - string
-     - GeoServer WCS ``GetCoverage`` URL (or, for the spider plot in the R
-       engines, an ``/images/`` static-asset URL).
+     - GeoServer WCS ``GetCoverage`` URL. (places' ``calculation.r`` still returns an
+       ``/images/`` static-asset URL for its spider plot; esgame's ``calculator.r`` stopped
+       rendering one on 2026-08-07 — see below.)
 
 
 FastAPI example (``app.py``)
@@ -365,10 +366,6 @@ The two engines compute **different services and ids**.
      - recreational value
      - 55
      - raster min–max ×100; score against ``[0, 32.2197]``
-   * - ``Spider_plot``
-     - spider plot PNG
-     - -1
-     - see below
 
 In ``calculator.r`` the "model" is a single shared air-concentration surface
 ``airconctot = airconc10 + airconc20 + airconc30 + airconc40 + airconc50`` (per
@@ -446,18 +443,25 @@ The upload list order is ``list(hh_info, wa_info, hc_info, np_info, rv_info, plo
 Spider plot
 ~~~~~~~~~~~
 
-Both engines render a polar ``ggplot`` bar chart of the per-service scores
-against a background max of 100 and save it as
-``Spider_plot_Game_<game_id>_Round_<round_id>.png`` (transparent background,
-5×5 cm — ``res=200`` in ``calculator.r``, ``res=900`` in ``calculation.r``).
-Labels are drawn with ``grid.text``. The plot is recorded as
-``plot_info <- list('name' = plot_name, 'id' = -1)`` and, because its ``id`` is
-``-1``, is **not** uploaded to GeoServer; instead its ``url`` is built as a
-static asset:
+**esgame's** :file:`tools/R/calculator.r` no longer renders one (*2026-08-07*). The chart is
+drawn in the browser by ``SpiderChartComponent`` from the five scores the response already
+carries, so there is no PNG, no ``@assets`` mount, and no sixth ``id == -1`` result. See
+:doc:`../verification-status` for why the pod-local file had to go — it is what stopped the
+calculation deployment being scaled.
+
+**places'** ``calculation.r`` still does. It renders a polar ``ggplot`` bar chart of the
+per-service scores against a background max of 100 and saves it as
+``Spider_plot_Game_<game_id>_Round_<round_id>.png`` (transparent background, 5×5 cm,
+``res=900``). Labels are drawn with ``grid.text``. The plot is recorded as
+``plot_info <- list('name' = plot_name, 'id' = -1)`` and, because its ``id`` is ``-1``, is
+**not** uploaded to GeoServer; instead its ``url`` is built as a static asset:
 
 .. code-block:: r
 
    paste0(req$rook.url_scheme, "://", req$HTTP_HOST, "/images/", name)
+
+which names whatever host the request happened to arrive on — the same defect the coverage
+URLs had before ``GEOSERVER_PUBLIC_URL`` split them.
 
 GeoServer upload (side effects)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -506,8 +510,8 @@ For every raster entry (``id != -1``), with ``short_name`` = file name minus the
   and ``format=image/tiff``.
 
 * **Return value:** ``list(results = calculated_rasters)`` — the list of
-  ``{name, id, score, url}`` entries (one per service plus the spider plot),
-  serialised as unboxed JSON.
+  ``{name, id, score, url}`` entries — one per service, plus the spider plot in
+  ``calculation.r`` only — serialised as unboxed JSON.
 
 **Filesystem side effects (per call):** writes one ``.tif`` per service (plus
 ``LU_*.tif`` in ``calculation.r``) and one ``Spider_plot_*.png`` into

--- a/docs/reference/frontend-components.rst
+++ b/docs/reference/frontend-components.rst
@@ -560,6 +560,36 @@ LoadingIndicatorComponent
 Spinner shown while the calculator is busy. ``@HostBinding('class.show') show`` is set true
 whenever ``loadingIndicatorObs`` emits a non-empty list (the service tracks in-flight requests).
 
+SpiderChartComponent
+--------------------
+
+:File: :file:`spider-chart/spider-chart.component.ts`
+:Selector: ``tro-spider-chart``
+:Change detection: ``OnPush``
+
+The five indicator scores drawn as a radar chart, in inline SVG.
+
+**Input:** ``entries: SpiderChartEntry[]`` — ``{ id, score }``, the calculator's own 0-100
+numbers, taken from ``level.indicatorScores``. Empty, ``null`` or ``undefined`` renders nothing
+rather than an empty frame.
+
+Added *2026-08-07*, replacing a PNG: ``calculator.r`` rendered a ggplot to a 394×394 raster,
+wrote it to the calculation pod's local ``/app/data``, and served it back through plumber's
+``@assets`` mount with a URL built from ``req$HTTP_HOST``. That is what stopped the calculation
+deployment being scaled — with more than one replica a plot GET can reach a pod that never wrote
+the file. The chart is a pure function of five numbers the response already carries, so nothing
+needs storing or serving.
+
+Axis labels come from ``map_name_<id>`` via ``TranslateService.instant``, the same keys
+:file:`shared/models/settings.ts` registers from ``data.json`` — so they are **translated**,
+where the PNG's were baked in English. The ``<svg>`` carries ``role="img"`` and an
+``aria-label`` naming every indicator and score.
+
+**The viewBox is wider than tall** (``320 × 230``) and sized by the labels, not the circle. A
+square box was tried first and clipped "Water availability" and "Recreational value"; every unit
+test passed anyway, because the geometry was correct and only the text fell outside. It was
+caught by looking at a screenshot, and there is now an assertion on the horizontal room.
+
 ProductionTypeButtonComponent
 -----------------------------
 
@@ -722,9 +752,12 @@ One round of play.
    * - ``scores``
      - ``ScoreEntry[]``
      - Per-map scores (``ScoreEntry = { id:string, score:number }``).
-   * - ``scoreImage``
-     - ``string``
-     - Optional rendered result image (dynamic mode).
+   * - ``indicatorScores``
+     - ``SpiderChartEntry[]``
+     - The five indicator scores as the calculator returned them, 0-100, for
+       ``SpiderChartComponent``. Distinct from ``scores`` above, which is the game's point
+       system. Replaced ``scoreImage: string`` (a URL to a PNG the calculator rendered and
+       served from its own pod) on 2026-08-07.
 
 Field
 -----

--- a/docs/reference/frontend-services.rst
+++ b/docs/reference/frontend-services.rst
@@ -597,8 +597,9 @@ a placement round). Branches on ``settings.mode``.
   consequence map's ``urlToData`` at the matching result ``url``, sanitizes
   ``NaN`` scores to ``0``, and builds ``level.scores`` as
   ``[{ id: "all", score: previousScore }, ...results (id != "-1") mapped to
-  { id, score: -(score*100) }]``. A result with ``id == "-1"`` is treated as a
-  ``scoreImage`` (``level.scoreImage = image.url``). It then re-renders the
+  { id, score: -(score*100) }]``. It also sets ``level.indicatorScores`` to the raw
+  ``{ id, score }`` pairs, which is what the spider chart is drawn from; a result with
+  ``id == "-1"`` (an older calculator's rendered plot) is excluded. It then re-renders the
   background (with 25% opacity applied via ``addTransparencyToColors("3F")``)
   and the consequence SVGs through ``TiffService``, refreshes field scores, and
   publishes.

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -49,7 +49,7 @@ Verified working
    * - Path
      - How it was checked
    * - Static / grid game
-     - 385 unit tests, 18 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
+     - 399 unit tests, 18 Playwright e2e, Lighthouse a11y 100 / best-practices 100 /
        SEO 100. The board renders 2,436 fields; the e2e suite asserts that rather than
        just asserting the component mounted.
    * - No external runtime deps
@@ -901,9 +901,28 @@ Adding calculation replicas breaks the spider plot — *measured 2026-08-06*
           is ReadWriteOnce, so it would mean adding an RWX provisioner as a dependency of running
           the game.
 
-   Nothing here changes yet: which of those is right is a decision about the response contract
-   and about what a deployment may depend on. The manifest still says ``replicas: 1``, and now
-   there is a reason written down for why raising it is not a one-line change.
+   **Closed 2026-08-07 by a fifth option none of those four is: stop producing the file.**
+
+   The plot is a pure function of five numbers the response already carries, so there was never
+   anything that had to be stored or served. ``SpiderChartComponent`` draws it as inline SVG;
+   :file:`tools/R/calculator.r` no longer renders a PNG, no longer returns an ``id == -1``
+   result, and no longer declares ``#* @assets /app/data /images`` — so the calculator has
+   stopped publishing the contents of its own ``/app/data`` over HTTP at all.
+
+   The table above is worth keeping for what it shows about how the question was framed. Every
+   option in it takes "there is a file, and it must reach the browser" as given, and then argues
+   about transport — inline it, pin the browser to a pod, put it in GeoServer, or add an RWX
+   provisioner. **The cheapest of the four was still more machinery than deleting the file.**
+   Returning it inline was the one that came closest, and it would have left R rendering a
+   394×394 raster nobody needed.
+
+   What it also bought, none of which was the point: the chart scales with the panel instead of
+   being a fixed raster, its axis labels come from ``map_name_<id>`` and so are **translated**
+   where the PNG's were baked in English, and it carries an ``aria-label`` naming every
+   indicator and score where the PNG had no alt text.
+
+   ``replicas`` is still 1 in the manifest, because nothing has re-measured the round throughput
+   since; what changed is that raising it no longer serves 404s for a player's own chart.
 
 .. _why-the-scores-go-nan:
 
@@ -1159,7 +1178,7 @@ A second shape, found 2026-08-07 — *the check was sound and could not run*
 
    .. code-block:: text
 
-      The documented test count is current   compares "385 unit tests" against the suite
+      The documented test count is current   compares "399 unit tests" against the suite
       The documented e2e count is current    compares "18 Playwright e2e" against the suite
 
    — while being filtered to ``v2/**``. Both are live: changing the claim to 384 and re-running

--- a/tools/R/calculator.r
+++ b/tools/R/calculator.r
@@ -16,8 +16,13 @@ cors <- function(req, res) {
   }
 }
 
-#* @assets /app/data /images
-list()
+# `#* @assets /app/data /images` used to be here. It served the rendered spider plot, and nothing
+# else — every other output goes to GeoServer as a coverage. The plot is drawn in the browser now
+# (v2's SpiderChartComponent), so there is nothing left to serve, and dropping the mount means
+# the calculator no longer publishes the contents of its own /app/data over HTTP.
+#
+# ONE WAY TO REACH A THING, NOT TWO. Leaving the mount in place would have kept working at one
+# replica and rotted unseen, which is exactly how the pod-local plot survived this long.
 
 #* @post /esgame
 #* @serializer unboxedJSON
@@ -331,56 +336,26 @@ calculate<-function(req, geoserver_url, game_id, round_id,score_PD,map_AG) {
   hc_info['score']<-score_HC
   rv_info['score']<-score_RV
   
-  # scores matrix
-  scores_df<-as.data.frame(matrix(data=c("Human health", "Nutrient pollution", "Water availability", "Habitat cohesion", "Recreational value",
-                                            score_HH , score_NP, score_WA, score_HC ,  score_RV), nrow =5 , ncol=2, byrow = F)) 
-  colnames(scores_df)<-c("consequence","scores")
-  scores_df$scores<-as.numeric(scores_df$scores)
-  
-  #write.table(scores_df, file=paste0("Scores_Game_",game_id,"Round_",round_id,".txt"), row.names=F, col.names = T)
-  
-  #### Spider plot #####
-  scores_df$max_cons<-rep(100,length(scores_df$consequence))
-  scores_df$id<- seq(1,length(scores_df$consequence),1)
-  
-  p <-
-    ggplot(scores_df, aes(x=as.factor(id), y=max_cons))+        # Note that id is a factor. If x is numeric, there is some space between the first bar
-    geom_bar(aes(x=as.factor(id), y=max_cons),fill = "snow4", stat="identity", alpha=0.3) +
-    geom_bar(aes(x=as.factor(id), y=scores, fill=consequence), stat="identity", alpha=0.9) +
-    theme_minimal() +
-    theme(
-      legend.position = "none",
-      axis.text = element_blank(),
-      axis.title = element_blank(),
-      panel.grid = element_blank(),
-      # A margin has four sides. rep(1,5) supplies five; ggplot2 tolerated the extra
-      # silently until 4.x, which now errors with "The `plot.margin` theme element must
-      # be a <unit> vector of length 4" — losing the whole round at plot(p) below, after
-      # the model has already done all its work.
-      plot.margin = unit(rep(1,4), "cm") 
-    ) +
-    coord_polar()
-  
-  # Save your plot
- png(paste0("Spider_plot_","Game_",game_id,"_Round_",round_id,".png"), bg = 'transparent',  width = 5, height = 5, units = "cm", res = 200)
-  plot(p)
+  # The spider plot used to be rendered here: a ggplot with coord_polar, written to a 394x394
+  # PNG in the calculation pod's own /app/data, served back through the `@assets` mount that used
+  # to be at the top of this file, with a URL built from req$HTTP_HOST, and returned as a sixth
+  # result with id -1.
+  #
+  # It is drawn in the browser now, by v2's SpiderChartComponent, from these five scores. The
+  # chart is a pure function of them, so there was never anything to store.
+  #
+  # WHAT THAT FIXES. The file lived on whichever pod happened to serve the round. With more than
+  # one calculation replica a plot GET can land on a pod that never wrote it, so the player gets
+  # a 404 for a chart of their own round — which is why `replicas` could not be raised. That is
+  # documented under "adding calculation replicas breaks the spider plot".
+  #
+  # It also removes the req$HTTP_HOST URL, which was wrong for the same reason the coverage URLs
+  # were: it names whatever host the request happened to arrive on.
+  #
+  # ggplot2/grid are no longer used by this file. They stay in the Dockerfile: dropping them is a
+  # separate change with its own image rebuild to verify, and an unused package costs nothing at
+  # run time.
 
-  # Adding labels
-  grid.text(scores_df[1,1], x=0.77,  y=0.75, gp=gpar(col="black", fontsize=5, fontface="bold"))
-  grid.text(scores_df[2,1], x=0.92,  y=0.4, gp=gpar(col="black", fontsize=5, fontface="bold"))
-  grid.text(scores_df[3,1], x=0.5,  y=0.21, gp=gpar(col="black", fontsize=5, fontface="bold"))
-  grid.text(scores_df[4,1], x=0.1,  y=0.4, gp=gpar(col="black", fontsize=5, fontface="bold"))
-  grid.text(scores_df[5,1], x=0.21,  y=0.75, gp=gpar(col="black", fontsize=5, fontface="bold"))
-
-  dev.off()
-
-#}  
-  
-  #NEW CODE
-  plot_name <- paste0("Spider_plot_", "Game_", game_id, "_Round_", round_id, ".png")
-  plot_info <- list('name' = plot_name, 'id' = -1)
-  
-  
 #### Upload #####
   #connect to GeoServer
   ## Geoserver
@@ -432,13 +407,13 @@ calculate<-function(req, geoserver_url, game_id, round_id,score_PD,map_AG) {
   #register each raster into GeoServer
   #https://cran.r-project.org/web/packages/geosapi/vignettes/geosapi.html#GSCoverage-upload
   
-  calculated_rasters <- list(hh_info, wa_info, hc_info, np_info, rv_info, plot_info)
-  
+  # Five coverages, no sixth plot entry. Everything in this list is a real GeoTIFF that goes to
+  # GeoServer, so the id == -1 branch that built a pod-local URL from req$HTTP_HOST is gone with
+  # it — see the note where the plot used to be rendered.
+  calculated_rasters <- list(hh_info, wa_info, hc_info, np_info, rv_info)
+
   #CHANGED CODE --> loop over calculated rasters which contains all the informations
   for (i in 1:length(calculated_rasters)) {
-      if(calculated_rasters[[i]]['id'] == -1) {
-        calculated_rasters[[i]]['url'] = paste0(req$rook.url_scheme,"://", req$HTTP_HOST, "/images/", calculated_rasters[[i]]['name'])
-      } else {
   short_name <- substring(calculated_rasters[[i]]['name'], 1, nchar(calculated_rasters[[i]]['name'])-4)
   log_info("Attempting upload of {short_name} from {calculated_rasters[[i]]['path']}")
   uploaded <- gsman$uploadGeoTIFF(
@@ -484,11 +459,10 @@ calculate<-function(req, geoserver_url, game_id, round_id,score_PD,map_AG) {
   
   calculated_rasters[[i]]['url'] = raster_url
   log_info("Constructed URL for  {short_name}: from {raster_url}")
-  
+
   #DELETED CODE
   }
-  }
- 
+
   
   #DELETED CODE
   

--- a/tools/R/golden-test.sh
+++ b/tools/R/golden-test.sh
@@ -48,7 +48,9 @@ got=$(python3 - "${body}" <<'PY'
 import json, sys
 d = json.load(open(sys.argv[1]))
 rows = d.get("results", [])
-# id -1 is the spider plot, which carries no score. Everything else is an indicator.
+# id -1 was the rendered spider plot, which carried no score. calculator.r no longer returns it —
+# v2 draws the chart from the scores — but the filter stays, because this script is also pointed
+# at deployments running an older calculation image.
 scores = {r["name"].split("_")[0]: r.get("score") for r in rows if r.get("id") != -1}
 if not scores:
     print("NO_SCORES"); raise SystemExit

--- a/v2/e2e/round-trip.spec.ts
+++ b/v2/e2e/round-trip.spec.ts
@@ -15,16 +15,25 @@ import { test, expect } from '@playwright/test';
 
 const CALC_URL = '/fake-calc';
 
-// ids 11/22/33/44/55 are the dynamic game's Consequence maps; -1 is the spider plot.
+// ids 11/22/33/44/55 are the dynamic game's Consequence maps.
+//
+// The -1 entry is a spider plot the calculator USED TO render and serve from its own pod. It is
+// kept here on purpose: tools/R/calculator.r stopped sending it on 2026-08-07 and the browser
+// draws the chart itself, but a frontend can be deployed against a calculation image that has
+// not been rebuilt, so "-1" must go on being filtered out rather than drawn as a sixth axis.
+//
+// Scores are the 0-100 integers the R calculator returns (these are the golden allocation's,
+// nudged per round so two rounds differ), not fractions — the chart is drawn against a 0-100
+// axis, so a fixture of 0.11 would have rendered five dots at the centre and asserted nothing.
 const calcResponse = (round: number) => ({
 	results: [
 		// Real GeoTIFFs that exist in the build. data.json's own Consequence_*_Clip.tif do NOT
 		// exist in this repository — see the note at the bottom of this file.
-		{ name: `HH_${round}.tif`, id: '11', score: 0.11 * round, url: `/assets/images/esgame_img_ag_carbon.tif?round=${round}` },
-		{ name: `NP_${round}.tif`, id: '22', score: 0.22 * round, url: `/assets/images/esgame_img_ag_habitat.tif?round=${round}` },
-		{ name: `WE_${round}.tif`, id: '33', score: 0.33 * round, url: `/assets/images/esgame_img_ag_hunt.tif?round=${round}` },
-		{ name: `WA_${round}.tif`, id: '44', score: 0.44 * round, url: `/assets/images/esgame_img_ag_water.tif?round=${round}` },
-		{ name: `HC_${round}.tif`, id: '55', score: 0.55 * round, url: `/assets/images/esgame_img_ranch_carbon.tif?round=${round}` },
+		{ name: `HH_${round}.tif`, id: '11', score: 65 + round, url: `/assets/images/esgame_img_ag_carbon.tif?round=${round}` },
+		{ name: `NP_${round}.tif`, id: '22', score: 60 + round, url: `/assets/images/esgame_img_ag_habitat.tif?round=${round}` },
+		{ name: `WE_${round}.tif`, id: '33', score: 72 + round, url: `/assets/images/esgame_img_ag_hunt.tif?round=${round}` },
+		{ name: `WA_${round}.tif`, id: '44', score: 66 + round, url: `/assets/images/esgame_img_ag_water.tif?round=${round}` },
+		{ name: `HC_${round}.tif`, id: '55', score: 68 + round, url: `/assets/images/esgame_img_ranch_carbon.tif?round=${round}` },
 		{ name: `Spider_${round}.png`, id: '-1', score: 0, url: `/assets/images/agropark.png?round=${round}` }
 	]
 });
@@ -144,8 +153,16 @@ test.describe('dynamic game round trip', () => {
 		await placeFields(page, 12);
 		await clickPastHelp(page, page.locator('button.btn-next'));
 
-		// The response is consumed: the spider plot only renders when a result carried id -1.
-		await expect(page.locator('.expandable img')).toBeVisible({ timeout: 60_000 });
+		// The response is consumed: the chart only renders once a round has been scored.
+		const chart = page.locator('tro-spider-chart svg');
+		await expect(chart).toBeVisible({ timeout: 60_000 });
+
+		// Drawn from the scores, in a real browser — not a PNG fetched from the calculator.
+		// Five axes, and the id -1 result must NOT have become a sixth.
+		await expect(page.locator('tro-spider-chart .spider-chart__dot')).toHaveCount(5);
+		await expect(page.locator('.expandable img')).toHaveCount(0);
+		// The numbers on the chart are the ones the calculator returned.
+		await expect(chart).toHaveAttribute('aria-label', /66 of 100/);
 
 		// The payload is the shape the R calculator parses into a reclassify matrix.
 		expect(posted).toHaveLength(1);
@@ -241,13 +258,17 @@ test.describe('dynamic game round trip', () => {
 
 		await placeFields(page, 12);
 		await clickPastHelp(page, page.locator('button.btn-next'));
-		await expect(page.locator('.expandable img')).toBeVisible({ timeout: 60_000 });
+		await expect(page.locator('tro-spider-chart svg')).toBeVisible({ timeout: 60_000 });
 
 		await placeFields(page, 8, 1);
 		await clickPastHelp(page, page.locator('button.btn-next'));
-		// The plot src carries the round, so waiting on it proves round 2 was consumed rather
-		// than the round-1 image simply still being on screen.
-		await expect(page.locator('.expandable img')).toHaveAttribute('src', /round=2/, { timeout: 60_000 });
+		// This used to wait on the plot's `src`, which carried ?round=N. There is no src now, so
+		// it waits on a SCORE only round 2 produces — id 33 is 72+round, so 74 appears in round 2
+		// and in no round-1 value (66/61/73/67/69). That proves round 2's numbers were consumed,
+		// which the URL never did: a changed query string only proved a different file was asked
+		// for.
+		await expect(page.locator('tro-spider-chart svg'))
+			.toHaveAttribute('aria-label', /74 of 100/, { timeout: 60_000 });
 
 		expect(posted).toHaveLength(2);
 		expect(posted[1].round).not.toBe(posted[0].round);
@@ -289,7 +310,7 @@ test.describe('dynamic game round trip', () => {
 
 		await placeFields(page, 12);
 		await clickPastHelp(page, page.locator('button.btn-next'));
-		await expect(page.locator('.expandable img')).toBeVisible({ timeout: 60_000 });
+		await expect(page.locator('tro-spider-chart svg')).toBeVisible({ timeout: 60_000 });
 
 		// Five indicators plus the running total.
 		// The static score board renders one table row per indicator plus the header total.

--- a/v2/src/app/app.module.ts
+++ b/v2/src/app/app.module.ts
@@ -26,6 +26,7 @@ import { LoadingIndicatorComponent } from './loading-indicator/loading-indicator
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { LevelIndicatorComponent } from './level-indicator/level-indicator.component';
 import { HomeComponent } from './home/home.component';
+import { SpiderChartComponent } from './spider-chart/spider-chart.component';
 
 @Injectable()
 export class MyMissingTranslationHandler implements MissingTranslationHandler {
@@ -52,6 +53,7 @@ export class MyMissingTranslationHandler implements MissingTranslationHandler {
 		LoadingIndicatorComponent,
 		LevelIndicatorComponent,
 		HomeComponent,
+		SpiderChartComponent,
 	],
 	imports: [
 		BrowserModule,

--- a/v2/src/app/level/svg-level/svg-level.component.html
+++ b/v2/src/app/level/svg-level/svg-level.component.html
@@ -30,8 +30,8 @@
 
 			<tro-score-board *ngIf="!((level | async)?.scores)" class="score-board"></tro-score-board>
 			<tro-score-board *ngIf="(level | async)?.scores" isStatic [scores]="(level | async)!.scores" class="score-board"></tro-score-board>
-			<div *ngIf="(level | async)?.scoreImage" [ngClass]="imageExpand ? 'expanded' : ''" class="expandable">
-				<img  [src]="(level | async)?.scoreImage" />
+			<div *ngIf="(level | async)?.indicatorScores?.length" [ngClass]="imageExpand ? 'expanded' : ''" class="expandable">
+				<tro-spider-chart [entries]="(level | async)!.indicatorScores"></tro-spider-chart>
 				<button mat-mini-fab color="primary" (click)="switchExpand()" aria-label="expand/collapse">
 					<mat-icon *ngIf="!imageExpand">open_in_full</mat-icon>
 					<mat-icon *ngIf="imageExpand">close_fullscreen</mat-icon>

--- a/v2/src/app/level/svg-level/svg-level.component.scss
+++ b/v2/src/app/level/svg-level/svg-level.component.scss
@@ -31,13 +31,17 @@
 			top: 0px;
 		}
 
-		img {
+		// Was `img`, for the PNG the calculator used to render. tro-spider-chart draws the same
+		// thing as inline SVG; the framing stays so the panel looks unchanged.
+		tro-spider-chart {
+			display: block;
 			width: 100%;
 			background: white;
 			margin: 0;
 			padding: 0;
 			max-width: 100%;
 			border: 2px solid lightgray;
+			box-sizing: border-box;
 		}
 
 		button {

--- a/v2/src/app/services/game.service.multiround.spec.ts
+++ b/v2/src/app/services/game.service.multiround.spec.ts
@@ -50,7 +50,10 @@ const settingsData = {
 	]
 };
 
-// Shaped exactly like what tools/R returns: string ids, a spider plot at id "-1".
+// Shaped like what tools/R USED to return: string ids, plus a rendered spider plot at id "-1".
+// Kept in that shape deliberately. The calculator no longer sends the plot — v2 draws the chart
+// itself — but a frontend can be deployed against a calculation image that has not been rebuilt,
+// so the "-1" entry has to keep being filtered out rather than drawn as a sixth axis.
 const resultFor = (round: number, scores: Record<string, number> = { '11': 0.13, '22': 0.17 }): CalculationResult => ({
 	results: [
 		{ name: `HH_r${round}.tif`, id: '11', score: scores['11'], url: `http://gs/wcs?coverageId=ws_round${round}:HH` },
@@ -144,10 +147,17 @@ describe('GameService multi-round (SVG)', () => {
 		expect(secondAll).toBe(55);
 	});
 
-	it('takes the spider plot from the id -1 result', async () => {
-		service.prepareNextLevel(resultFor(2), 55);
+	it('gives the chart the indicator scores, and never the old plot result', async () => {
+		service.prepareNextLevel(resultFor(2, { '11': 65, '22': 60 }), 55);
 
-		expect((await currentLevel(service))!.scoreImage).toBe('http://calc/images/Spider_r2.png');
+		const entries = (await currentLevel(service))!.indicatorScores;
+
+		// The scores the chart draws are the calculator's own 0-100 numbers, NOT the negated,
+		// x100 values in level.scores that the score board uses for game points.
+		expect(entries).toEqual([{ id: '11', score: 65 }, { id: '22', score: 60 }]);
+		// A calculator that still sends the rendered plot must not get it drawn as a sixth axis
+		// with a nonsense label.
+		expect(entries.some(e => e.id === '-1')).toBe(false);
 	});
 
 	it('does not leave a consequence board from the previous round on the new level', async () => {

--- a/v2/src/app/services/game.service.ts
+++ b/v2/src/app/services/game.service.ts
@@ -277,9 +277,19 @@ export class GameService {
 				level.scores = [{ id: "all", score: previousScore!} , ...calculationResult.results.filter(c => c.id != "-1").map(c => ({ score: -((c.score ?? 0)*100), id: c.id } as ScoreEntry))];
 			}
 
-			const image = calculationResult?.results.find(c => c.id == "-1");
-			if(image) {
-				level.scoreImage = image.url;
+			// The spider chart is drawn from these five numbers rather than fetched as a PNG.
+			// The calculator used to return a sixth result with id "-1" — a rendered chart it had
+			// written to its own pod's disk — and the level took its URL. That is gone: the chart
+			// is a pure function of the scores, so there is nothing to serve, and the calculation
+			// deployment can be scaled. See SpiderChartComponent.
+			//
+			// `id != "-1"` is kept when filtering, deliberately. A calculator that still sends the
+			// old plot result must not have it drawn as a sixth axis with a nonsense label; this
+			// frontend has to work against a backend that has not been redeployed yet.
+			if (calculationResult) {
+				level.indicatorScores = calculationResult.results
+					.filter(c => c.id != "-1")
+					.map(c => ({ id: c.id, score: c.score ?? 0 }));
 			}
 
 			level.gameBoards.push(...previousLevel.gameBoards.filter(c => c.gameBoardType != GameBoardType.ConsequenceMap));

--- a/v2/src/app/shared/models/level.ts
+++ b/v2/src/app/shared/models/level.ts
@@ -1,4 +1,5 @@
 import { ScoreEntry } from "src/app/services/score.service";
+import { SpiderChartEntry } from "src/app/spider-chart/spider-chart.component";
 import { SelectedField } from "./field";
 import { GameBoard } from "./game-board";
 
@@ -9,5 +10,14 @@ export class Level {
 	isReadOnly = false;
 	showConsequenceMaps = false;
 	scores: ScoreEntry[];
-	scoreImage: string;
+	/**
+	 * The five indicator scores as the calculator returned them, 0-100, for the spider chart.
+	 *
+	 * Distinct from `scores` above, which is the game's point system — negated and scaled by 100
+	 * for the score board. The chart wants what the model actually said.
+	 *
+	 * This replaced `scoreImage: string`, a URL to a PNG the calculator rendered and served from
+	 * its own pod. See SpiderChartComponent for why that had to go.
+	 */
+	indicatorScores: SpiderChartEntry[];
 }

--- a/v2/src/app/spider-chart/spider-chart.component.html
+++ b/v2/src/app/spider-chart/spider-chart.component.html
@@ -1,0 +1,40 @@
+<!--
+  role="img" with a label, because the shape is the meaning: a screen reader gets the same five
+  numbers a sighted player reads off the axes. The PNG this replaced had no alt text at all.
+-->
+<svg *ngIf="!isEmpty"
+	 class="spider-chart"
+	 [attr.viewBox]="'0 0 ' + viewWidth + ' ' + viewHeight"
+	 role="img"
+	 [attr.aria-label]="summary"
+	 preserveAspectRatio="xMidYMid meet">
+
+	<!-- Grid rings. -->
+	<polygon *ngFor="let r of rings"
+			 class="spider-chart__ring"
+			 [attr.points]="ringPoints(r)" />
+
+	<!-- One spoke per indicator. -->
+	<line *ngFor="let entry of entries; index as i; trackBy: trackById"
+		  class="spider-chart__spoke"
+		  [attr.x1]="cx" [attr.y1]="cy"
+		  [attr.x2]="spoke(i).x" [attr.y2]="spoke(i).y" />
+
+	<!-- The scores themselves. -->
+	<polygon class="spider-chart__area" [attr.points]="scorePoints" />
+
+	<circle *ngFor="let entry of entries; index as i; trackBy: trackById"
+			class="spider-chart__dot"
+			[attr.cx]="dot(i).x" [attr.cy]="dot(i).y" r="2.5" />
+
+	<!-- Labels sit outside the outer ring. aria-hidden because `summary` already says all of it. -->
+	<text *ngFor="let entry of entries; index as i; trackBy: trackById"
+		  class="spider-chart__label"
+		  [attr.x]="labelAt(i).x" [attr.y]="labelAt(i).y"
+		  [attr.text-anchor]="labelAnchor(i)"
+		  aria-hidden="true">
+		<tspan>{{ label(i) }}</tspan>
+		<tspan class="spider-chart__label-score"
+			   [attr.x]="labelAt(i).x" dy="1.1em">{{ displayScore(i) }}</tspan>
+	</text>
+</svg>

--- a/v2/src/app/spider-chart/spider-chart.component.scss
+++ b/v2/src/app/spider-chart/spider-chart.component.scss
@@ -1,0 +1,50 @@
+// A custom element is `display: inline` by default, so without this the host box collapses and
+// the chart is clipped to a couple of text-line heights. Caught by screenshotting it: every DOM
+// assertion passed against the clipped render, because all the nodes were present and "visible".
+:host {
+	display: block;
+	width: 100%;
+}
+
+// The chart scales with its container rather than being a fixed 394x394 raster, which is the
+// point of drawing it here. `display: block` so the SVG does not sit on a text baseline and
+// leave a few pixels of gap under it.
+.spider-chart {
+	display: block;
+	width: 100%;
+	height: auto;
+}
+
+.spider-chart__ring {
+	fill: none;
+	stroke: rgba(0, 0, 0, 0.14);
+	stroke-width: 0.75;
+}
+
+.spider-chart__spoke {
+	stroke: rgba(0, 0, 0, 0.14);
+	stroke-width: 0.75;
+}
+
+// $color-primary is #0B5ED7 (5.84:1 against white) — see docs/verification-status. Written out
+// rather than imported so this component carries no build-order dependency on the theme file.
+.spider-chart__area {
+	fill: rgba(11, 94, 215, 0.28);
+	stroke: #0b5ed7;
+	stroke-width: 1.5;
+	stroke-linejoin: round;
+}
+
+.spider-chart__dot {
+	fill: #0b5ed7;
+}
+
+.spider-chart__label {
+	font-size: 8px;
+	fill: #333;
+}
+
+.spider-chart__label-score {
+	font-weight: 700;
+	fill: #0b5ed7;
+}

--- a/v2/src/app/spider-chart/spider-chart.component.spec.ts
+++ b/v2/src/app/spider-chart/spider-chart.component.spec.ts
@@ -1,0 +1,175 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateService } from '@ngx-translate/core';
+import { SpiderChartComponent } from './spider-chart.component';
+
+// The chart replaced a PNG the calculator rendered, so nothing downstream validates it any more
+// — the geometry here IS the output. These check the things that can be wrong without anything
+// throwing: a polygon with the wrong number of corners, a score plotted at the wrong radius, a
+// NaN silently dropping an axis.
+
+/** Minimal stand-in: `map_name_<id>` -> a label, the same keys settings.ts registers. */
+const LABELS: Record<string, string> = {
+	map_name_11: 'Human health',
+	map_name_22: 'Nutrient pollution',
+	map_name_33: 'Water availability',
+	map_name_44: 'Habitat cohesion',
+	map_name_55: 'Recreational value'
+};
+
+const FIVE = [
+	{ id: '11', score: 65 },
+	{ id: '22', score: 60 },
+	{ id: '33', score: 72 },
+	{ id: '44', score: 66 },
+	{ id: '55', score: 68 }
+];
+
+/** Parse a `points` attribute into numeric pairs. */
+const pts = (s: string) => s.trim().split(/\s+/).map(p => p.split(',').map(Number) as [number, number]);
+const dist = (c: SpiderChartComponent, [x, y]: [number, number]) =>
+	Math.hypot(x - c.cx, y - c.cy);
+
+describe('SpiderChartComponent', () => {
+	let fixture: ComponentFixture<SpiderChartComponent>;
+	let component: SpiderChartComponent;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			declarations: [SpiderChartComponent],
+			providers: [{
+				provide: TranslateService,
+				useValue: { instant: (k: string) => LABELS[k] ?? k }
+			}]
+		}).compileComponents();
+
+		fixture = TestBed.createComponent(SpiderChartComponent);
+		component = fixture.componentInstance;
+	});
+
+	it('draws nothing at all when there are no scores', () => {
+		component.entries = [];
+		fixture.detectChanges();
+
+		expect(component.isEmpty).toBe(true);
+		expect(fixture.nativeElement.querySelector('svg')).toBeNull();
+	});
+
+	it('treats null and undefined as empty rather than throwing', () => {
+		component.entries = null;
+		expect(component.isEmpty).toBe(true);
+		component.entries = undefined;
+		expect(component.isEmpty).toBe(true);
+	});
+
+	it('gives the score polygon one corner per indicator', () => {
+		component.entries = FIVE;
+		expect(pts(component.scorePoints).length).toBe(5);
+		expect(pts(component.ringPoints(1)).length).toBe(5);
+	});
+
+	it('puts a score of 100 on the outer ring and 0 at the centre', () => {
+		component.entries = [{ id: '11', score: 100 }, { id: '22', score: 0 }];
+		const [full, none] = pts(component.scorePoints);
+
+		expect(dist(component, full)).toBeCloseTo(component.radius, 5);
+		expect(dist(component, none)).toBeCloseTo(0, 5);
+	});
+
+	it('places a score at a radius proportional to it', () => {
+		component.entries = [{ id: '11', score: 50 }];
+		expect(dist(component, pts(component.scorePoints)[0])).toBeCloseTo(component.radius / 2, 5);
+	});
+
+	it('starts the first axis at the top', () => {
+		component.entries = FIVE;
+		const [x, y] = pts(component.ringPoints(1))[0];
+
+		expect(x).toBeCloseTo(component.cx, 5);
+		expect(y).toBeCloseTo(component.cy - component.radius, 5);
+	});
+
+	it('clamps out-of-range scores instead of drawing outside the chart', () => {
+		component.entries = [{ id: '11', score: 250 }, { id: '22', score: -40 }];
+		const [over, under] = pts(component.scorePoints);
+
+		expect(dist(component, over)).toBeCloseTo(component.radius, 5);
+		expect(dist(component, under)).toBeCloseTo(0, 5);
+		expect(component.displayScore(0)).toBe(100);
+		expect(component.displayScore(1)).toBe(0);
+	});
+
+	it('shows a NaN score as 0 rather than dropping the axis', () => {
+		// The calculator used to return NaN for a landscape with no agriculture. An axis that
+		// vanished would make a broken round look like a four-indicator game.
+		component.entries = [{ id: '11', score: NaN }, { id: '22', score: 50 }];
+
+		expect(pts(component.scorePoints).length).toBe(2);
+		expect(dist(component, pts(component.scorePoints)[0])).toBeCloseTo(0, 5);
+		expect(component.displayScore(0)).toBe(0);
+	});
+
+	it('labels the axes from the map_name_<id> translations', () => {
+		component.entries = FIVE;
+		fixture.detectChanges();
+
+		expect(component.label(0)).toBe('Human health');
+		expect(component.label(4)).toBe('Recreational value');
+		expect(fixture.nativeElement.textContent).toContain('Water availability');
+	});
+
+	it('describes itself for a reader who cannot see it', () => {
+		component.entries = FIVE;
+		fixture.detectChanges();
+
+		const svg: SVGElement = fixture.nativeElement.querySelector('svg');
+		expect(svg.getAttribute('role')).toBe('img');
+		// Every indicator and its number, so the chart is not a blank to a screen reader the way
+		// the PNG was.
+		expect(svg.getAttribute('aria-label')).toContain('Human health: 65 of 100');
+		expect(svg.getAttribute('aria-label')).toContain('Recreational value: 68 of 100');
+	});
+
+	it('anchors labels so the left-hand ones do not run over the chart', () => {
+		component.entries = FIVE;
+
+		// index 0 is straight up; the left-hand axes must be end-anchored and the right-hand
+		// ones start-anchored.
+		expect(component.labelAnchor(0)).toBe('middle');
+		expect(component.labelAnchor(1)).toBe('start');
+		expect(component.labelAnchor(4)).toBe('end');
+	});
+
+	it('renders one spoke, dot and label per indicator', () => {
+		component.entries = FIVE;
+		fixture.detectChanges();
+		const el = fixture.nativeElement;
+
+		expect(el.querySelectorAll('.spider-chart__spoke').length).toBe(5);
+		expect(el.querySelectorAll('.spider-chart__dot').length).toBe(5);
+		expect(el.querySelectorAll('.spider-chart__label').length).toBe(5);
+		expect(el.querySelectorAll('.spider-chart__ring').length).toBe(component.rings.length);
+	});
+
+	it('leaves room in the viewBox for the widest labels', () => {
+		// A square box clipped "Water availability" and "Recreational value" — every other test
+		// passed, because the geometry was right and only the text fell outside. Assert the
+		// horizontal room explicitly so the box cannot quietly go back to square.
+		component.entries = FIVE;
+		const widest = 75; // px at this font size, measured from the rendered chart
+		expect(component.cx - component.radius - component.labelGap).toBeGreaterThan(widest);
+		expect(component.viewWidth - (component.cx + component.radius + component.labelGap))
+			.toBeGreaterThan(widest - 5);
+		expect(component.viewWidth).toBeGreaterThan(component.viewHeight);
+	});
+
+	it('scales with its container rather than being a fixed raster', () => {
+		component.entries = FIVE;
+		fixture.detectChanges();
+		const svg: SVGElement = fixture.nativeElement.querySelector('svg');
+
+		// A viewBox and no width/height is what makes it responsive; the PNG was 394x394.
+		expect(svg.getAttribute('viewBox')).toBe(`0 0 ${component.viewWidth} ${component.viewHeight}`);
+		expect(svg.getAttribute('width')).toBeNull();
+		expect(svg.getAttribute('height')).toBeNull();
+	});
+});

--- a/v2/src/app/spider-chart/spider-chart.component.ts
+++ b/v2/src/app/spider-chart/spider-chart.component.ts
@@ -1,0 +1,165 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+
+/** One axis of the chart: a consequence-map id, and its 0-100 score for this round. */
+export interface SpiderChartEntry {
+	id: string;
+	score: number;
+}
+
+/**
+ * The five indicator scores, drawn as a radar chart.
+ *
+ * This used to be a PNG. tools/R/calculator.r rendered a ggplot to a 394x394 raster, wrote it to
+ * the calculation pod's local /app/data, and served it back through plumber's `@assets` mount
+ * with a URL built from `req$HTTP_HOST`. That is why the calculation deployment could not be
+ * scaled: with more than one replica a plot GET can land on a pod that never wrote the file, so
+ * a player gets a 404 for a chart of their own round.
+ *
+ * The chart is a pure function of five numbers the calculator already returns, so there is
+ * nothing to store or serve. Beyond unblocking the replicas, that buys three things the raster
+ * could not have: it scales with the panel instead of being a fixed size, the axis labels come
+ * from `map_name_<id>` and so are translated (the PNG's were baked in English), and it carries
+ * a text description for anyone not looking at it.
+ *
+ * Labels are resolved with `TranslateService.instant`, matching ScoreBoardComponent — the same
+ * `map_name_<id>` keys settings.ts registers from data.json.
+ */
+@Component({
+	selector: 'tro-spider-chart',
+	templateUrl: './spider-chart.component.html',
+	styleUrls: ['./spider-chart.component.scss'],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	standalone: false
+})
+export class SpiderChartComponent {
+	/**
+	 * The viewBox is WIDER THAN TALL, and sized by the labels rather than by the circle.
+	 *
+	 * A square 200x200 box was the obvious choice and was wrong: "Water availability" is about
+	 * 71px at this font size, and anchored outside a radius-62 ring it ran to x=254 and was
+	 * clipped. Every unit test still passed — the geometry was correct, the text was simply
+	 * outside the box — which is why this was only caught by looking at a screenshot.
+	 *
+	 * Worst case is the widest label on each side: left is "Recreational value" ending at
+	 * cx - radius - labelGap - width, right is "Water availability" ending at
+	 * cx + radius + labelGap + width. Both fit with room to spare at these numbers.
+	 */
+	readonly viewWidth = 320;
+	readonly viewHeight = 230;
+	readonly cx = 160;
+	readonly cy = 100;
+	readonly radius = 58;
+	/** Gap between the outer ring and the start of a label. */
+	readonly labelGap = 18;
+	/** Grid rings behind the polygon, as fractions of `radius`. */
+	readonly rings = [0.25, 0.5, 0.75, 1];
+
+	private _entries: SpiderChartEntry[] = [];
+
+	@Input() set entries(value: SpiderChartEntry[] | null | undefined) {
+		this._entries = value ?? [];
+	}
+	get entries(): SpiderChartEntry[] {
+		return this._entries;
+	}
+
+	constructor(private translateService: TranslateService) {}
+
+	/** Nothing to draw — the template omits the chart rather than rendering an empty frame. */
+	get isEmpty(): boolean {
+		return this._entries.length === 0;
+	}
+
+	label(i: number): string {
+		return this.translateService.instant('map_name_' + this._entries[i].id) as string;
+	}
+
+	/**
+	 * The angle of axis `i`, from straight up, going clockwise — so the first indicator is at the
+	 * top, which is where the ggplot version put it and where a reader expects it.
+	 */
+	private angle(i: number): number {
+		return (Math.PI * 2 * i) / Math.max(1, this._entries.length) - Math.PI / 2;
+	}
+
+	private point(i: number, r: number): { x: number; y: number } {
+		const a = this.angle(i);
+		return { x: this.cx + Math.cos(a) * r, y: this.cy + Math.sin(a) * r };
+	}
+
+	/**
+	 * A score clamped to the 0-100 the axes are drawn for.
+	 *
+	 * A non-finite score becomes 0 rather than being dropped. The calculator used to return NaN
+	 * for a landscape with no agriculture; tools/R/model.R scores that 0 now, but a chart that
+	 * silently omitted an axis would hide a broken round instead of showing it.
+	 */
+	private clamped(score: number): number {
+		if (!Number.isFinite(score)) { return 0; }
+		return Math.max(0, Math.min(100, score));
+	}
+
+	/** One grid ring, drawn as a polygon so it lines up with the spokes. */
+	ringPoints(fraction: number): string {
+		return this._entries
+			.map((_, i) => {
+				const p = this.point(i, this.radius * fraction);
+				return `${p.x.toFixed(2)},${p.y.toFixed(2)}`;
+			})
+			.join(' ');
+	}
+
+	/** The filled polygon of this round's scores. */
+	get scorePoints(): string {
+		return this._entries
+			.map((e, i) => {
+				const p = this.point(i, (this.radius * this.clamped(e.score)) / 100);
+				return `${p.x.toFixed(2)},${p.y.toFixed(2)}`;
+			})
+			.join(' ');
+	}
+
+	/** The outer end of the spoke for axis `i`. */
+	spoke(i: number): { x: number; y: number } {
+		return this.point(i, this.radius);
+	}
+
+	/** Where the score dot for axis `i` sits. */
+	dot(i: number): { x: number; y: number } {
+		return this.point(i, (this.radius * this.clamped(this._entries[i].score)) / 100);
+	}
+
+	/** Label position, pushed outside the outer ring. */
+	labelAt(i: number): { x: number; y: number } {
+		return this.point(i, this.radius + this.labelGap);
+	}
+
+	/**
+	 * Horizontal anchoring, from where the label sits around the circle. Without it, labels on
+	 * the left overlap the chart: a middle-anchored string is centred on a point already at the
+	 * edge of the drawing.
+	 */
+	labelAnchor(i: number): 'start' | 'middle' | 'end' {
+		const x = Math.cos(this.angle(i));
+		if (x > 0.2) { return 'start'; }
+		if (x < -0.2) { return 'end'; }
+		return 'middle';
+	}
+
+	/** The number shown beside each label. Rounded, because the calculator rounds too. */
+	displayScore(i: number): number {
+		return Math.round(this.clamped(this._entries[i].score));
+	}
+
+	/** A one-line description of the chart, for anyone not looking at it. */
+	get summary(): string {
+		return this._entries
+			.map((_, i) => `${this.label(i)}: ${this.displayScore(i)} of 100`)
+			.join(', ');
+	}
+
+	trackById(_index: number, entry: SpiderChartEntry): string {
+		return entry.id;
+	}
+}


### PR DESCRIPTION
Closes the finding written up as *"adding calculation replicas breaks the spider plot"*.

## What was wrong

The plot was a 394×394 ggplot PNG that `calculator.r` wrote to the calculation pod's **local** `/app/data` and served back through plumber's `@assets` mount, with a URL built from `req$HTTP_HOST`. With more than one replica a plot GET can land on a pod that never wrote the file — so a player gets a 404 for a chart of their own round. That is why `replicas` could not be raised.

## The fix is to stop producing the file

The chart is a pure function of five numbers the response already carries. `SpiderChartComponent` draws it as inline SVG; `calculator.r` no longer renders a PNG, no longer returns an `id == -1` result, and **no longer declares `#* @assets /app/data /images`** — so it has stopped publishing its own `/app/data` over HTTP at all.

The four options previously tabled — inline it as a data URI, sticky sessions, upload to GeoServer, add an RWX provisioner — all take *"there is a file, and it must reach the browser"* as given and then argue about transport. **The cheapest of the four was still more machinery than deleting the file.**

Three things that weren't the point and came free:

- the chart **scales with the panel** instead of being a fixed raster;
- axis labels come from `map_name_<id>`, so they are **translated** — the PNG's were baked in English;
- `role="img"` plus an `aria-label` naming every indicator and score, where the PNG had **no alt text**.

## The bug the unit tests could not catch

**The viewBox is wider than tall (320×230) and sized by the labels, not the circle.** A square 200×200 box was the obvious choice and clipped "Water availability" and "Recreational value". Every unit test passed against the clipped render, because the geometry was correct and only the text fell outside — it was caught by *looking at a screenshot*. There's now an explicit assertion on the horizontal room so it can't quietly go back to square.

Getting there also cost one round to this repo's own documented trap: `npx playwright test` does **not** rebuild, so my first two screenshots were of the previous `dist`.

## Compatibility is deliberate

Both `game.service.ts` and `golden-test.sh` still filter `id == -1`, and the e2e fixture still *sends* it. A frontend can be deployed against a calculation image that hasn't been rebuilt, and that plot must not become a sixth axis with a nonsense label.

## Verification

| | |
|---|---|
| Unit | **399 tests** (14 new on the chart) |
| E2E | **18 Playwright, real browser** — round-trip now asserts five dots, `<img>` count 0, and the scores in the `aria-label` |
| Round 2 | proved by a score only round 2 produces, not a changed query string — the old test only proved a different file was requested |
| Visual | screenshotted and inspected; all five labels fit, polygon and values correct |
| Lighthouse | green |
| R | parses; `test-coverage.R` 19/19 |
| Docs | `sphinx -W` clean, `check-file-paths` 306/306, `actionlint` clean |

Documented in `reference/frontend-components` (new component entry), `reference/calculator` (esgame no longer renders one; places still does), `data-flow`, `game-mechanics`, and `verification-status` (the replicas finding is now closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHv4YE8wLeH8UyPrt6ftjs