### PR TITLE
fix(ci): a high-severity advisory sat in the tree and nothing here could see it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,9 +135,39 @@ jobs:
           path: v2/.lighthouseci/reports
           retention-days: 7
 
-      # Scheduled runs only: a new advisory against a shipped dependency should surface
-      # on its own, but should not block an unrelated PR that happens to be open when it
-      # lands. Production dependencies are at 0 — this defends that.
+  # Dependency advisories.
+  #
+  # Scheduled and on-demand, not per-PR: a new advisory should surface on its own, but should
+  # not block an unrelated pull request that happens to be open when it lands. That much was
+  # already true. Two things about it were not.
+  #
+  # It is a JOB now, not the last step of build-test. There it ran only once the build, both
+  # suites and Lighthouse had all passed — so a flaky e2e or a Lighthouse blip on a Monday took
+  # the audit with it, silently, and the run was red for a reason that had nothing to do with
+  # dependencies. `npm audit` reads package-lock.json: it needs no `npm ci`, no build and no
+  # browser, so it has no business waiting behind ten minutes of work it does not use.
+  #
+  # And it covers the dev tree. See "The dependency audit" in docs/verification-status.rst.
+  audit:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: v2
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          # Pinned to build-test's Node so both see the same npm and the same audit behaviour.
+          # No `cache: npm`, because nothing here installs.
+          node-version: 26.5.0
+
+      # Split in two so the failure says which tree, and neither hides the other: production is
+      # the stricter invariant — it is what reaches the browser — and it has been at 0 since
+      # this existed. Without the `if:`, a production finding would skip the dev report entirely.
       - name: Production dependency audit
-        if: github.event_name == 'schedule'
         run: npm audit --omit=dev --audit-level=high
+
+      - name: Full dependency audit, including the build toolchain
+        if: ${{ !cancelled() }}
+        run: npm audit --audit-level=high

--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -9,7 +9,7 @@ time precisely because nothing had ever run them, and the failures were silent �
 that logged ``done`` having registered nothing, an e2e suite passing against a board that
 never rendered, a schema check reporting 10/10 valid on manifests the API server rejected.
 
-Last updated: **2026-08-06**.
+Last updated: **2026-08-09**.
 
 .. note::
 
@@ -396,6 +396,56 @@ The published site was twelve commits behind master — *closed 2026-08-07*
    had failed on runner acquisition rather than on their contents. That is what the
    "re-verify locally before merging" rule exists for, and it held — but it is worth recording
    that *"the run is red"* and *"the change is bad"* came apart here for a whole day.
+
+.. _the-dependency-audit:
+
+The dependency audit — *closed 2026-08-09*
+   A **high**-severity advisory sat in the tree and neither of the two things that should have
+   found it did. ``nanoid`` 3.3.16, `GHSA-2v37-7h3g-55p8
+   <https://github.com/advisories/GHSA-2v37-7h3g-55p8>`_ — custom generators loop forever when
+   asked for a zero-length id. It was found by running ``npm audit`` by hand.
+
+   **CI could not see it, by construction.** ``nanoid`` arrives as
+   ``@angular/build`` → ``postcss`` → ``nanoid``, so it is ``dev`` scope, and the audit step
+   was ``--omit=dev``. Measured against the pre-fix lockfile, that command is
+   ``found 0 vulnerabilities``, **exit 0**, while the same lockfile with the dev tree included
+   is **exit 1** naming ``nanoid``. The production tree really is at 0 and really is the
+   stricter invariant; the mistake was treating it as the *only* one.
+
+   **Dependabot was the fallback, and it lagged.** It does watch the dev scope of
+   :file:`v2/package-lock.json` — 165 alerts on this repository, essentially all of them
+   ``development`` — so "the dev tree is Dependabot's job" was true, and still insufficient.
+   The advisory was published 2026-07-29 covering only ``>= 4.0.0, < 5.1.6``, then **amended**
+   2026-08-07 20:50 UTC to add ``< 3.3.17``; the newest alert of any kind here is dated
+   2026-08-07 04:13 UTC. No alert for ``nanoid`` was ever raised. An advisory whose *range*
+   grows later is not the same event as a new advisory, and only the second one was covered.
+
+   **The audit also ran last, behind everything it does not need.** It was the final step of
+   ``build-test``, after the build, both suites and Lighthouse — so it executed only if all of
+   them had passed. One flaky e2e on a Monday and the audit was skipped, in a run that was
+   already red for an unrelated reason and would be read as such. ``npm audit`` resolves
+   :file:`v2/package-lock.json` and needs no ``npm ci``, no build and no browser: verified by
+   running it in a directory holding nothing but a ``package.json`` and the lockfile, with no
+   ``node_modules`` at all. It is its own ``audit`` job now, still scheduled-only
+   (plus ``workflow_dispatch``), in two steps — production, then the whole tree — with the
+   second one under ``if: !cancelled()`` so a production finding cannot suppress the dev report.
+
+   The fix itself is three lines of lockfile: ``postcss`` declares ``nanoid: ^3.3.16``, so the
+   patched release was already inside the allowed range and nothing needed a new dependency.
+   Took **3.3.18** rather than the minimum 3.3.17 — diffed, and 3.3.18 is 3.3.17 plus the same
+   one-line guard applied to the async-native variant.
+
+   **It was not reachable here, and was bumped anyway.** The defect is in ``customRandom`` in
+   ``nanoid``'s *secure* entry point, whose ``while (true)`` compares ``id.length === size``
+   only after appending — never true for ``size`` 0. The sole consumer in this tree is
+   ``postcss/lib/input.js``, which calls ``nanoid/non-secure``'s ``nanoid(6)``: a literal size,
+   a different entry point, and ``non-secure/index.cjs`` is **byte-identical** between 3.3.16
+   and 3.3.18. Nothing in :file:`v2/src` imports ``nanoid`` directly. So this was free, in
+   range, and worth taking on those grounds rather than on urgency — the finding worth keeping
+   is not the bump but that two independent mechanisms both let it through.
+
+   Confirmed able to fail, in both directions: pre-fix lockfile, **exit 1**; post-fix,
+   ``found 0 vulnerabilities``, **exit 0**.
 
 
 Known incomplete

--- a/v2/package-lock.json
+++ b/v2/package-lock.json
@@ -8437,9 +8437,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
`nanoid` 3.3.16, [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — **high**, custom generators loop forever when asked for a zero-length id. Found by running `npm audit` by hand. Both of the things that were supposed to find it did not, for two unrelated reasons.

### CI could not, by construction

`nanoid` arrives as `@angular/build` → `postcss` → `nanoid`, so it is **dev** scope, and the audit step was `--omit=dev`. Measured under CI's own Node 26.5.0 against the pre-fix lockfile:

```
--omit=dev  exit=0     <- what CI runs today
full tree   exit=1     <- names nanoid
```

The production tree really is at 0 and really is the stricter invariant. The mistake was treating it as the *only* one.

### Dependabot was the fallback, and it lagged

It does watch this manifest's dev scope — 165 alerts here, essentially all `development` — so "the dev tree is Dependabot's job" was true and still insufficient. The advisory was published **2026-07-29** covering only `>= 4.0.0, < 5.1.6`, then **amended 2026-08-07 20:50 UTC** to add `< 3.3.17`. The newest alert of any kind on this repository is **2026-08-07 04:13 UTC**, and no `nanoid` alert was ever raised. An advisory whose *range* grows later is not the same event as a new advisory, and only the second was covered.

### The audit also ran last, behind everything it does not need

It was the final step of `build-test`, after the build, both suites and Lighthouse — so it executed only if all of them passed. One flaky e2e on a Monday and the audit is skipped, inside a run already red for an unrelated reason and read as such. The "check that cannot run" shape again, with the trigger fine and the *position* wrong.

`npm audit` resolves `package-lock.json` and needs no `npm ci`, no build, no browser — verified in a directory holding nothing but a `package.json` and the lockfile, no `node_modules` at all. It is its own `audit` job now (seconds, not ten minutes), still scheduled-only plus `workflow_dispatch`, in two steps so the failure says which tree, the second under `if: !cancelled()` so a production finding cannot suppress the dev report.

### The bump

Three lines of lockfile: `postcss` declares `nanoid: ^3.3.16`, so the patched release was already in range. Took **3.3.18** over the minimum 3.3.17 — diffed, and 3.3.18 is 3.3.17 plus the same one-line guard applied to the async-native variant.

**Not reachable here, and bumped anyway.** The defect is in `customRandom` in nanoid's *secure* entry, whose `while (true)` compares `id.length === size` only after appending — never true for `size` 0. The sole consumer in this tree is `postcss/lib/input.js` calling `nanoid/non-secure`'s `nanoid(6)`: literal size, different entry point, and `non-secure/index.cjs` is **byte-identical** between 3.3.16 and 3.3.18. Nothing in `v2/src` imports `nanoid`. Free and in range, so worth taking on those grounds rather than on urgency — the finding worth keeping is not the bump but that two independent mechanisms both let it through.

### Verified

`npm ci` clean, production build, **399 unit**, **18 Playwright e2e**, audit 0 including dev. `actionlint` clean. `sphinx -W --keep-going` exit 0, `check-references.py` 7/7, `check-file-paths.py` 308/308 — which failed first, correctly, on two generic names in the new prose that are not paths in this repository; they are ` ``literal`` ` now.

Confirmed able to fail **in both directions** under Node 26.5.0 with no `node_modules`:

```
old lockfile   --omit=dev exit=0    full tree exit=1
new lockfile   --omit=dev exit=0    full tree exit=0
```

Also bumps the page's "Last updated", stale since #197 added to it. Nothing gates that line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmZ3ACD7PnDrHvcBfmZKiE