### PR TITLE
docs(k8s): the replicas note described a defect that no longer exists

### DIFF
--- a/deploy/k8s/base/calculation-deployment.yaml
+++ b/deploy/k8s/base/calculation-deployment.yaml
@@ -5,12 +5,19 @@ metadata:
   labels:
     app: esgame-calculation
 spec:
-  # 1, and raising it is not a one-line change. Measured 2026-08-06: at two replicas the same
-  # spider-plot URL returns 404 about half the time, because calculator.r writes the plot into
-  # /app/data — an emptyDir, so per pod — and hands back a URL pointing at plumber's own @assets
-  # mount. The round still returns 200 with five correct scores, so the failure is quiet.
-  # Everything else shared goes to GeoServer; the plot is the exception. Options and their costs
-  # are in docs/verification-status.rst under "Adding calculation replicas breaks the spider plot".
+  # 1 — but no longer because raising it would break anything.
+  #
+  # It used to. Measured 2026-08-06: at two replicas the same spider-plot URL returned 404 about
+  # half the time, because calculator.r wrote the plot into /app/data (an emptyDir, so per pod)
+  # and handed back a URL pointing at plumber's own @assets mount. That was fixed on 2026-08-07
+  # by not producing the file at all: the browser draws the chart from the five scores, and
+  # calculator.r no longer renders a PNG, returns an id -1 result, or declares @assets. Nothing
+  # pod-local is served now — every output goes to GeoServer, which is shared.
+  #
+  # This stays at 1 because nothing has re-measured throughput since, not because of the plot.
+  # One replica sustains about one concurrent player (perf/calc-load.js, 2026-08-06: rounds take
+  # 12.9-28.2s and do not overlap, since Plumber is single-threaded), so raising it is a real
+  # decision about capacity — it is just no longer a correctness one.
   replicas: 1
   selector:
     matchLabels:
@@ -34,7 +41,7 @@ spec:
           emptyDir: {}
       securityContext:
         # /app/data is a mount, so its ownership comes from the volume, not the image.
-        # calculator.r does setwd() there and writes seven rasters plus the spider plot, and a
+        # calculator.r does setwd() there and writes its rasters, and a
         # bare emptyDir is created root-owned — the calculation would start and then fail on its
         # first write. fsGroup 0 matches the image's `useradd --gid 0` and makes the kubelet set
         # group ownership on the volume.
@@ -96,7 +103,7 @@ spec:
           # Neither needs anything from the image.
           #
           # readOnlyRootFilesystem holds because both paths this writes are mounts: /app/data,
-          # where calculator.r does setwd() and writes its rasters and the spider plot, and /tmp,
+          # where calculator.r does setwd() and writes its rasters, and /tmp,
           # which is where R puts tempdir(). An earlier comment here said R "writes to its library
           # and temp paths outside the /app/data mount" — the library is read at run time, not
           # written to, and the temp paths are now mounted.

--- a/tools/R/Dockerfile
+++ b/tools/R/Dockerfile
@@ -83,7 +83,7 @@ COPY . .
 #
 # Two things make this container the tractable one of the three. It listens on 8000, above the
 # privileged range, so nothing needs CAP_NET_BIND_SERVICE to bind. And the only path it writes
-# is /app/data — calculator.r does setwd() there and writes seven rasters plus the spider plot —
+# is /app/data — calculator.r does setwd() there and writes its rasters —
 # which is an emptyDir in the base and a PVC in the places overlay, so it is a mount, not image
 # content: the directory has to exist and be owned here, and the volume inherits that ownership
 # via fsGroup.


### PR DESCRIPTION
Follow-up to #195, found by re-reading what it left behind.

Removing the pod-local spider plot left **five comments describing behaviour the code no longer has**. The most misleading is the calculation Deployment's `replicas: 1` note, which explains at length why raising it returns 404s:

```yaml
# 1, and raising it is not a one-line change. Measured 2026-08-06: at two replicas the same
# spider-plot URL returns 404 about half the time, because calculator.r writes the plot into
# /app/data — an emptyDir, so per pod — and hands back a URL pointing at plumber's own @assets
# mount.
```

None of that is true now. `calculator.r` renders no PNG, returns no `id == -1` result and declares no `@assets` mount, so **nothing pod-local is served** — every output goes to GeoServer, which is shared.

Three more said the calculator writes "seven rasters plus the spider plot" (two in the Deployment, one in the Dockerfile).

## `replicas` stays at 1 — but the reason changed

It's now **capacity, not correctness**. `perf/calc-load.js` measured one replica sustaining about one concurrent player: rounds take 12.9–28.2s and don't overlap, Plumber being single-threaded. That's a real decision to make about a workshop's class size. It just isn't a correctness one any more, and a comment saying otherwise sends the next reader hunting a bug that's already fixed.

## Verification

Comments only, and proven so: `kustomize build deploy/k8s/base` is **byte-identical** to master's render. `kubeconform -strict` 10/10, `render-test.sh` PASS.

While checking this I also confirmed the re-recorded golden scores from #194 will hold on the cluster: `kind.sh:199` seeds the calculator's `/app/data` from `v2/src/assets/images/LU_and_NEW_hexa.tif`, which is the same committed raster `derive-bounds.R` was run against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHv4YE8wLeH8UyPrt6ftjs