### PR TITLE
docs: the Dependabot figure in #198 was an alert id, not a count

### DIFF
--- a/docs/verification-status.rst
+++ b/docs/verification-status.rst
@@ -413,8 +413,8 @@ The dependency audit — *closed 2026-08-09*
    stricter invariant; the mistake was treating it as the *only* one.
 
    **Dependabot was the fallback, and it lagged.** It does watch the dev scope of
-   :file:`v2/package-lock.json` — 165 alerts on this repository, essentially all of them
-   ``development`` — so "the dev tree is Dependabot's job" was true, and still insufficient.
+   :file:`v2/package-lock.json` — 145 alerts on this repository, 115 of them ``development``
+   and 30 ``runtime`` — so "the dev tree is Dependabot's job" was true, and still insufficient.
    The advisory was published 2026-07-29 covering only ``>= 4.0.0, < 5.1.6``, then **amended**
    2026-08-07 20:50 UTC to add ``< 3.3.17``; the newest alert of any kind here is dated
    2026-08-07 04:13 UTC. No alert for ``nanoid`` was ever raised. An advisory whose *range*


### PR DESCRIPTION
#198 wrote *"165 alerts on this repository, essentially all of them `development`"*. **165 is the highest alert number** — an identifier, covering everything GitHub ever opened here including dismissed and deduplicated ones. It is not a total. Re-derived from the API by scope:

```
145 alerts   115 development   30 runtime
```

So "essentially all" was wrong too — about a fifth are runtime.

Neither error touches the argument the paragraph makes: Dependabot does watch this manifest's dev scope, and it still did not raise `nanoid`. But this page's whole subject is numbers that were true when written and never re-derived, and this one was **never** true.

Counted with `gh api repos/:owner/:repo/dependabot/alerts --paginate` piped through `.dependency.scope`, rather than by reading the largest id off the top of the list, which is how the wrong figure was produced.

Verified: `sphinx -W --keep-going` exit 0, `check-references.py` exit 0, `check-file-paths.py` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmZ3ACD7PnDrHvcBfmZKiE